### PR TITLE
docs: customization-bridge boundary — _<pack>-custom/ ↔ _<pack>/custom/

### DIFF
--- a/charter.md
+++ b/charter.md
@@ -16,7 +16,13 @@ platform.
   global/OS-wide is not a goal).
 - **orc-declared** shape: `aae-orc/sideshow.toml` at orchestrator root
   declares which subrepos get which packs at which versions.
-- Per-repo customization via `_{pack}-custom/` (checked in).
+- Per-repo customization via `_{pack}-custom/` (checked in). For packs
+  that ship an upstream customization surface at `_{pack}/custom/`
+  (bmad 6.4+), sideshow renders a symlink
+  `_{pack}/custom/ → ../_{pack}-custom/` so upstream's runtime
+  resolver and authoring skills (`bmad-customize`) write into the
+  checked-in per-repo dir transparently. See
+  [`docs/customization-bridge.md`](docs/customization-bridge.md).
 - Per-repo output via `_{pack}-output/` (**checked in** — corrected
   session-029). Previously labeled "gitignored" which conflated
   scaffolding with deliverables. The dir holds agent-produced
@@ -41,8 +47,19 @@ orc `charter.md` F24 and `_kos/nodes/frontier/question-sideshow-install-architec
 
 - **6.3.0-first.** Sideshow support targets bmad 6.3.0 and forward.
   6.2.2 is legacy; we will not build new infrastructure against it.
-  Tracked by `aae-orc-2lma` (P1) — sideshow sync for the bmad 6.3.0
-  `.claude/skills/` distribution model.
+  `aae-orc-2lma` shipped session-029 (skill-dir bindings for the 6.3.0
+  `.claude/skills/` distribution); subsequent binding work for 6.4+
+  customization tracked under the bridge entry below.
+- **Customization bridge for upstream-defined `custom/` surfaces.**
+  bmad 6.4 introduced `_bmad/custom/` TOML customization. Sideshow
+  bridges this to its per-repo `_<pack>-custom/` convention via a
+  gitignored symlink `_bmad/custom/ → ../_bmad-custom/` created at
+  project init. Customization survives version switches (lives in
+  checked-in territory). Other packs without a `custom/` sub-
+  convention are unaffected. Tracked by `aae-orc-5g9m` (this
+  boundary doc) and `aae-orc-mkpo` (implementation). Required before
+  `aae-orc-10vq` overlay spec ships. See
+  [`docs/customization-bridge.md`](docs/customization-bridge.md).
 - **Shared pack store + alternatives-style escape.** One
   `~/.local/share/sideshow/packs/` store across orchestrators; when two
   orchestrators pin different versions, fall back to the alternatives

--- a/docs/consumer-repo-convention.md
+++ b/docs/consumer-repo-convention.md
@@ -26,14 +26,18 @@ repo.
 project-repo/                            PROJECT-SCOPE (per-repo)
 ├── _bmad-custom/                        ── CHECKED IN: overrides
 │   ├── agents/                          ──   project-specific agents
+│   ├── workflows/                       ──   per-workflow customize.toml
+│   ├── config.toml                      ──   pack-level customization
 │   └── memories/                        ──   project-specific context
 ├── _bmad-output/                        ── CHECKED IN: the project's deliverables
 │   ├── planning-artifacts/              ──   PRDs, stories, decisions
 │   └── implementation-artifacts/        ──   implementation docs
-├── _bmad/                               ── GITIGNORED: pack content
-│                                            (sideshow writes to user-scope; this
-│                                             only exists if upstream installer
-│                                             ran locally; do not commit)
+├── _bmad/                               ── GITIGNORED: sideshow scaffolding
+│   └── custom/  -> ../_bmad-custom/     ──   bridge symlink to checked-in dir
+│                                            (bmad-customize and the bmad runtime
+│                                             read/write through this symlink;
+│                                             pack content itself stays at
+│                                             user-scope)
 └── .claude/                             ── GITIGNORED: tool binding duplicates
     └── skills/bmad-*/                        (sideshow syncs user-scope; these
                                               are redundant if present)
@@ -45,7 +49,8 @@ project-repo/                            PROJECT-SCOPE (per-repo)
 |---|---|---|
 | `_<pack>-custom/`     | **Check in**  | Project-specific overrides. These ARE the project's choices. |
 | `_<pack>-output/`     | **Check in**  | Agent-produced deliverables (PRDs, stories, architecture, implementation docs). These ARE the project's output. |
-| `_<pack>/`            | **Gitignore** | Pack content lives at `~/.local/share/sideshow/packs/<pack>/<v>/`. If present in-project, it's stale from an upstream installer run — do not commit. |
+| `_<pack>/`            | **Gitignore** | Pack content lives at `~/.local/share/sideshow/packs/<pack>/<v>/`. If present in-project beyond the customization-bridge symlink, it's stale from an upstream installer run — do not commit. |
+| `_<pack>/custom/` (symlink) | **Gitignore** (the link itself; target is checked in) | Customization-bridge symlink → `../_<pack>-custom/`. Created at `sideshow project init` for packs that ship an upstream `custom/` sub-convention (bmad 6.4+). Lets upstream's `bmad-customize` skill and runtime resolver write to the checked-in per-repo dir. See [`customization-bridge.md`](customization-bridge.md). |
 | `.claude/commands/<pack>-*.md` | **Gitignore** | sideshow syncs to `~/.claude/commands/` at user-scope. Per-project duplicates conflict. |
 | `.claude/skills/<pack>-*/`     | **Gitignore** | sideshow syncs to `~/.claude/skills/` at user-scope. Per-project duplicates conflict. |
 | `sideshow.lock`       | **Check in**  | Pins the pack version the repo was last known to work against. See aae-orc-333y. |
@@ -143,4 +148,6 @@ the offline machine via rsync or similar.
 - `aae-orc-f6ei` — sideshow distributes the gitignore fragment (next).
 - `aae-orc-333y` — `sideshow.lock` for cross-user version pinning.
 - `aae-orc-d9a3` — stale-binding cleanup on pack version transition.
+- `aae-orc-5g9m` — `customization-bridge.md` (this doc's companion).
+- `aae-orc-mkpo` — bridge symlink implementation.
 - sideshow/charter.md — canonical design shapes.

--- a/docs/customization-bridge.md
+++ b/docs/customization-bridge.md
@@ -1,0 +1,169 @@
+# Customization Bridge — `_<pack>-custom/` ↔ upstream `_<pack>/custom/`
+
+**Status:** committed direction (boundary doc). Implementation tracked
+in `aae-orc-mkpo`. Charter overlay-spec work (`aae-orc-10vq`) depends
+on this resolution.
+
+## The collision
+
+Two concepts that were once orthogonal now share a name:
+
+| Convention | Owner | Purpose | Persistence |
+|---|---|---|---|
+| `_<pack>-custom/` | sideshow | Per-repo overlay over the user-scope pack content. Sideshow's original convention from session-029. | **Checked in** to the consumer repo. |
+| `_<pack>/custom/` | upstream pack runtime | Pack-internal customization layer (TOML configs, agent overrides, workflow tweaks) the runtime resolver merges with pack defaults. | Implicitly lives next to pack content. |
+
+Concrete instance: bmad 6.4.0 introduced TOML-based agent and workflow
+customization with a four-file architecture rooted at `_bmad/custom/`
+plus a `bmad-customize` skill that authors files there interactively.
+Before 6.4 there was no upstream customization surface; sideshow's
+`_<pack>-custom/` was the only customization concept and there was no
+collision.
+
+## Why this matters
+
+If sideshow does nothing:
+
+1. A user runs `/bmad-customize` to override an agent. The skill writes
+   to `_bmad/custom/agents/...toml`.
+2. `_bmad/` is **gitignored** at the project root (per
+   `consumer-repo-convention.md`) — the customization either lands in
+   gitignored space (lost on commit) or in `~/.local/share/sideshow/`
+   (globally polluting every consumer of that pack version).
+3. On `sideshow install bmad@<next-version>`, the user-scope pack
+   directory is replaced. Customization vanishes silently.
+
+In all three cases the user ends up surprised. The customization is
+either lost, scoped wrong, or non-portable across machines.
+
+## The bridge
+
+At `sideshow project init <pack>` (or equivalent) time, sideshow
+creates a sentinel-tracked symlink in the consumer repo:
+
+```
+<project>/_bmad/custom/  →  ../_bmad-custom/
+```
+
+Effects:
+
+- `_bmad/` exists at the project root as a directory containing **only
+  sideshow-managed symlinks** (today: just `custom/`). It is still
+  gitignored.
+- `_bmad-custom/` is **checked in**, unchanged from the existing
+  convention.
+- Upstream's `bmad-customize` skill writes to `_bmad/custom/...toml`,
+  which the symlink resolves to `_bmad-custom/...toml`. The actual
+  bytes live in checked-in territory.
+- `bmad`'s runtime resolver (which expects to read from
+  `_bmad/custom/`) gets exactly what it expects. No bmad code change.
+- `sideshow install bmad@<next-version>` swaps the user-scope pack
+  content but does NOT touch the symlink or the `_bmad-custom/` tree.
+  Customization survives version transitions for free.
+
+## Why `_<pack>-custom/` keeps its name
+
+Sideshow's `_<pack>-custom/` convention is **broader** than upstream's
+`_<pack>/custom/`. Sideshow customization may include:
+
+- Files that don't fit upstream's TOML schema (per-project README
+  fragments, decision-record templates, prompt overrides).
+- Customization for packs that have **no upstream customization
+  surface at all** (e.g. spectacle, future packs).
+- Sideshow-managed scaffolding the upstream pack doesn't know exists.
+
+The bridge applies *only* where an upstream pack defines a `custom/`
+sub-convention. Other packs use `_<pack>-custom/` exactly as before,
+with no symlink, no bridge, no collision.
+
+## Boundary table
+
+| Path | Owner | Persistence | Bridge applies? |
+|---|---|---|---|
+| `_<pack>-custom/` (project root) | sideshow + user | checked in | source of truth |
+| `_<pack>/custom/` (project root, symlink) | sideshow scaffolding | gitignored symlink → `../_<pack>-custom/` | applies for packs with a custom sub-convention (bmad 6.4+) |
+| `_<pack>/` (project root, beyond the `custom/` symlink) | nobody — should not exist | gitignored | n/a |
+| `~/.local/share/sideshow/packs/<pack>/<v>/custom/` | nobody — pack content is immutable | should be empty in installed packs | n/a |
+| `~/.local/share/sideshow/packs/<pack>/<v>/` | sideshow (immutable) | user-scope, version-isolated | n/a |
+
+## Implementation notes (for `aae-orc-mkpo`)
+
+1. **Detection.** A pack opts into the bridge by declaring it in
+   `pack.yaml`:
+
+   ```yaml
+   schema_version: 1
+   name: bmad
+   distribute:
+     custom_bridge:
+       upstream_path: _bmad/custom
+       per_repo_dir: _bmad-custom
+   ```
+
+   No `custom_bridge` declaration → no bridge created. Backward
+   compatible with packs that don't ship a custom sub-convention.
+
+2. **Install action (`sideshow project init <pack>` /
+   `--scope project`):**
+   - Create `<project>/_bmad/` if absent (gitignored shim dir).
+   - Create `<project>/_bmad-custom/` if absent (checked in).
+   - Create symlink `<project>/_bmad/custom/ → ../_bmad-custom/` if
+     absent. If a regular file or non-matching symlink exists at
+     that path, refuse and report (per the per-repo overlay safety
+     model).
+   - Append `_bmad/` to `.gitignore` (idempotent, marker-bracketed).
+
+3. **Doctor check.** `sideshow doctor` (`aae-orc-xteh`) verifies the
+   symlink exists and points to the right target. `--fix` recreates
+   if missing.
+
+4. **Removal.** `sideshow project remove <pack>` removes the symlink
+   but leaves `_<pack>-custom/` (it's the user's data) and the
+   gitignore marker (let the user clean up explicitly).
+
+5. **Cross-platform.** Symlinks work on macOS, Linux, and modern
+   Windows (Developer Mode or admin). For Windows-without-symlink
+   environments, fall back to a directory-junction or — last resort —
+   a one-shot `bmad-customize` interceptor that rewrites paths.
+   Decide when a Windows user reports the problem; YAGNI today.
+
+## Why a symlink and not a write-through interceptor
+
+Considered: have sideshow intercept writes to `_bmad/custom/...` and
+redirect to `_<pack>-custom/`. Rejected because:
+
+- Sideshow would need to be a runtime presence, not a one-shot CLI.
+- bmad's writer is upstream code; intercepting its writes is fragile.
+- Symlink is OS-native, transparent to upstream, and free.
+
+The symlink approach also matches the existing per-repo overlay model
+(symlink-or-copy is already a sideshow primitive in
+`internal/distribute/`).
+
+## Why the bridge isn't bedrock yet
+
+This doc is committed direction, not bedrock, because:
+
+1. `aae-orc-mkpo` (the implementation issue) hasn't shipped.
+2. We have no empirical evidence that the symlink works under bmad's
+   actual 6.4 customization workflow — finding-035 only documented the
+   collision, not a fix attempt.
+3. Windows behavior is unverified (see implementation note 5).
+
+Promotion path: ship `aae-orc-mkpo`, run `bmad-customize` end-to-end
+on a sideshow-managed bmad@6.4+ install, validate the customization
+survives a version switch (`sideshow install bmad@<next>`), then
+graduate this doc's content into charter bedrock.
+
+## Related
+
+- orc charter F24 — sideshow install + audit infrastructure.
+- `aae-orc-5g9m` — this doc.
+- `aae-orc-mkpo` — implementation.
+- `aae-orc-10vq` — overlay artifact spec (depends on this boundary).
+- `_kos/findings/finding-035-bmad-65-sideshow-readiness.md` — where
+  the collision was first observed.
+- bmad 6.4.0 release notes — TOML customization framework, four-file
+  architecture, `bmad-customize` skill (#2284, #2285, #2287, #2289).
+- `docs/consumer-repo-convention.md` — the broader per-repo
+  convention this bridge plugs into.


### PR DESCRIPTION
## Summary

bmad 6.4.0 introduced TOML-based customization at `_bmad/custom/` with a four-file architecture and `bmad-customize` skill. That collides conceptually with sideshow's `_<pack>-custom/` per-repo overlay convention from session-029. This PR documents the boundary and the bridge that resolves the collision.

The bridge: at `sideshow project init <pack>` time, sideshow creates a gitignored symlink

```
<project>/_bmad/custom/  →  ../_bmad-custom/
```

Effects:
- Upstream's `bmad-customize` and runtime resolver write to `_bmad/custom/...toml` exactly as designed
- The actual bytes land in checked-in `_bmad-custom/...toml`
- Customization survives version switches (lives outside the user-scope pack store)
- No bmad code change required
- Other packs without a `custom/` sub-convention are unaffected

## Files

- **New:** `docs/customization-bridge.md` — full design rationale, boundary table, implementation notes for `aae-orc-mkpo`, promotion path to bedrock.
- **Updated:** `charter.md` — bedrock entry for `_<pack>-custom/` mentions the bridge; frontier section: `aae-orc-2lma` marked shipped (closed session-029), customization-bridge entry replaces it as the active pre-overlay-spec gate.
- **Updated:** `docs/consumer-repo-convention.md` — gitignored `_<pack>/custom/` symlink row added to the table; layout diagram shows the bridge.

## Implementation status

This is the boundary doc only (`aae-orc-5g9m`). Symlink implementation tracked in `aae-orc-mkpo` (P2, blocked on this PR landing). Overlay artifact spec (`aae-orc-10vq`) depends on the bridge being settled.

## Why a symlink and not a write-through interceptor

Considered: have sideshow intercept writes and redirect. Rejected because sideshow would need to be a runtime presence (not a one-shot CLI), bmad's writer is upstream code (intercepting is fragile), and symlinks are OS-native and free. The symlink approach also matches sideshow's existing per-repo overlay primitive in `internal/distribute/`.

## Why the bridge isn't bedrock yet

Doc is committed direction, not bedrock — `aae-orc-mkpo` hasn't shipped, no end-to-end validation against bmad's real 6.4 customization workflow, Windows-without-symlink behavior unverified. Promotion path: ship mkpo, run `bmad-customize` end-to-end, validate version-switch survival, then graduate.

## Test plan

Doc-only PR, no code. Reviewers should:

- [x] Confirm `customization-bridge.md` reads cleanly without prior context
- [x] Confirm boundary table matches the existing `consumer-repo-convention.md` model
- [x] Confirm charter delta accurately reflects shipped vs frontier state
- [x] Confirm the symlink shape resolves the collision finding-035 documented
- [ ] Reviewers: any objection to the symlink approach over a write-through interceptor or two-separate-dirs-with-no-bridge?

Refs: aae-orc-5g9m, finding-035, bmad 6.4.0 release notes