### PR TITLE
feat(distribute): custom_bridge artifact — per-repo customization bridge (aae-orc-mkpo)

### DIFF
--- a/docs/customization-bridge.md
+++ b/docs/customization-bridge.md
@@ -1,8 +1,13 @@
 # Customization Bridge — `_<pack>-custom/` ↔ upstream `_<pack>/custom/`
 
-**Status:** committed direction (boundary doc). Implementation tracked
-in `aae-orc-mkpo`. Charter overlay-spec work (`aae-orc-10vq`) depends
-on this resolution.
+**Status:** implemented (consumer side) — `custom_bridge` declaration in
+pack.yaml's `distribute` section, applied by `sideshow init --scope
+project` via `internal/distribute`. Producer side emits the declaration
+in sideshow-packs `build-bmad.sh`. End-to-end validation against a real
+bmad 6.4+ install (bmad-customize round-trip + version-switch survival)
+still pending before bedrock promotion — see "Why the bridge isn't
+bedrock yet" below. `aae-orc-mkpo`. Charter overlay-spec work
+(`aae-orc-10vq`) depends on this resolution.
 
 ## The collision
 

--- a/internal/distribute/distribute.go
+++ b/internal/distribute/distribute.go
@@ -91,6 +91,11 @@ func ToRepo(repo project.Subrepo, manifest *Manifest, opts Options) Result {
 		result.Actions = append(result.Actions, action)
 	}
 
+	if manifest.CustomBridge != nil {
+		actions := distributeCustomBridge(repo.AbsPath, *manifest.CustomBridge, opts)
+		result.Actions = append(result.Actions, actions...)
+	}
+
 	for _, line := range manifest.Gitignore {
 		action := distributeGitignore(repo.AbsPath, line, opts)
 		result.Actions = append(result.Actions, action)
@@ -522,6 +527,83 @@ func distributeSymlink(repoRoot string, link SymlinkArtifact, opts Options) Acti
 		Target: link.Target,
 	}
 	return action
+}
+
+// distributeCustomBridge wires the per-repo customization bridge:
+// a checked-in customization dir (per_repo_dir) reachable through a
+// symlink at upstream_path inside the gitignored pack shim dir, so
+// upstream customization tooling (e.g. bmad-customize) writes into
+// tracked territory that survives pack version switches.
+// See docs/customization-bridge.md.
+//
+// Safety: never touches existing customization content; symlink
+// conflicts (regular file, wrong target) are reported not repaired.
+func distributeCustomBridge(repoRoot string, bridge CustomBridgeArtifact, opts Options) []Action {
+	upstream := filepath.Clean(bridge.UpstreamPath)
+	perRepo := filepath.Clean(bridge.PerRepoDir)
+	shimDir := filepath.Dir(upstream)
+
+	if filepath.IsAbs(upstream) || filepath.IsAbs(perRepo) ||
+		strings.HasPrefix(upstream, "..") || strings.HasPrefix(perRepo, "..") ||
+		upstream == "." || perRepo == "." || shimDir == "." {
+		return []Action{{
+			Type:   "custom_bridge",
+			Path:   bridge.UpstreamPath,
+			Status: "error",
+			Detail: "invalid custom_bridge paths: upstream_path and per_repo_dir must be relative, inside the repo, and upstream_path must have a parent shim dir",
+		}}
+	}
+
+	relTarget, err := filepath.Rel(shimDir, perRepo)
+	if err != nil {
+		return []Action{{
+			Type:   "custom_bridge",
+			Path:   bridge.UpstreamPath,
+			Status: "error",
+			Detail: fmt.Sprintf("resolve symlink target: %v", err),
+		}}
+	}
+
+	var actions []Action
+
+	// 1. Per-repo customization dir (checked in). Create with .gitkeep
+	// if absent; existing content is the user's data — never touched.
+	perRepoAbs := filepath.Join(repoRoot, perRepo)
+	dirAction := Action{Type: "custom_bridge", Path: perRepo + "/"}
+	if _, statErr := os.Stat(perRepoAbs); statErr == nil {
+		dirAction.Status = "skipped"
+		dirAction.Detail = "per-repo customization dir already exists (left untouched)"
+	} else if !os.IsNotExist(statErr) {
+		dirAction.Status = "error"
+		dirAction.Detail = fmt.Sprintf("stat %s: %v", perRepo, statErr)
+	} else if opts.DryRun {
+		dirAction.Status = "wrote"
+		dirAction.Detail = "would create per-repo customization dir (+ .gitkeep)"
+	} else if mkErr := os.MkdirAll(perRepoAbs, 0o755); mkErr != nil {
+		dirAction.Status = "error"
+		dirAction.Detail = fmt.Sprintf("create dir: %v", mkErr)
+	} else if wErr := os.WriteFile(filepath.Join(perRepoAbs, ".gitkeep"), nil, 0o644); wErr != nil {
+		dirAction.Status = "error"
+		dirAction.Detail = fmt.Sprintf("write .gitkeep: %v", wErr)
+	} else {
+		dirAction.Status = "wrote"
+		dirAction.Detail = "created per-repo customization dir (+ .gitkeep)"
+	}
+	actions = append(actions, dirAction)
+
+	// 2. Bridge symlink (creates the shim dir as its parent). Reuses the
+	// symlink primitive's conflict semantics: wrong target or regular
+	// file at the path is reported, never replaced.
+	actions = append(actions, distributeSymlink(repoRoot, SymlinkArtifact{
+		Path:   upstream,
+		Target: relTarget,
+	}, opts))
+
+	// 3. Gitignore the shim dir. Idempotent append; packs that already
+	// declare the same line in distribute.gitignore dedupe here.
+	actions = append(actions, distributeGitignore(repoRoot, "/"+shimDir+"/", opts))
+
+	return actions
 }
 
 // distributeGitignore appends a line to .gitignore if missing.

--- a/internal/distribute/distribute_test.go
+++ b/internal/distribute/distribute_test.go
@@ -624,3 +624,193 @@ func TestManifest_IsEmpty(t *testing.T) {
 		t.Error("manifest with rules should not be empty")
 	}
 }
+
+// --- Custom bridge tests ---
+
+func bmadBridge() CustomBridgeArtifact {
+	return CustomBridgeArtifact{
+		UpstreamPath: "_bmad/custom",
+		PerRepoDir:   "_bmad-custom",
+	}
+}
+
+func TestCustomBridge_FreshRepo(t *testing.T) {
+	t.Parallel()
+	repoRoot := t.TempDir()
+
+	actions := distributeCustomBridge(repoRoot, bmadBridge(), defaultOpts(t.TempDir()))
+	if len(actions) != 3 {
+		t.Fatalf("actions = %d, want 3", len(actions))
+	}
+	for _, a := range actions {
+		if a.Status != "wrote" {
+			t.Errorf("action %s/%s status = %q (%s), want wrote", a.Type, a.Path, a.Status, a.Detail)
+		}
+	}
+
+	// Per-repo dir exists with .gitkeep
+	if _, err := os.Stat(filepath.Join(repoRoot, "_bmad-custom", ".gitkeep")); err != nil {
+		t.Errorf("_bmad-custom/.gitkeep missing: %v", err)
+	}
+
+	// Symlink resolves: a write through _bmad/custom/ lands in _bmad-custom/
+	throughLink := filepath.Join(repoRoot, "_bmad", "custom", "agents.toml")
+	if err := os.WriteFile(throughLink, []byte("x = 1\n"), 0o644); err != nil {
+		t.Fatalf("write through bridge symlink: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(repoRoot, "_bmad-custom", "agents.toml")); err != nil {
+		t.Errorf("write through symlink did not land in _bmad-custom: %v", err)
+	}
+
+	// Gitignore carries the shim dir
+	gi, err := os.ReadFile(filepath.Join(repoRoot, ".gitignore"))
+	if err != nil {
+		t.Fatalf("read .gitignore: %v", err)
+	}
+	if !strings.Contains(string(gi), "/_bmad/") {
+		t.Errorf(".gitignore missing /_bmad/ line, got %q", string(gi))
+	}
+}
+
+func TestCustomBridge_Idempotent(t *testing.T) {
+	t.Parallel()
+	repoRoot := t.TempDir()
+	opts := defaultOpts(t.TempDir())
+
+	distributeCustomBridge(repoRoot, bmadBridge(), opts)
+	second := distributeCustomBridge(repoRoot, bmadBridge(), opts)
+
+	for _, a := range second {
+		if a.Status != "skipped" {
+			t.Errorf("second run action %s/%s status = %q (%s), want skipped", a.Type, a.Path, a.Status, a.Detail)
+		}
+	}
+}
+
+func TestCustomBridge_PreservesExistingCustomization(t *testing.T) {
+	t.Parallel()
+	repoRoot := t.TempDir()
+
+	// Pre-existing customization content
+	customDir := filepath.Join(repoRoot, "_bmad-custom")
+	if err := os.MkdirAll(customDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(customDir, "agents.toml"), []byte("keep = true\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	actions := distributeCustomBridge(repoRoot, bmadBridge(), defaultOpts(t.TempDir()))
+	if actions[0].Status != "skipped" {
+		t.Errorf("per-repo dir action status = %q, want skipped", actions[0].Status)
+	}
+
+	data, err := os.ReadFile(filepath.Join(customDir, "agents.toml"))
+	if err != nil || string(data) != "keep = true\n" {
+		t.Errorf("existing customization modified: %q, %v", string(data), err)
+	}
+	if _, err := os.Stat(filepath.Join(customDir, ".gitkeep")); !os.IsNotExist(err) {
+		t.Error(".gitkeep should not be added to a pre-existing customization dir")
+	}
+}
+
+func TestCustomBridge_ConflictAtSymlinkPath(t *testing.T) {
+	t.Parallel()
+	repoRoot := t.TempDir()
+
+	// A real directory occupies the bridge path (e.g. upstream installer
+	// materialized _bmad/custom/ before sideshow ran).
+	if err := os.MkdirAll(filepath.Join(repoRoot, "_bmad", "custom"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	actions := distributeCustomBridge(repoRoot, bmadBridge(), defaultOpts(t.TempDir()))
+	var symlinkAction *Action
+	for i := range actions {
+		if actions[i].Type == "symlink" {
+			symlinkAction = &actions[i]
+		}
+	}
+	if symlinkAction == nil {
+		t.Fatal("no symlink action emitted")
+	}
+	if symlinkAction.Status != "conflict" {
+		t.Errorf("symlink action status = %q (%s), want conflict", symlinkAction.Status, symlinkAction.Detail)
+	}
+}
+
+func TestCustomBridge_DryRun(t *testing.T) {
+	t.Parallel()
+	repoRoot := t.TempDir()
+	opts := defaultOpts(t.TempDir())
+	opts.DryRun = true
+
+	actions := distributeCustomBridge(repoRoot, bmadBridge(), opts)
+	for _, a := range actions {
+		if a.Status != "wrote" {
+			t.Errorf("dry-run action %s/%s status = %q, want wrote", a.Type, a.Path, a.Status)
+		}
+	}
+
+	// Nothing on disk
+	for _, p := range []string{"_bmad", "_bmad-custom", ".gitignore"} {
+		if _, err := os.Stat(filepath.Join(repoRoot, p)); !os.IsNotExist(err) {
+			t.Errorf("dry-run created %s", p)
+		}
+	}
+}
+
+func TestCustomBridge_InvalidPaths(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		bridge CustomBridgeArtifact
+	}{
+		{"absolute upstream", CustomBridgeArtifact{UpstreamPath: "/etc/bmad/custom", PerRepoDir: "_bmad-custom"}},
+		{"absolute per-repo", CustomBridgeArtifact{UpstreamPath: "_bmad/custom", PerRepoDir: "/tmp/custom"}},
+		{"escaping upstream", CustomBridgeArtifact{UpstreamPath: "../outside/custom", PerRepoDir: "_bmad-custom"}},
+		{"escaping per-repo", CustomBridgeArtifact{UpstreamPath: "_bmad/custom", PerRepoDir: "../outside"}},
+		{"no shim parent", CustomBridgeArtifact{UpstreamPath: "custom", PerRepoDir: "_bmad-custom"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			repoRoot := t.TempDir()
+			actions := distributeCustomBridge(repoRoot, tc.bridge, defaultOpts(t.TempDir()))
+			if len(actions) != 1 || actions[0].Status != "error" {
+				t.Errorf("actions = %+v, want single error action", actions)
+			}
+		})
+	}
+}
+
+func TestLoadPackYAML_CustomBridge(t *testing.T) {
+	t.Parallel()
+	packRoot := t.TempDir()
+	yaml := `name: bmad
+version: 6.4.0
+distribute:
+  custom_bridge:
+    upstream_path: _bmad/custom
+    per_repo_dir: _bmad-custom
+`
+	if err := os.WriteFile(filepath.Join(packRoot, "pack.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	p, err := LoadPackYAML(packRoot)
+	if err != nil {
+		t.Fatalf("LoadPackYAML: %v", err)
+	}
+	if p.Distribute.CustomBridge == nil {
+		t.Fatal("CustomBridge not parsed")
+	}
+	if p.Distribute.CustomBridge.UpstreamPath != "_bmad/custom" ||
+		p.Distribute.CustomBridge.PerRepoDir != "_bmad-custom" {
+		t.Errorf("CustomBridge = %+v", *p.Distribute.CustomBridge)
+	}
+	if p.Distribute.IsEmpty() {
+		t.Error("manifest with custom_bridge should not be IsEmpty")
+	}
+}

--- a/internal/distribute/manifest.go
+++ b/internal/distribute/manifest.go
@@ -17,11 +17,24 @@ import (
 
 // Manifest is the distribute section of a pack.yaml.
 type Manifest struct {
-	Rules     []RuleArtifact     `yaml:"rules,omitempty"`
-	Hooks     []HookArtifact     `yaml:"hooks,omitempty"`
-	ClaudeMD  []ClaudeMDArtifact `yaml:"claude_md,omitempty"`
-	Symlinks  []SymlinkArtifact  `yaml:"symlinks,omitempty"`
-	Gitignore []string           `yaml:"gitignore,omitempty"`
+	Rules        []RuleArtifact        `yaml:"rules,omitempty"`
+	Hooks        []HookArtifact        `yaml:"hooks,omitempty"`
+	ClaudeMD     []ClaudeMDArtifact    `yaml:"claude_md,omitempty"`
+	Symlinks     []SymlinkArtifact     `yaml:"symlinks,omitempty"`
+	Gitignore    []string              `yaml:"gitignore,omitempty"`
+	CustomBridge *CustomBridgeArtifact `yaml:"custom_bridge,omitempty"`
+}
+
+// CustomBridgeArtifact declares the customization bridge for packs whose
+// upstream runtime reads a custom/ sub-directory inside the gitignored
+// pack shim dir (e.g. bmad 6.4+ reads _bmad/custom/). The bridge symlinks
+// that path into the checked-in per-repo customization dir so upstream
+// customization writes land in tracked territory and survive pack version
+// switches. Packs without a custom_bridge declaration get no bridge.
+// See docs/customization-bridge.md.
+type CustomBridgeArtifact struct {
+	UpstreamPath string `yaml:"upstream_path"` // e.g. _bmad/custom (relative to repo root)
+	PerRepoDir   string `yaml:"per_repo_dir"`  // e.g. _bmad-custom (relative to repo root)
 }
 
 // RuleArtifact is a file to copy into .claude/rules/.
@@ -79,5 +92,6 @@ func (m *Manifest) IsEmpty() bool {
 		len(m.Hooks) == 0 &&
 		len(m.ClaudeMD) == 0 &&
 		len(m.Symlinks) == 0 &&
-		len(m.Gitignore) == 0
+		len(m.Gitignore) == 0 &&
+		m.CustomBridge == nil
 }


### PR DESCRIPTION
Implements the customization bridge from docs/customization-bridge.md (boundary doc, aae-orc-5g9m).

## What

Packs declare an opt-in bridge in pack.yaml:

```yaml
distribute:
  custom_bridge:
    upstream_path: _bmad/custom
    per_repo_dir: _bmad-custom
```

`sideshow init --scope project` then:
1. Creates the checked-in `_bmad-custom/` dir (+ .gitkeep when fresh; existing content never touched)
2. Symlinks `_bmad/custom -> ../_bmad-custom` (reuses the symlink primitive's refuse-on-conflict semantics)
3. Appends `/_bmad/` to .gitignore (idempotent)

## Why

bmad 6.4.0 introduced `_bmad/custom/` TOML customization written by the bmad-customize skill. Without the bridge that customization lands in gitignored or user-scope territory and silently vanishes on pack version switches (finding-035).

## Design

Declaration-driven, not version-sniffed: packs without `custom_bridge` get no bridge, so pre-6.4 and 6.4+ packs coexist under one code path. Version-awareness lives in one place — the sideshow-packs build script, which now emits the declaration (companion commit in that repo).

## Deferred

- Doctor check (rides aae-orc-xteh)
- `project remove` (command doesn't exist yet)
- Windows fallback (YAGNI per boundary doc)
- Bedrock promotion gates on end-to-end validation vs a live bmad 6.4+ install (next step in the packaging-ladder session)

7 new tests; `ax test/lint/build` green.

Refs: aae-orc-mkpo