### PR TITLE
feat(bindings): process upstream removals.txt during sync

### DIFF
--- a/internal/bindings/bindings.go
+++ b/internal/bindings/bindings.go
@@ -71,11 +71,23 @@ func Sync() error {
 	}
 
 	totalSynced := 0
+	totalRemoved := 0
 	for _, p := range packs {
 		bindings, err := DiscoverBindings(p)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "warning: discover %s: %v\n", p.Name, err)
 			continue
+		}
+
+		// Process removals.txt before writing fresh bindings so stale
+		// entries from prior versions don't accumulate.
+		if resolved, rerr := filepath.EvalSymlinks(p.Path); rerr == nil {
+			if n, perr := ProcessRemovals(resolved); perr != nil {
+				fmt.Fprintf(os.Stderr, "warning: process removals %s: %v\n", p.Name, perr)
+			} else if n > 0 {
+				fmt.Printf("Removed %d stale binding(s) for %s\n", n, p.Name)
+				totalRemoved += n
+			}
 		}
 
 		for _, b := range bindings {
@@ -88,6 +100,9 @@ func Sync() error {
 		}
 	}
 
+	if totalRemoved > 0 {
+		fmt.Printf("Removed %d stale binding(s) across all packs\n", totalRemoved)
+	}
 	fmt.Printf("Synced %d artifacts across all bindings\n", totalSynced)
 	return nil
 }

