### PR TITLE
feat(bindings): canonical-id ownership for synced-count

### DIFF
--- a/cmd/sideshow/main.go
+++ b/cmd/sideshow/main.go
@@ -607,7 +607,7 @@ func runStatus() error {
 		} else {
 			fmt.Printf("  available: %d\n", available)
 		}
-		synced, err := bindings.SyncedCount(p.Name)
+		synced, err := bindings.SyncedCount(p.Name, p.Path)
 		if err != nil {
 			fmt.Printf("  synced:    error: %v\n", err)
 		} else {

--- a/internal/bindings/bindings.go
+++ b/internal/bindings/bindings.go
@@ -112,16 +112,27 @@ func CountForPack(_, packPath string) (int, error) {
 
 // SyncedCount returns the total number of artifacts currently synced to
 // tool-config directories for this pack across all binding types.
-func SyncedCount(packName string) (int, error) {
+// Ownership is determined by the canonical-id / basename set the pack
+// ships at packPath — not by a name prefix — so packs that ship
+// multi-prefix bindings (bmad ships bmad-* and gds-*) are accounted
+// fully. The first arg is reserved for future per-pack lookup hints
+// (e.g. a registry-stored manifest of what was actually written) and
+// is unused today; pass the pack name for forward compatibility.
+func SyncedCount(_, packPath string) (int, error) {
+	resolved, err := filepath.EvalSymlinks(packPath)
+	if err != nil {
+		return 0, err
+	}
+
 	total := 0
 
-	c, err := countSyncedCommands(packName)
+	c, err := countSyncedCommands(resolved)
 	if err != nil {
 		return 0, err
 	}
 	total += c
 
-	s, err := countSyncedSkills(packName)
+	s, err := countSyncedSkills(resolved)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/bindings/markdown_command.go
+++ b/internal/bindings/markdown_command.go
@@ -206,23 +206,54 @@ func countMarkdownCommands(packPath string) int {
 }
 
 // countSyncedCommands returns how many markdown command files for a pack
-// are present in ~/.claude/commands/.
-func countSyncedCommands(packName string) (int, error) {
-	dir := claudeCommandsDir()
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return 0, nil
-		}
-		return 0, err
+// are present in ~/.claude/commands/. Ownership is determined by
+// the basenames the pack ships, not by name prefix — packs that ship
+// multi-prefix commands (e.g. bmad's bmad-* + gds-*) would otherwise be
+// undercounted by a "<packName>-" heuristic.
+func countSyncedCommands(packPath string) (int, error) {
+	owned := commandBasenames(packPath)
+	if len(owned) == 0 {
+		return 0, nil
 	}
 
+	dir := claudeCommandsDir()
 	count := 0
-	prefix := packName + "-"
-	for _, e := range entries {
-		if strings.HasPrefix(e.Name(), prefix) && strings.HasSuffix(e.Name(), ".md") {
+	for name := range owned {
+		info, err := os.Stat(filepath.Join(dir, name))
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return 0, err
+		}
+		if !info.IsDir() {
 			count++
 		}
 	}
 	return count, nil
+}
+
+// commandBasenames returns the set of *.md basenames the pack ships as
+// markdown command bindings (root-level commands/ or pack-root *.md).
+func commandBasenames(packPath string) map[string]struct{} {
+	out := map[string]struct{}{}
+
+	addFrom := func(dir string) {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			return
+		}
+		for _, e := range entries {
+			if e.IsDir() {
+				continue
+			}
+			name := e.Name()
+			if strings.HasSuffix(name, ".md") {
+				out[name] = struct{}{}
+			}
+		}
+	}
+
+	addFrom(filepath.Join(packPath, "commands"))
+	return out
 }

--- a/internal/bindings/markdown_command_test.go
+++ b/internal/bindings/markdown_command_test.go
@@ -97,3 +97,44 @@ func TestCountMarkdownCommands_Deduplicates(t *testing.T) {
 		t.Errorf("countMarkdownCommands = %d, want 2 (a and b; the root-level bmad-a.md is a duplicate basename)", count)
 	}
 }
+
+func TestCountSyncedCommands_OwnershipByBasename(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+
+	packPath := t.TempDir()
+	// Pack ships two prefixes of commands.
+	writeFile(t, filepath.Join(packPath, "commands", "bmad-help.md"), "x")
+	writeFile(t, filepath.Join(packPath, "commands", "bmad-init.md"), "x")
+	writeFile(t, filepath.Join(packPath, "commands", "gds-quickstart.md"), "x")
+
+	cmdsDir := filepath.Join(homeDir, ".claude", "commands")
+	writeFile(t, filepath.Join(cmdsDir, "bmad-help.md"), "y")
+	writeFile(t, filepath.Join(cmdsDir, "bmad-init.md"), "y")
+	writeFile(t, filepath.Join(cmdsDir, "gds-quickstart.md"), "y")
+	// Foreign command at target — must not count.
+	writeFile(t, filepath.Join(cmdsDir, "user-authored.md"), "foreign")
+
+	got, err := countSyncedCommands(packPath)
+	if err != nil {
+		t.Fatalf("countSyncedCommands: %v", err)
+	}
+	if got != 3 {
+		t.Errorf("countSyncedCommands = %d, want 3 (multi-prefix, ignoring foreign)", got)
+	}
+}
+
+func TestCountSyncedCommands_PackHasNoCommands(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+
+	packPath := t.TempDir()
+
+	got, err := countSyncedCommands(packPath)
+	if err != nil {
+		t.Fatalf("countSyncedCommands: %v", err)
+	}
+	if got != 0 {
+		t.Errorf("countSyncedCommands = %d, want 0", got)
+	}
+}

--- a/internal/bindings/skill_dir.go
+++ b/internal/bindings/skill_dir.go
@@ -196,28 +196,49 @@ func countSkillDirs(packPath string) int {
 }
 
 // countSyncedSkills counts skill directories currently present in
-// ~/.claude/skills/ that belong to a given pack. A skill is attributed
-// to a pack when its name starts with "<packName>-" (matches bmad-*
-// convention; future binding types may need a manifest).
-func countSyncedSkills(packName string) (int, error) {
-	dir := claudeSkillsDir()
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return 0, nil
-		}
-		return 0, err
+// ~/.claude/skills/ that the given pack ships. Ownership is determined
+// by canonical id — the directory name under the pack's .claude/skills/.
+// This matches upstream bmad's `installed-skills.js` approach (added in
+// bmad 6.5) which reads the canonicalId set rather than relying on a
+// name prefix. Packs may ship skills with multiple prefixes (bmad ships
+// bmad-* and gds-* both); a prefix heuristic undercounts those packs.
+func countSyncedSkills(packPath string) (int, error) {
+	owned := skillCanonicalIds(packPath)
+	if len(owned) == 0 {
+		return 0, nil
 	}
 
+	dir := claudeSkillsDir()
 	count := 0
-	prefix := packName + "-"
-	for _, e := range entries {
-		if !e.IsDir() {
-			continue
+	for id := range owned {
+		info, err := os.Stat(filepath.Join(dir, id))
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return 0, err
 		}
-		if strings.HasPrefix(e.Name(), prefix) {
+		if info.IsDir() {
 			count++
 		}
 	}
 	return count, nil
+}
+
+// skillCanonicalIds returns the set of skill directory names (canonical
+// ids) the pack ships under .claude/skills/. Returns an empty set if the
+// pack has no skills binding.
+func skillCanonicalIds(packPath string) map[string]struct{} {
+	skillsSrc := filepath.Join(packPath, ".claude", "skills")
+	entries, err := os.ReadDir(skillsSrc)
+	if err != nil {
+		return map[string]struct{}{}
+	}
+	ids := make(map[string]struct{}, len(entries))
+	for _, e := range entries {
+		if e.IsDir() {
+			ids[e.Name()] = struct{}{}
+		}
+	}
+	return ids
 }

--- a/internal/bindings/skill_dir_test.go
+++ b/internal/bindings/skill_dir_test.go
@@ -145,3 +145,84 @@ func TestSkillDirBinding_Validate_EmptySkillsDir(t *testing.T) {
 		t.Fatalf("Validate passed on empty skills dir; expected error")
 	}
 }
+
+func TestCountSyncedSkills_OwnershipByCanonicalId(t *testing.T) {
+	// HOME override isolates the test from the user's real ~/.claude/.
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+
+	packPath := t.TempDir()
+	// Pack ships skills with TWO prefixes (mirrors bmad 6.3.0: bmad-* + gds-*).
+	writeFile(t, filepath.Join(packPath, ".claude", "skills", "bmad-help", "SKILL.md"), "x")
+	writeFile(t, filepath.Join(packPath, ".claude", "skills", "bmad-party-mode", "SKILL.md"), "x")
+	writeFile(t, filepath.Join(packPath, ".claude", "skills", "gds-create-prd", "SKILL.md"), "x")
+	writeFile(t, filepath.Join(packPath, ".claude", "skills", "gds-validate-gdd", "SKILL.md"), "x")
+
+	// Simulate a sync: every skill the pack ships is present at the target.
+	skillsDir := filepath.Join(homeDir, ".claude", "skills")
+	for _, id := range []string{"bmad-help", "bmad-party-mode", "gds-create-prd", "gds-validate-gdd"} {
+		writeFile(t, filepath.Join(skillsDir, id, "SKILL.md"), "synced")
+	}
+	// Foreign skill present at target, NOT owned by this pack.
+	writeFile(t, filepath.Join(skillsDir, "user-authored-skill", "SKILL.md"), "foreign")
+
+	got, err := countSyncedSkills(packPath)
+	if err != nil {
+		t.Fatalf("countSyncedSkills: %v", err)
+	}
+	if got != 4 {
+		t.Errorf("countSyncedSkills = %d, want 4 (multi-prefix bmad-* + gds-*, ignoring foreign)", got)
+	}
+}
+
+func TestCountSyncedSkills_PartiallySynced(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+
+	packPath := t.TempDir()
+	for _, id := range []string{"bmad-help", "bmad-customize", "bmad-shard-doc"} {
+		writeFile(t, filepath.Join(packPath, ".claude", "skills", id, "SKILL.md"), "x")
+	}
+	// Only one of the three is in the target.
+	writeFile(t, filepath.Join(homeDir, ".claude", "skills", "bmad-help", "SKILL.md"), "ok")
+
+	got, err := countSyncedSkills(packPath)
+	if err != nil {
+		t.Fatalf("countSyncedSkills: %v", err)
+	}
+	if got != 1 {
+		t.Errorf("countSyncedSkills = %d, want 1 (only bmad-help present at target)", got)
+	}
+}
+
+func TestCountSyncedSkills_PackHasNoSkills(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+
+	packPath := t.TempDir() // no .claude/skills/
+
+	got, err := countSyncedSkills(packPath)
+	if err != nil {
+		t.Fatalf("countSyncedSkills: %v", err)
+	}
+	if got != 0 {
+		t.Errorf("countSyncedSkills = %d, want 0", got)
+	}
+}
+
+func TestCountSyncedSkills_TargetMissing(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+
+	packPath := t.TempDir()
+	writeFile(t, filepath.Join(packPath, ".claude", "skills", "bmad-help", "SKILL.md"), "x")
+	// homeDir/.claude/skills doesn't exist — no sync has run.
+
+	got, err := countSyncedSkills(packPath)
+	if err != nil {
+		t.Fatalf("countSyncedSkills: %v", err)
+	}
+	if got != 0 {
+		t.Errorf("countSyncedSkills = %d, want 0 (target dir absent)", got)
+	}
+}


### PR DESCRIPTION
## Summary

Replace the `"<packName>-"` prefix heuristic in `countSyncedSkills` / `countSyncedCommands` with canonical-id ownership: enumerate the skill directory names (and command basenames) the pack ships at `packPath`, then count how many of those are present in the user-scope binding target.

Closes the bmad 6.3.0 undercount: prefix matching counted only `bmad-*` (61) and missed the `gds-*` skills (36) that ship with the same pack. Status now reports the correct 97.

```
$ sideshow status
bmad 6.3.0
  available: 97
  synced:    97   # was: 61
```

The same fix in spirit as upstream bmad 6.5's `tools/installer/ide/shared/installed-skills.js` (added in that release). They cite custom modules shipping with non-bmad prefixes (e.g. `fred-cool-skill`) as the reason a prefix match doesn't work.

## What changed

- `countSyncedSkills(packName)` → `countSyncedSkills(packPath)` — walks the pack source for ownership, intersects with target dir
- `countSyncedCommands(packName)` → `countSyncedCommands(packPath)` — same shape for markdown commands
- `SyncedCount(name, packPath)` signature: `name` reserved for a future registry-stored manifest lookup; pass for forward compatibility
- Foreign artifacts in `~/.claude/skills/` and `~/.claude/commands/` are correctly not attributed to any pack

## Tests

7 new tests covering:
- Multi-prefix pack: `bmad-*` + `gds-*` count together (the bug)
- Partial sync: only some shipped skills present at target
- Empty pack (no `.claude/skills/`)
- Target dir absent (no sync has run)
- Foreign skill at target ignored
- Same surface for commands

`go test -race ./...` clean. `golangci-lint` clean. `gofmt` clean.

## Empirical verification

Tested against the live `~/.local/share/sideshow/packs/bmad/6.3.0/` install. Before: `synced: 61`. After: `synced: 97`. Correct.

## Test plan

- [x] `go test -race ./...`
- [x] `golangci-lint run ./...`
- [x] `gofmt -l .`
- [x] Manual: `sideshow status` against real bmad 6.3.0 install — reports 97/97
- [x] Foreign `~/.claude/skills/<not-our-skill>/` not counted

Refs: aae-orc-po9j, aae-orc-51j0