### PR TITLE
chore(dependabot): emit type.deps + agent.bot labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,12 +11,14 @@ updates:
         patterns:
           - "*"
     labels:
-      - "dependencies"
+      - "type.deps"
+      - "agent.bot"
 
   - package-ecosystem: gomod
     directory: /
     schedule:
       interval: daily
     labels:
-      - "dependencies"
+      - "type.deps"
+      - "agent.bot"
 


### PR DESCRIPTION
## Summary

Swaps Dependabot's auto-applied labels from the legacy `dependencies` to the canonical ArcavenAE labels:

- `type.deps` — the "kind of change" scope for dependency updates
- `agent.bot` — non-human origin (distinct from `agent.worker` / `agent.envoy`)

Part of the org-wide label scheme consolidation landed in `aae-orc/labels/schema.yaml`.

## Context

Every active ArcavenAE repo now shares the canonical label set (universal `type.*`, `priority.*`, `scope.*`, `triage.*`, `status.*`, `agent.*`, `resolution.*`, `contrib.*`, optional `gate.*` / `provenance.*` / `process.*`, plus per-repo `area.*`). Dependabot is the last system still emitting the legacy `dependencies` label; this PR fixes that.

## Test plan

- [ ] After merge, the next Dependabot PR in this repo carries `type.deps` + `agent.bot` and NOT `dependencies`
- [ ] No workflow references `dependencies` as a label trigger (verified before merge)

## Follow-up

Once every open Dependabot PR in the repo uses the new labels, the legacy `dependencies` label can be deleted from the repo's label set.

## Related

- Reference scheme: `~/.claude/skills/gh-labels/references/arcavenae-label-scheme.md`
- Source of truth: `aae-orc/labels/schema.yaml`