--- a/internal/bindings/removals.go
+++ b/internal/bindings/removals.go
@@ -1,0 +1,134 @@
+package bindings
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// SideshowSentinel is the marker that identifies a sideshow-managed
+// binding output. ProcessRemovals will only delete entries that contain
+// this sentinel — user-authored content with the same name is left
+// alone.
+const SideshowSentinel = "<!-- sideshow:fallback-resolution:begin -->"
+
+// ProcessRemovals reads <packPath>/removals.txt (if present) and removes
+// matching binding entries from user-scope target dirs. Each non-blank,
+// non-comment line names a canonicalId — a skill directory under
+// ~/.claude/skills/<id>/ or a command file at ~/.claude/commands/<id>.md.
+// Only entries that carry the sideshow sentinel are removed; user-authored
+// content with the same name is left alone.
+//
+// As a defensive measure, an entry is skipped (NOT removed) if the
+// current pack still ships a binding by that canonicalId — the pack
+// is the authority on what it currently provides.
+//
+// Returns the number of entries removed and the first error
+// encountered. Per-entry errors are non-fatal; processing continues.
+func ProcessRemovals(packPath string) (int, error) {
+	removalsFile := filepath.Join(packPath, "removals.txt")
+	f, err := os.Open(removalsFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("open removals.txt: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	// Build the pack's current canonical set so we never delete what's
+	// still shipped (defensive: upstream may carry stale entries).
+	currentSkills := skillCanonicalIds(packPath)
+	currentCommands := commandBasenames(packPath)
+
+	removed := 0
+	var firstErr error
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		canonicalID := line
+
+		if _, stillShipped := currentSkills[canonicalID]; !stillShipped {
+			ok, err := removeManagedSkill(canonicalID)
+			if err != nil && firstErr == nil {
+				firstErr = err
+			}
+			if ok {
+				removed++
+			}
+		}
+
+		cmdName := canonicalID + ".md"
+		if _, stillShipped := currentCommands[cmdName]; !stillShipped {
+			ok, err := removeManagedCommand(cmdName)
+			if err != nil && firstErr == nil {
+				firstErr = err
+			}
+			if ok {
+				removed++
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil && firstErr == nil {
+		firstErr = err
+	}
+
+	return removed, firstErr
+}
+
+// removeManagedSkill deletes ~/.claude/skills/<canonicalId>/ if its
+// SKILL.md carries the sideshow sentinel. Returns (true, nil) on
+// successful removal, (false, nil) if not sideshow-managed or absent,
+// (false, err) on filesystem error.
+func removeManagedSkill(canonicalID string) (bool, error) {
+	skillDir := filepath.Join(claudeSkillsDir(), canonicalID)
+	skillEntry := filepath.Join(skillDir, "SKILL.md")
+	owned, err := hasSentinel(skillEntry)
+	if err != nil {
+		return false, err
+	}
+	if !owned {
+		return false, nil
+	}
+	if err := os.RemoveAll(skillDir); err != nil {
+		return false, fmt.Errorf("remove skill %s: %w", canonicalID, err)
+	}
+	return true, nil
+}
+
+// removeManagedCommand deletes ~/.claude/commands/<name> if it carries
+// the sideshow sentinel.
+func removeManagedCommand(name string) (bool, error) {
+	cmdFile := filepath.Join(claudeCommandsDir(), name)
+	owned, err := hasSentinel(cmdFile)
+	if err != nil {
+		return false, err
+	}
+	if !owned {
+		return false, nil
+	}
+	if err := os.Remove(cmdFile); err != nil {
+		return false, fmt.Errorf("remove command %s: %w", name, err)
+	}
+	return true, nil
+}
+
+// hasSentinel reports whether path exists and contains the sideshow
+// fallback-resolution sentinel. A non-existent file returns (false, nil)
+// — that's a normal "not sideshow-managed" answer, not an error.
+func hasSentinel(path string) (bool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return strings.Contains(string(data), SideshowSentinel), nil
+}

--- a/internal/bindings/removals_test.go
+++ b/internal/bindings/removals_test.go
@@ -1,0 +1,215 @@
+package bindings
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeSidesowOwned writes a SKILL.md (or generic md) at path with the
+// fallback-resolution sentinel embedded — marking it as sideshow-managed.
+func writeSideshowOwned(t *testing.T, path, body string) {
+	t.Helper()
+	content := body + "\n\n" + SideshowSentinel + "\nfooter\n<!-- sideshow:fallback-resolution:end -->\n"
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// writeUserAuthored writes a file with no sentinel — simulating a user-
+// authored skill or command sideshow must NOT touch.
+func writeUserAuthored(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestProcessRemovals_NoFile(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+
+	packPath := t.TempDir()
+	got, err := ProcessRemovals(packPath)
+	if err != nil {
+		t.Fatalf("ProcessRemovals: %v", err)
+	}
+	if got != 0 {
+		t.Errorf("got %d removals, want 0 when removals.txt is absent", got)
+	}
+}
+
+func TestProcessRemovals_RemovesManagedSkill(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+
+	packPath := t.TempDir()
+	if err := os.WriteFile(filepath.Join(packPath, "removals.txt"),
+		[]byte("# comments OK\n\nbmad-old-thing\n"),
+		0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	skillsDir := filepath.Join(homeDir, ".claude", "skills")
+	writeSideshowOwned(t, filepath.Join(skillsDir, "bmad-old-thing", "SKILL.md"), "stale skill")
+
+	got, err := ProcessRemovals(packPath)
+	if err != nil {
+		t.Fatalf("ProcessRemovals: %v", err)
+	}
+	if got != 1 {
+		t.Errorf("got %d removals, want 1", got)
+	}
+	if _, err := os.Stat(filepath.Join(skillsDir, "bmad-old-thing")); !os.IsNotExist(err) {
+		t.Errorf("expected bmad-old-thing/ to be deleted; stat err = %v", err)
+	}
+}
+
+func TestProcessRemovals_LeavesUserAuthoredAlone(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+
+	packPath := t.TempDir()
+	if err := os.WriteFile(filepath.Join(packPath, "removals.txt"),
+		[]byte("bmad-handcrafted\n"),
+		0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	// User-authored skill at the same canonicalId — NO sentinel.
+	skillsDir := filepath.Join(homeDir, ".claude", "skills")
+	skillEntry := filepath.Join(skillsDir, "bmad-handcrafted", "SKILL.md")
+	writeUserAuthored(t, skillEntry, "I wrote this myself")
+
+	got, err := ProcessRemovals(packPath)
+	if err != nil {
+		t.Fatalf("ProcessRemovals: %v", err)
+	}
+	if got != 0 {
+		t.Errorf("got %d removals, want 0 (user-authored should be preserved)", got)
+	}
+	data, err := os.ReadFile(skillEntry)
+	if err != nil {
+		t.Fatalf("user-authored skill missing: %v", err)
+	}
+	if !strings.Contains(string(data), "I wrote this myself") {
+		t.Errorf("user-authored content modified: %s", data)
+	}
+}
+
+func TestProcessRemovals_DefersToCurrentlyShipped(t *testing.T) {
+	// Defensive case: removals.txt names something the current pack
+	// ALSO ships. Don't delete — pack is authority on what's current.
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+
+	packPath := t.TempDir()
+	if err := os.WriteFile(filepath.Join(packPath, "removals.txt"),
+		[]byte("bmad-still-here\n"),
+		0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+	// Pack ships this canonicalId — it's NOT removed in this version.
+	if err := os.MkdirAll(filepath.Join(packPath, ".claude", "skills", "bmad-still-here"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeSideshowOwned(t, filepath.Join(packPath, ".claude", "skills", "bmad-still-here", "SKILL.md"), "x")
+
+	// Target has it from a prior sync.
+	skillsDir := filepath.Join(homeDir, ".claude", "skills")
+	writeSideshowOwned(t, filepath.Join(skillsDir, "bmad-still-here", "SKILL.md"), "synced")
+
+	got, err := ProcessRemovals(packPath)
+	if err != nil {
+		t.Fatalf("ProcessRemovals: %v", err)
+	}
+	if got != 0 {
+		t.Errorf("got %d removals, want 0 (still-shipped canonicalId must not be deleted)", got)
+	}
+	if _, err := os.Stat(filepath.Join(skillsDir, "bmad-still-here", "SKILL.md")); err != nil {
+		t.Errorf("still-shipped skill incorrectly removed: %v", err)
+	}
+}
+
+func TestProcessRemovals_RemovesManagedCommand(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+
+	packPath := t.TempDir()
+	if err := os.WriteFile(filepath.Join(packPath, "removals.txt"),
+		[]byte("bmad-old-command\n"),
+		0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	cmdsDir := filepath.Join(homeDir, ".claude", "commands")
+	writeSideshowOwned(t, filepath.Join(cmdsDir, "bmad-old-command.md"), "stale command")
+
+	got, err := ProcessRemovals(packPath)
+	if err != nil {
+		t.Fatalf("ProcessRemovals: %v", err)
+	}
+	if got != 1 {
+		t.Errorf("got %d removals, want 1", got)
+	}
+	if _, err := os.Stat(filepath.Join(cmdsDir, "bmad-old-command.md")); !os.IsNotExist(err) {
+		t.Errorf("expected old command to be deleted; stat err = %v", err)
+	}
+}
+
+func TestProcessRemovals_SkipsBlanksAndComments(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+
+	packPath := t.TempDir()
+	if err := os.WriteFile(filepath.Join(packPath, "removals.txt"),
+		[]byte("# header\n\n   \n# another comment\nbmad-real-removal\n# trailing\n"),
+		0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	skillsDir := filepath.Join(homeDir, ".claude", "skills")
+	writeSideshowOwned(t, filepath.Join(skillsDir, "bmad-real-removal", "SKILL.md"), "x")
+
+	got, err := ProcessRemovals(packPath)
+	if err != nil {
+		t.Fatalf("ProcessRemovals: %v", err)
+	}
+	if got != 1 {
+		t.Errorf("got %d removals, want 1 (only one real entry)", got)
+	}
+}
+
+func TestProcessRemovals_EntryAbsentFromTarget(t *testing.T) {
+	// removals.txt names something that isn't synced — silent no-op.
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+
+	packPath := t.TempDir()
+	if err := os.WriteFile(filepath.Join(packPath, "removals.txt"),
+		[]byte("bmad-never-synced\n"),
+		0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := ProcessRemovals(packPath)
+	if err != nil {
+		t.Fatalf("ProcessRemovals: %v", err)
+	}
+	if got != 0 {
+		t.Errorf("got %d removals, want 0", got)
+	}
+}


### PR DESCRIPTION
## Summary

bmad ships a `removals.txt` at the top of every release tarball — a list of canonicalIds (skill directory names, command basenames) that were removed or renamed in prior versions. Upstream's installer reads it and prunes matching entries from `.claude/skills/<id>/` on install/update so renamed skills don't ghost-load alongside the new ones. Sideshow ignored the file. Stale skills accumulated across upgrades.

This PR adds `ProcessRemovals(packPath)` and calls it from `Sync()` before each pack's binding sync.

## Behavior

For every non-blank, non-comment line in `<packPath>/removals.txt`:

- Look at `~/.claude/skills/<canonicalId>/SKILL.md` and `~/.claude/commands/<canonicalId>.md`
- **Only delete if the entry contains the sideshow fallback-resolution sentinel** (= sideshow wrote it). User-authored content with the same name is left alone.
- **Defensive: if the current pack still ships the canonicalId, skip the removal** (pack is authority on what's current).

```
$ sideshow commands sync
Removed 3 stale binding(s) for bmad
Removed 3 stale binding(s) across all packs
Synced 97 artifacts across all bindings
```

## Why sentinel-based ownership

Per finding-035 the right long-term answer is a registry-stored manifest of "what sideshow actually wrote" — but that's a bigger lift coordinated with the F24 distribution-ledger work. Until then, the fallback-resolution sentinel that every sideshow-written SKILL.md / command.md carries is a reliable enough ownership signal: anything sideshow wrote has it, anything user-authored doesn't.

## Builds on PR #28

This PR is based on `feat/canonicalid-binding-ownership` (PR #28) — it reuses `skillCanonicalIds` / `commandBasenames` for the "still shipped" defense. Once #28 merges, this PR rebases cleanly to main.

## Tests

7 new tests covering:
- Missing `removals.txt` (silent no-op)
- Managed skill removed cleanly
- User-authored skill with same canonicalId preserved
- Still-shipped canonicalId not removed (defensive)
- Managed command removal
- Blanks + `#` comments skipped
- Target absent (silent no-op)

`go test -race ./...` clean. `golangci-lint` clean. `gofmt` clean.

## Test plan

- [x] `go test -race ./...`
- [x] `golangci-lint run ./...`
- [x] `gofmt -l .`
- [x] Manual: pack with `removals.txt` + sentinel-marked stale entries → entries removed
- [x] Manual: same pack + user-authored same-name entry → preserved
- [x] Manual: pack still-shipping a canonicalId listed in removals.txt → skip

Refs: aae-orc-z2zu