### PR TITLE
feat(install): auto-detect bmad installer-output sibling layout

### DIFF
--- a/internal/pack/pack.go
+++ b/internal/pack/pack.go
@@ -220,6 +220,29 @@ func hasDir(root string, name string) bool {
 	return info.IsDir()
 }
 
+// hasInstallerSiblingLayout reports whether sourcePath looks like the
+// raw output of the upstream bmad installer: an _bmad/ directory
+// containing _config/manifest.yaml plus a sibling .claude/skills/
+// directory. This is the layout `npx bmad-method install
+// --output-folder X` produces. Sideshow can ingest this directly by
+// stripping the _bmad/ prefix; without the auto-detect, users have to
+// manually restructure before running `sideshow install`.
+func hasInstallerSiblingLayout(sourcePath string) bool {
+	if !hasFile(sourcePath, "_bmad", "_config", "manifest.yaml") {
+		return false
+	}
+	if !hasDir(sourcePath, ".claude") {
+		return false
+	}
+	// Defensive: if _config/manifest.yaml ALSO exists at the root, the
+	// pack has already been unified — don't strip a prefix that isn't
+	// load-bearing.
+	if hasFile(sourcePath, "_config", "manifest.yaml") {
+		return false
+	}
+	return true
+}
+
 // DetectVersion tries to read the version from a pack's manifest.
 //
 // Supports three --from layouts:
@@ -339,6 +362,18 @@ func InstallFromLocal(name, sourcePath string) error {
 		return err
 	}
 
+	// Detect bmad installer-output sibling layout. The upstream
+	// installer (npx bmad-method install --output-folder X) writes
+	// X/_bmad/ (pack content) AND X/.claude/ (IDE bindings) as siblings.
+	// Sideshow's on-disk pack format expects content at the pack root
+	// (no _bmad/ prefix) — so when the sibling layout is detected, strip
+	// the _bmad/ prefix during copy. .claude/ stays where it is.
+	stripPrefix := ""
+	if hasInstallerSiblingLayout(sourcePath) {
+		stripPrefix = "_bmad"
+		fmt.Println("Detected bmad installer-output layout; unifying _bmad/ + .claude/ into pack root.")
+	}
+
 	// Detect version
 	version := DetectVersion(sourcePath)
 	fmt.Printf("Installing %s %s from %s\n", name, version, sourcePath)
@@ -359,6 +394,20 @@ func InstallFromLocal(name, sourcePath string) error {
 		relPath, err := filepath.Rel(sourcePath, path)
 		if err != nil {
 			return err
+		}
+
+		// Apply installer-output unification: drop the bare _bmad
+		// directory itself (we recurse into its contents) and strip
+		// the _bmad/ prefix from anything inside it. Sibling .claude/
+		// passes through unchanged.
+		if stripPrefix != "" {
+			if relPath == stripPrefix {
+				return nil
+			}
+			sep := string(os.PathSeparator)
+			if strings.HasPrefix(relPath, stripPrefix+sep) {
+				relPath = strings.TrimPrefix(relPath, stripPrefix+sep)
+			}
 		}
 
 		destPath := filepath.Join(destDir, relPath)

--- a/internal/pack/pack_test.go
+++ b/internal/pack/pack_test.go
@@ -395,3 +395,157 @@ func TestInstallFromLocal_RejectsSourceTarballShape(t *testing.T) {
 		t.Fatalf("expected upstream-source-rejection in error, got: %v", err)
 	}
 }
