### PR TITLE
fix(install): validate pack shape + scope permissions to SIDESHOW_HOME

### DIFF
--- a/cmd/sideshow/main.go
+++ b/cmd/sideshow/main.go
@@ -394,6 +394,7 @@ func runInstall(args []string) error {
 	autoYes := false
 	noPerms := false
 	scope := permissions.ScopeUser
+	scopeExplicit := false
 
 	for i := 1; i < len(args); i++ {
 		switch args[i] {
@@ -416,6 +417,7 @@ func runInstall(args []string) error {
 				default:
 					return fmt.Errorf("unknown scope: %s (use 'user' or 'project')", args[i+1])
 				}
+				scopeExplicit = true
 				i++
 			}
 		}
@@ -429,8 +431,17 @@ func runInstall(args []string) error {
 		return err
 	}
 
-	// Configure Claude Code permissions
+	// Configure Claude Code permissions.
 	if noPerms {
+		return nil
+	}
+
+	// SIDESHOW_HOME signals a non-default data dir — typically a probe,
+	// test, or scoped install. Don't write to user-global permissions
+	// unless the caller explicitly asked for it via --scope.
+	if os.Getenv("SIDESHOW_HOME") != "" && !scopeExplicit {
+		fmt.Printf("\nSIDESHOW_HOME is set; skipping Claude Code permission configuration.\n")
+		fmt.Printf("Pass --scope user or --scope project to configure permissions explicitly.\n")
 		return nil
 	}
 

--- a/internal/pack/pack.go
+++ b/internal/pack/pack.go
@@ -159,6 +159,67 @@ func (r *Registry) Save() error {
 	return os.WriteFile(RegistryPath(), data, 0o644)
 }
 
+// ValidateShape returns nil if sourcePath looks like a recognized pack
+// shape sideshow knows how to install. Two shapes are accepted today:
+//
+//  1. bmad installer output — marked by _config/manifest.yaml
+//     (the layout npx bmad-method install produces, with or without
+//     the _bmad/ prefix)
+//  2. sideshow-native pack — marked by pack.yaml at the root
+//
+// Common rejection: an upstream npm source tarball (BMAD-METHOD/
+// repo, with src/ + tools/ + package.json but no _config/manifest.yaml)
+// is NOT installable as a pack — the upstream installer must run first
+// to emit installer output. ValidateShape detects this case and returns
+// a specific error pointing at the next step.
+func ValidateShape(sourcePath string) error {
+	if hasFile(sourcePath, "_config", "manifest.yaml") ||
+		hasFile(sourcePath, "_bmad", "_config", "manifest.yaml") {
+		return nil
+	}
+	if hasFile(sourcePath, "pack.yaml") {
+		return nil
+	}
+
+	// Diagnose the most common rejection: looks like an upstream npm
+	// source tarball (e.g. tar -xzf bmad-method-6.5.0.tgz).
+	if hasFile(sourcePath, "package.json") &&
+		(hasDir(sourcePath, "src") || hasDir(sourcePath, "tools")) {
+		return fmt.Errorf(
+			"source path %q looks like an upstream npm source tarball, "+
+				"not an installable pack. Sideshow installs the OUTPUT of "+
+				"the upstream installer (which contains _config/manifest.yaml), "+
+				"not the source repo. Run the upstream installer first "+
+				"(e.g. `npx bmad-method install --output-folder /tmp/build`) "+
+				"and pass --from <build-dir>",
+			sourcePath,
+		)
+	}
+
+	return fmt.Errorf(
+		"source path %q does not look like a sideshow-installable pack: "+
+			"expected either an installer-output layout (_config/manifest.yaml) "+
+			"or a sideshow-native pack (pack.yaml at the root)",
+		sourcePath,
+	)
+}
+
+func hasFile(root string, parts ...string) bool {
+	info, err := os.Stat(filepath.Join(append([]string{root}, parts...)...))
+	if err != nil {
+		return false
+	}
+	return !info.IsDir()
+}
+
+func hasDir(root string, name string) bool {
+	info, err := os.Stat(filepath.Join(root, name))
+	if err != nil {
+		return false
+	}
+	return info.IsDir()
+}
+
 // DetectVersion tries to read the version from a pack's manifest.
 //
 // Supports three --from layouts:
@@ -267,6 +328,15 @@ func InstallFromLocal(name, sourcePath string) error {
 	}
 	if !info.IsDir() {
 		return fmt.Errorf("source path is not a directory: %s", sourcePath)
+	}
+
+	// Validate pack shape before copying. Sideshow accepts two shapes:
+	//   - installer output (bmad-style, marked by _config/manifest.yaml)
+	//   - sideshow-native pack (marked by pack.yaml)
+	// An npm source tarball (package.json + src/ + tools/) is NOT a pack
+	// — the upstream installer must run first to produce installable output.
+	if err := ValidateShape(sourcePath); err != nil {
+		return err
 	}
 
 	// Detect version

--- a/internal/pack/pack_test.go
+++ b/internal/pack/pack_test.go
@@ -3,6 +3,7 @@ package pack
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -291,5 +292,106 @@ func TestInstallFromLocal(t *testing.T) {
 	}
 	if target != "1.0.0" {
 		t.Errorf("current symlink = %q, want 1.0.0", target)
+	}
+}
+
+func TestValidateShape_AcceptsBmadInstallerOutputDirectChild(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	cfg := filepath.Join(dir, "_config")
+	if err := os.MkdirAll(cfg, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cfg, "manifest.yaml"), []byte("version: 6.3.0\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := ValidateShape(dir); err != nil {
+		t.Fatalf("ValidateShape rejected installer-output layout: %v", err)
+	}
+}
+
+func TestValidateShape_AcceptsBmadInstallerOutputNestedPrefix(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	cfg := filepath.Join(dir, "_bmad", "_config")
+	if err := os.MkdirAll(cfg, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cfg, "manifest.yaml"), []byte("version: 6.3.0\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := ValidateShape(dir); err != nil {
+		t.Fatalf("ValidateShape rejected nested _bmad/ layout: %v", err)
+	}
+}
+
+func TestValidateShape_AcceptsSideshowNativePack(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "pack.yaml"), []byte("name: foo\nversion: 1.0.0\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := ValidateShape(dir); err != nil {
+		t.Fatalf("ValidateShape rejected sideshow-native pack: %v", err)
+	}
+}
+
+func TestValidateShape_RejectsUpstreamSourceTarball(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	// Mimic bmad-method-6.5.0.tgz extracted: package.json + src/ + tools/
+	if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte(`{"version":"6.5.0"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "src"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "tools"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	err := ValidateShape(dir)
+	if err == nil {
+		t.Fatal("ValidateShape accepted upstream source tarball; expected rejection")
+	}
+	if !strings.Contains(err.Error(), "upstream npm source tarball") {
+		t.Fatalf("expected 'upstream npm source tarball' in error, got: %v", err)
+	}
+}
+
+func TestValidateShape_RejectsUnknownLayout(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err := ValidateShape(dir)
+	if err == nil {
+		t.Fatal("ValidateShape accepted unrecognized layout; expected rejection")
+	}
+	if !strings.Contains(err.Error(), "does not look like a sideshow-installable pack") {
+		t.Fatalf("expected generic 'does not look like' error, got: %v", err)
+	}
+}
+
+func TestInstallFromLocal_RejectsSourceTarballShape(t *testing.T) {
+	t.Setenv("SIDESHOW_HOME", t.TempDir())
+
+	source := t.TempDir()
+	if err := os.WriteFile(filepath.Join(source, "package.json"), []byte(`{"version":"6.5.0"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(source, "src"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(source, "tools"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	err := InstallFromLocal("bmad", source)
+	if err == nil {
+		t.Fatal("InstallFromLocal accepted upstream source tarball; expected rejection")
+	}
+	if !strings.Contains(err.Error(), "upstream npm source tarball") {
+		t.Fatalf("expected upstream-source-rejection in error, got: %v", err)
 	}
 }

--- a/internal/permissions/permissions_test.go
+++ b/internal/permissions/permissions_test.go
@@ -1,0 +1,162 @@
+package permissions
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSettingsPath_ProjectScope(t *testing.T) {
+	t.Parallel()
+	got := SettingsPath(ScopeProject, "/tmp/example")
+	want := "/tmp/example/.claude/settings.local.json"
+	if got != want {
+		t.Fatalf("SettingsPath(project)=%q want %q", got, want)
+	}
+}
+
+func TestSettingsPath_UserScopeUsesHome(t *testing.T) {
+	t.Parallel()
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("UserHomeDir: %v", err)
+	}
+	got := SettingsPath(ScopeUser, "/ignored")
+	want := filepath.Join(home, ".claude", "settings.json")
+	if got != want {
+		t.Fatalf("SettingsPath(user)=%q want %q", got, want)
+	}
+}
+
+func TestAddReadPermission_NewPath(t *testing.T) {
+	t.Parallel()
+	s := &ClaudeSettings{raw: map[string]any{}}
+	if !s.AddReadPermission("/tmp/packs/") {
+		t.Fatal("AddReadPermission returned false for new path")
+	}
+	allow := s.GetAllowList()
+	if len(allow) != 1 || allow[0] != "Read(/tmp/packs/)" {
+		t.Fatalf("allow list = %v, want [Read(/tmp/packs/)]", allow)
+	}
+}
+
+func TestAddReadPermission_Idempotent(t *testing.T) {
+	t.Parallel()
+	s := &ClaudeSettings{raw: map[string]any{}}
+	s.AddReadPermission("/tmp/packs/")
+	if s.AddReadPermission("/tmp/packs/") {
+		t.Fatal("AddReadPermission returned true for already-present path")
+	}
+	if got := len(s.GetAllowList()); got != 1 {
+		t.Fatalf("allow list len = %d, want 1", got)
+	}
+}
+
+func TestRemoveReadPermission_Removes(t *testing.T) {
+	t.Parallel()
+	s := &ClaudeSettings{raw: map[string]any{}}
+	s.AddReadPermission("/tmp/packs/")
+	s.AddReadPermission("/var/data/")
+	if !s.RemoveReadPermission("/tmp/packs/") {
+		t.Fatal("RemoveReadPermission returned false for present path")
+	}
+	allow := s.GetAllowList()
+	if len(allow) != 1 || allow[0] != "Read(/var/data/)" {
+		t.Fatalf("allow list = %v, want [Read(/var/data/)]", allow)
+	}
+}
+
+func TestSaveAndLoadSettings_Roundtrip(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.json")
+
+	s := &ClaudeSettings{raw: map[string]any{}}
+	s.AddReadPermission("/tmp/packs/")
+	if err := s.Save(path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	loaded, err := LoadSettings(path)
+	if err != nil {
+		t.Fatalf("LoadSettings: %v", err)
+	}
+	allow := loaded.GetAllowList()
+	if len(allow) != 1 || allow[0] != "Read(/tmp/packs/)" {
+		t.Fatalf("loaded allow list = %v", allow)
+	}
+}
+
+func TestSaveAndLoadSettings_PreservesUnrelatedKeys(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.json")
+
+	// Pre-populate a settings file with unrelated content.
+	pre := map[string]any{
+		"theme": "dark",
+		"hooks": map[string]any{
+			"SessionStart": []any{
+				map[string]any{"command": "bd prime"},
+			},
+		},
+	}
+	data, err := json.Marshal(pre)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	// Load, mutate via permissions, save.
+	s, err := LoadSettings(path)
+	if err != nil {
+		t.Fatalf("LoadSettings: %v", err)
+	}
+	s.AddReadPermission("/tmp/packs/")
+	if err := s.Save(path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// Re-read raw bytes; verify both unrelated keys and new permissions.
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	var roundtrip map[string]any
+	if err := json.Unmarshal(got, &roundtrip); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if roundtrip["theme"] != "dark" {
+		t.Errorf("theme key lost: %v", roundtrip["theme"])
+	}
+	if _, ok := roundtrip["hooks"]; !ok {
+		t.Errorf("hooks key lost")
+	}
+	if _, ok := roundtrip["permissions"]; !ok {
+		t.Errorf("permissions key not added")
+	}
+}
+
+func TestConfigureForScope_ProjectWritesProjectFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	if err := ConfigureForScope(ScopeProject, "/tmp/packs", dir); err != nil {
+		t.Fatalf("ConfigureForScope: %v", err)
+	}
+	expected := filepath.Join(dir, ".claude", "settings.local.json")
+	if _, err := os.Stat(expected); err != nil {
+		t.Fatalf("expected settings file at %s: %v", expected, err)
+	}
+
+	loaded, err := LoadSettings(expected)
+	if err != nil {
+		t.Fatalf("LoadSettings: %v", err)
+	}
+	allow := loaded.GetAllowList()
+	if len(allow) != 1 || allow[0] != "Read(/tmp/packs/)" {
+		t.Fatalf("allow list = %v", allow)
+	}
+}


### PR DESCRIPTION
## Summary

Two `sideshow install` bugs surfaced in [aae-orc finding-035](https://github.com/ArcavenAE/aae-orc/blob/main/_kos/findings/finding-035-bmad-65-sideshow-readiness.md) (the bmad 6.4/6.5 readiness probe).

- **aae-orc-2gxt** — `sideshow install --from <upstream-source-tarball>` silently produced a broken install. `detectPackageJSONVersion` fallback accepted the npm source tarball shape (`package.json` + `src/` + `tools/`), registry was updated, `current` symlink flipped, then `commands sync` reported "Synced 0 artifacts" with no diagnostic. Now: `ValidateShape` runs before any copy and rejects unrecognized shapes with a specific, actionable error.
- **aae-orc-crds** — `SIDESHOW_HOME=/tmp/scratch sideshow install` correctly wrote pack content to the override path but the permissions writer unconditionally added `Read(<packs-dir>)` to `~/.claude/settings.json`. Probe-dir paths leaked into user-global permissions. Now: when `SIDESHOW_HOME` is set and `--scope` was not explicitly passed, skip permissions configuration with a helpful message. Explicit `--scope user` or `--scope project` still works as before.

## Behavior

```
$ SIDESHOW_HOME=/tmp/scratch sideshow install bmad --from /tmp/bmad-method-6.5.0/ --yes
error: source path "/tmp/bmad-method-6.5.0" looks like an upstream npm
source tarball, not an installable pack. Sideshow installs the OUTPUT
of the upstream installer (which contains _config/manifest.yaml), not
the source repo. Run the upstream installer first (e.g. `npx
bmad-method install --output-folder /tmp/build`) and pass --from <build-dir>
```

```
$ SIDESHOW_HOME=/tmp/scratch sideshow install bmad --from /tmp/installer-output/ --yes
Installing bmad 6.3.0 from /tmp/installer-output
Installed 1361 files to /tmp/scratch/packs/bmad/6.3.0
Run 'sideshow commands sync' to update Claude Code commands.

SIDESHOW_HOME is set; skipping Claude Code permission configuration.
Pass --scope user or --scope project to configure permissions explicitly.
```

## Tests

- `ValidateShape`: 4 cases (bmad installer output direct + nested, sideshow-native pack, upstream-source rejection, unknown-layout rejection)
- `InstallFromLocal`: 1 end-to-end rejection test
- `permissions`: 8 tests where the package previously had zero (`Save`/`Load` roundtrip, idempotent add, project-scope path resolution, preserves unrelated keys, `ConfigureForScope` end-to-end)

`go test -race ./...` clean. `golangci-lint` clean. `gofmt` clean.

## Side discovery

While writing tests I noticed that `AddReadPermission`'s parent-coverage check uses `strings.HasPrefix(perm, existing)` against permission strings of the form `Read(/path/)` — which never matches a parent because of the closing `)`. The comment claims "parent already allowed" but the logic doesn't deliver that. Filed as a separate low-priority bug ([aae-orc-9bht]) and explicitly not addressed here to keep this PR scoped.

## Test plan

- [x] `go test -race ./...`
- [x] `golangci-lint run ./...`
- [x] `gofmt -l .`
- [x] Manual verification: install upstream tarball → rejected with helpful message
- [x] Manual verification: install installer-output → succeeds, no user-global permission write under `SIDESHOW_HOME`
- [x] Manual verification: explicit `--scope project` still writes to project-local settings under `SIDESHOW_HOME`
- [x] User settings.json untouched after probe runs

Refs: aae-orc-2gxt, aae-orc-crds