+
+func TestHasInstallerSiblingLayout_Detects(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	// _bmad/_config/manifest.yaml + .claude/skills sibling
+	cfg := filepath.Join(dir, "_bmad", "_config")
+	if err := os.MkdirAll(cfg, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cfg, "manifest.yaml"), []byte("version: 6.5.0\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, ".claude", "skills"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if !hasInstallerSiblingLayout(dir) {
+		t.Errorf("hasInstallerSiblingLayout = false for canonical sibling layout")
+	}
+}
+
+func TestHasInstallerSiblingLayout_RequiresClaudeSibling(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	cfg := filepath.Join(dir, "_bmad", "_config")
+	if err := os.MkdirAll(cfg, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cfg, "manifest.yaml"), []byte("version: 6.5.0\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// No .claude sibling — the user pointed at a project root that doesn't have IDE bindings.
+	if hasInstallerSiblingLayout(dir) {
+		t.Errorf("hasInstallerSiblingLayout = true without .claude/ sibling")
+	}
+}
+
+func TestHasInstallerSiblingLayout_AlreadyUnified(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	// Pack has both _bmad/_config AND _config — already unified, don't strip.
+	if err := os.MkdirAll(filepath.Join(dir, "_bmad", "_config"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "_bmad", "_config", "manifest.yaml"), []byte("v"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "_config"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "_config", "manifest.yaml"), []byte("v"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, ".claude", "skills"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if hasInstallerSiblingLayout(dir) {
+		t.Errorf("hasInstallerSiblingLayout = true for already-unified pack (would re-strip)")
+	}
+}
+
+func TestInstallFromLocal_UnifiesInstallerSiblingLayout(t *testing.T) {
+	t.Setenv("SIDESHOW_HOME", t.TempDir())
+
+	source := t.TempDir()
+	// Build a realistic upstream installer output: _bmad/_config/manifest.yaml
+	// + _bmad/core/something + _bmad/bmm/dir + .claude/skills/bmad-help/SKILL.md
+	if err := os.MkdirAll(filepath.Join(source, "_bmad", "_config"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(source, "_bmad", "_config", "manifest.yaml"),
+		[]byte("installation:\n  version: 6.5.0\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(source, "_bmad", "core"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(source, "_bmad", "core", "config.yaml"),
+		[]byte("module: core\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(source, ".claude", "skills", "bmad-help"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(source, ".claude", "skills", "bmad-help", "SKILL.md"),
+		[]byte("# bmad-help\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := InstallFromLocal("bmad", source); err != nil {
+		t.Fatalf("InstallFromLocal: %v", err)
+	}
+
+	// Verify the installed pack has _bmad/ stripped: _config/manifest.yaml at root,
+	// core/config.yaml at root, .claude/skills/bmad-help/SKILL.md at root, and
+	// NO _bmad/ directory in the destination.
+	packRoot := filepath.Join(PacksDir(), "bmad", "6.5.0")
+
+	tests := []struct {
+		path  string
+		isDir bool
+		want  string
+	}{
+		{filepath.Join(packRoot, "_config", "manifest.yaml"), false, "installation:\n  version: 6.5.0\n"},
+		{filepath.Join(packRoot, "core", "config.yaml"), false, "module: core\n"},
+		{filepath.Join(packRoot, ".claude", "skills", "bmad-help", "SKILL.md"), false, "# bmad-help\n"},
+	}
+	for _, tc := range tests {
+		data, err := os.ReadFile(tc.path)
+		if err != nil {
+			t.Errorf("expected %s after unification: %v", tc.path, err)
+			continue
+		}
+		if string(data) != tc.want {
+			t.Errorf("%s content = %q, want %q", tc.path, data, tc.want)
+		}
+	}
+
+	// _bmad/ must not exist at the destination — the prefix was stripped.
+	if _, err := os.Stat(filepath.Join(packRoot, "_bmad")); !os.IsNotExist(err) {
+		t.Errorf("_bmad/ leaked into destination; stat err = %v", err)
+	}
+}
+
+func TestInstallFromLocal_AlreadyUnifiedPassesThrough(t *testing.T) {
+	t.Setenv("SIDESHOW_HOME", t.TempDir())
+
+	source := t.TempDir()
+	// Pack root with _config/ at top level (no _bmad/ prefix at all).
+	if err := os.MkdirAll(filepath.Join(source, "_config"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(source, "_config", "manifest.yaml"),
+		[]byte("installation:\n  version: 6.3.0\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(source, "core"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(source, "core", "config.yaml"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := InstallFromLocal("bmad", source); err != nil {
+		t.Fatalf("InstallFromLocal: %v", err)
+	}
+
+	packRoot := filepath.Join(PacksDir(), "bmad", "6.3.0")
+	if _, err := os.Stat(filepath.Join(packRoot, "_config", "manifest.yaml")); err != nil {
+		t.Errorf("expected _config/manifest.yaml: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(packRoot, "core", "config.yaml")); err != nil {
+		t.Errorf("expected core/config.yaml: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

The upstream bmad installer (`npx bmad-method install --output-folder X`) writes a sibling tree:

```
X/_bmad/      pack content (manifest, modules, workflows)
X/.claude/    IDE bindings (skills/<id>/SKILL.md)
```

Sideshow's on-disk pack format expects content at the pack root with no `_bmad/` prefix. Before this change, users had to manually unify the two trees before running `sideshow install --from X`. Now sideshow detects the sibling layout (`_bmad/_config/manifest.yaml` AND `.claude/` AND no top-level `_config/manifest.yaml`) and strips the `_bmad/` prefix during the copy. `.claude/` passes through unchanged.

## Behavior

```
$ sideshow install bmad --from /tmp/upstream-output --yes
Detected bmad installer-output layout; unifying _bmad/ + .claude/ into pack root.
Installing bmad 6.5.0 from /tmp/upstream-output
Installed 2 files to ~/.local/share/sideshow/packs/bmad/6.5.0
```

```
Input:  /tmp/upstream-output/_bmad/_config/manifest.yaml
        /tmp/upstream-output/.claude/skills/bmad-help/SKILL.md

Output: <packs>/bmad/6.5.0/_config/manifest.yaml
        <packs>/bmad/6.5.0/.claude/skills/bmad-help/SKILL.md
```

## Defensive: detect already-unified

If both `_bmad/_config/manifest.yaml` AND `_config/manifest.yaml` exist at the source (an already-unified pack — e.g. an existing sideshow install), the detection returns `false` and no stripping is applied. Re-running install on an already-unified source is a pass-through.

## Tests

5 new tests:
- `hasInstallerSiblingLayout` detects canonical sibling layout
- Requires `.claude/` sibling (returns false otherwise)
- Already-unified pack returns false (no double-strip)
- End-to-end install: sibling layout unifies correctly
- End-to-end install: already-unified pack passes through

`go test -race ./...` clean. `golangci-lint` clean. `gofmt` clean.

## Empirical verification

Synthesized fixture install matches expected output paths byte-for-byte. The pre-change manual recipe (per finding-025 / 2lma close note: "/tmp/bmad-6.3.0-pack manual assembly") is now `sideshow install bmad --from <output-folder>` directly.

## Test plan

- [x] `go test -race ./...`
- [x] `golangci-lint run ./...`
- [x] `gofmt -l .`
- [x] Manual: synthesized installer-output dir → installed pack has unified layout
- [x] Manual: already-unified pack → pass-through, no double-strip

Refs: aae-orc-d7xi