### PR TITLE
feat: activation honesty — sync reconciliation, use command, --no-activate, multi-version list, bridge seeding

### DIFF
--- a/cmd/sideshow/main.go
+++ b/cmd/sideshow/main.go
@@ -32,7 +32,8 @@ Usage:
                                           Create config shim for BMAD agents
   sideshow init --scope project [--manifest <path>] [--pack <name>] [--dry-run]
                                           Distribute pack artifacts to subrepos
-  sideshow list                           List installed packs
+  sideshow use <pack> <version>           Activate an installed version + sync bindings
+  sideshow list                           List installed packs (all versions, active marked)
   sideshow commands sync                  Sync commands to ~/.claude/commands/
   sideshow status                         Show installation status
   sideshow version                        Show version
@@ -40,6 +41,8 @@ Usage:
 Install options:
   --from <path>          Source directory (required for now)
   --yes, -y              Skip confirmation prompts
+  --no-activate          Install without flipping the active version
+                         (first install of a pack always activates)
   --no-permissions       Don't configure Claude Code read permissions
   --scope user|project   Where to add permissions (default: user)
 
@@ -75,6 +78,8 @@ func main() {
 		err = runInit(os.Args[2:])
 	case "install":
 		err = runInstall(os.Args[2:])
+	case "use":
+		err = runUse(os.Args[2:])
 	case "list":
 		err = runList()
 	case "commands":
@@ -393,6 +398,7 @@ func runInstall(args []string) error {
 	var fromPath string
 	autoYes := false
 	noPerms := false
+	noActivate := false
 	scope := permissions.ScopeUser
 	scopeExplicit := false
 
@@ -405,6 +411,8 @@ func runInstall(args []string) error {
 			}
 		case "--yes", "-y":
 			autoYes = true
+		case "--no-activate":
+			noActivate = true
 		case "--no-permissions":
 			noPerms = true
 		case "--scope":
@@ -427,7 +435,7 @@ func runInstall(args []string) error {
 		return fmt.Errorf("--from <path> is required (git install not yet implemented)")
 	}
 
-	if err := pack.InstallFromLocal(name, fromPath); err != nil {
+	if err := pack.InstallFromLocal(name, fromPath, !noActivate); err != nil {
 		return err
 	}
 
@@ -470,6 +478,23 @@ func runInstall(args []string) error {
 	return nil
 }
 
+// runUse activates an installed pack version and re-syncs bindings so
+// the flip is honest end-to-end (stale artifacts from the previously
+// active version are reconciled away by the sync manifest).
+func runUse(args []string) error {
+	if len(args) < 2 {
+		return fmt.Errorf("usage: sideshow use <pack> <version>")
+	}
+	name, version := args[0], args[1]
+
+	if err := pack.Activate(name, version); err != nil {
+		return err
+	}
+	fmt.Printf("Activated %s %s\n", name, version)
+
+	return bindings.Sync()
+}
+
 func runList() error {
 	packs, err := pack.List()
 	if err != nil {
@@ -481,9 +506,22 @@ func runList() error {
 		return nil
 	}
 
-	fmt.Printf("%-20s %-15s %s\n", "PACK", "VERSION", "PATH")
+	fmt.Printf("%-20s %-15s %-7s %s\n", "PACK", "VERSION", "ACTIVE", "PATH")
 	for _, p := range packs {
-		fmt.Printf("%-20s %-15s %s\n", p.Name, p.Version, p.Path)
+		versions, active, vErr := pack.InstalledVersions(p.Name)
+		if vErr != nil || len(versions) == 0 {
+			// Fall back to the registry's single-version view.
+			fmt.Printf("%-20s %-15s %-7s %s\n", p.Name, p.Version, "*", p.Path)
+			continue
+		}
+		for _, v := range versions {
+			mark := ""
+			if v == active {
+				mark = "*"
+			}
+			fmt.Printf("%-20s %-15s %-7s %s\n", p.Name, v, mark,
+				filepath.Join(pack.PacksDir(), p.Name, v))
+		}
 	}
 	return nil
 }

--- a/internal/bindings/bindings.go
+++ b/internal/bindings/bindings.go
@@ -31,6 +31,11 @@ type Binding interface {
 	// Returns the number of artifacts written.
 	Sync() (int, error)
 
+	// Artifacts returns the destination paths this binding owns — the
+	// exact set Sync writes. Used for the sync-manifest ownership ledger
+	// so stale artifacts from a previously active version are removed.
+	Artifacts() ([]string, error)
+
 	// Validate checks the binding is internally consistent.
 	Validate() error
 }
@@ -70,26 +75,60 @@ func Sync() error {
 		return nil
 	}
 
-	totalSynced := 0
+	var all []Binding
 	for _, p := range packs {
-		bindings, err := DiscoverBindings(p)
+		discovered, err := DiscoverBindings(p)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "warning: discover %s: %v\n", p.Name, err)
 			continue
 		}
+		all = append(all, discovered...)
+	}
 
-		for _, b := range bindings {
-			n, err := b.Sync()
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "warning: sync %s/%s: %v\n", p.Name, b.Kind(), err)
-				continue
-			}
-			totalSynced += n
-		}
+	totalSynced, removed, err := runSync(all)
+	if err != nil {
+		return err
 	}
 
 	fmt.Printf("Synced %d artifacts across all bindings\n", totalSynced)
+	if removed > 0 {
+		fmt.Printf("Removed %d stale artifact(s) from a previously active version\n", removed)
+	}
 	return nil
+}
+
+// runSync syncs every binding, then reconciles the sync manifest:
+// artifacts recorded by the previous sync but owned by no current
+// binding are removed (the stale-binding chimera fix — an activation
+// flip no longer leaves the old version's extra skills behind).
+func runSync(all []Binding) (synced, removed int, err error) {
+	var current []ManifestEntry
+
+	for _, b := range all {
+		n, syncErr := b.Sync()
+		if syncErr != nil {
+			fmt.Fprintf(os.Stderr, "warning: sync %s/%s: %v\n", b.PackName(), b.Kind(), syncErr)
+			continue
+		}
+		synced += n
+
+		arts, artErr := b.Artifacts()
+		if artErr != nil {
+			fmt.Fprintf(os.Stderr, "warning: enumerate %s/%s artifacts: %v\n", b.PackName(), b.Kind(), artErr)
+			continue
+		}
+		for _, a := range arts {
+			current = append(current, ManifestEntry{
+				Pack:    b.PackName(),
+				Version: b.PackVersion(),
+				Kind:    b.Kind(),
+				Path:    a,
+			})
+		}
+	}
+
+	removed, err = reconcile(current)
+	return synced, removed, err
 }
 
 // CountForPack returns the total discoverable artifacts across all bindings

--- a/internal/bindings/manifest.go
+++ b/internal/bindings/manifest.go
@@ -1,0 +1,132 @@
+package bindings
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/ArcavenAE/sideshow/internal/pack"
+	"gopkg.in/yaml.v3"
+)
+
+// SyncManifest records what the last `commands sync` wrote, per artifact.
+// It is the ownership ledger that makes activation flips honest: on the
+// next sync, artifacts recorded here but no longer shipped by any active
+// pack version are removed instead of lingering as stale mixed-version
+// bindings.
+type SyncManifest struct {
+	SchemaVersion string          `yaml:"schema_version"`
+	SyncedAt      string          `yaml:"synced_at"`
+	Entries       []ManifestEntry `yaml:"entries"`
+}
+
+// ManifestEntry is one synced artifact: the destination path plus the
+// pack@version and binding kind that produced it.
+type ManifestEntry struct {
+	Pack    string `yaml:"pack"`
+	Version string `yaml:"version"`
+	Kind    string `yaml:"kind"`
+	Path    string `yaml:"path"`
+}
+
+// manifestPath returns the sync-manifest location inside the sideshow
+// data dir (sibling of packs/).
+func manifestPath() string {
+	return filepath.Join(filepath.Dir(pack.PacksDir()), "sync-manifest.yaml")
+}
+
+// loadManifest reads the previous sync manifest. A missing file returns
+// an empty manifest, not an error.
+func loadManifest() (*SyncManifest, error) {
+	data, err := os.ReadFile(manifestPath())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &SyncManifest{}, nil
+		}
+		return nil, fmt.Errorf("read sync manifest: %w", err)
+	}
+	var m SyncManifest
+	if err := yaml.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("parse sync manifest: %w", err)
+	}
+	return &m, nil
+}
+
+// saveManifest writes the sync manifest for the just-completed sync.
+func saveManifest(entries []ManifestEntry) error {
+	m := SyncManifest{
+		SchemaVersion: "0.1.0",
+		SyncedAt:      time.Now().UTC().Format(time.RFC3339),
+		Entries:       entries,
+	}
+	data, err := yaml.Marshal(&m)
+	if err != nil {
+		return fmt.Errorf("marshal sync manifest: %w", err)
+	}
+	path := manifestPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create sideshow dir: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("write sync manifest: %w", err)
+	}
+	return nil
+}
+
+// reconcile removes artifacts recorded in the previous manifest that are
+// absent from the current sync set, then persists the current set. Only
+// paths inside the binding target dirs (~/.claude/commands, ~/.claude/
+// skills) are ever removed — the manifest is the record that sideshow
+// wrote them, and the containment check is the belt to that suspender.
+// Returns the number of stale artifacts removed.
+func reconcile(current []ManifestEntry) (int, error) {
+	prev, err := loadManifest()
+	if err != nil {
+		return 0, err
+	}
+
+	currentPaths := make(map[string]struct{}, len(current))
+	for _, e := range current {
+		currentPaths[e.Path] = struct{}{}
+	}
+
+	removed := 0
+	for _, e := range prev.Entries {
+		if _, ok := currentPaths[e.Path]; ok {
+			continue
+		}
+		if !withinBindingTargets(e.Path) {
+			continue
+		}
+		if _, statErr := os.Lstat(e.Path); statErr != nil {
+			continue // already gone
+		}
+		if rmErr := os.RemoveAll(e.Path); rmErr != nil {
+			fmt.Fprintf(os.Stderr, "warning: remove stale %s: %v\n", e.Path, rmErr)
+			continue
+		}
+		removed++
+	}
+
+	if err := saveManifest(current); err != nil {
+		return removed, err
+	}
+	return removed, nil
+}
+
+// withinBindingTargets reports whether a path is inside one of the
+// binding target directories sync writes to.
+func withinBindingTargets(path string) bool {
+	for _, dir := range []string{claudeCommandsDir(), claudeSkillsDir()} {
+		rel, err := filepath.Rel(dir, path)
+		if err != nil {
+			continue
+		}
+		if rel != "." && !strings.HasPrefix(rel, "..") {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/bindings/manifest_test.go
+++ b/internal/bindings/manifest_test.go
@@ -1,0 +1,117 @@
+package bindings
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// makeSkillPack creates a pack dir shipping the named skills.
+func makeSkillPack(t *testing.T, skills ...string) string {
+	t.Helper()
+	root := t.TempDir()
+	for _, s := range skills {
+		dir := filepath.Join(root, ".claude", "skills", s)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "SKILL.md"),
+			[]byte("---\nname: "+s+"\n---\ncontent\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}
+
+func skillExists(t *testing.T, home, name string) bool {
+	t.Helper()
+	info, err := os.Stat(filepath.Join(home, ".claude", "skills", name))
+	return err == nil && info.IsDir()
+}
+
+func TestRunSync_ReconcilesStaleSkillsOnVersionFlip(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("SIDESHOW_HOME", "")
+
+	// Version 1 ships skills a + b.
+	v1 := makeSkillPack(t, "bmad-alpha", "bmad-beta")
+	synced, removed, err := runSync([]Binding{NewSkillDirBinding("bmad", "1.0.0", v1)})
+	if err != nil {
+		t.Fatalf("first sync: %v", err)
+	}
+	if synced != 2 || removed != 0 {
+		t.Fatalf("first sync = %d synced, %d removed; want 2, 0", synced, removed)
+	}
+	if !skillExists(t, home, "bmad-alpha") || !skillExists(t, home, "bmad-beta") {
+		t.Fatal("v1 skills not synced")
+	}
+
+	// Version 2 drops bmad-alpha, adds bmad-gamma — the activation flip.
+	v2 := makeSkillPack(t, "bmad-beta", "bmad-gamma")
+	synced, removed, err = runSync([]Binding{NewSkillDirBinding("bmad", "2.0.0", v2)})
+	if err != nil {
+		t.Fatalf("second sync: %v", err)
+	}
+	if synced != 2 {
+		t.Errorf("second sync synced = %d, want 2", synced)
+	}
+	if removed != 1 {
+		t.Errorf("second sync removed = %d, want 1 (the stale bmad-alpha)", removed)
+	}
+	if skillExists(t, home, "bmad-alpha") {
+		t.Error("stale bmad-alpha survived the flip — chimera not reconciled")
+	}
+	if !skillExists(t, home, "bmad-beta") || !skillExists(t, home, "bmad-gamma") {
+		t.Error("v2 skills missing after flip")
+	}
+}
+
+func TestRunSync_DoesNotRemoveUnrecordedArtifacts(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("SIDESHOW_HOME", "")
+
+	// A user-authored skill sideshow never wrote.
+	userSkill := filepath.Join(home, ".claude", "skills", "my-own-skill")
+	if err := os.MkdirAll(userSkill, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(userSkill, "SKILL.md"), []byte("mine"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	v1 := makeSkillPack(t, "bmad-alpha")
+	if _, _, err := runSync([]Binding{NewSkillDirBinding("bmad", "1.0.0", v1)}); err != nil {
+		t.Fatal(err)
+	}
+	v2 := makeSkillPack(t, "bmad-beta")
+	if _, _, err := runSync([]Binding{NewSkillDirBinding("bmad", "2.0.0", v2)}); err != nil {
+		t.Fatal(err)
+	}
+
+	if !skillExists(t, home, "my-own-skill") {
+		t.Error("user-authored skill was removed — reconciliation must only touch manifest-recorded artifacts")
+	}
+}
+
+func TestArtifacts_MatchSyncDestinations(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("SIDESHOW_HOME", "")
+
+	pack := makeSkillPack(t, "bmad-one", "gds-two")
+	b := NewSkillDirBinding("bmad", "1.0.0", pack)
+
+	arts, err := b.Artifacts()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{
+		filepath.Join(home, ".claude", "skills", "bmad-one"),
+		filepath.Join(home, ".claude", "skills", "gds-two"),
+	}
+	if len(arts) != 2 || arts[0] != want[0] || arts[1] != want[1] {
+		t.Errorf("Artifacts() = %v, want %v", arts, want)
+	}
+}

--- a/internal/bindings/markdown_command.go
+++ b/internal/bindings/markdown_command.go
@@ -5,6 +5,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 )
 
@@ -115,6 +116,55 @@ func (b *MarkdownCommandBinding) Sync() (int, error) {
 	})
 
 	return synced, walkErr
+}
+
+// Artifacts returns the destination command files this binding owns,
+// mirroring Sync's two passes: every .md under commands/ (by basename)
+// plus bmad-*.md anywhere else in the pack.
+func (b *MarkdownCommandBinding) Artifacts() ([]string, error) {
+	claudeDir := claudeCommandsDir()
+	seen := map[string]struct{}{}
+	var out []string
+
+	commandsSubdir := filepath.Join(b.packPath, "commands")
+	if info, err := os.Stat(commandsSubdir); err == nil && info.IsDir() {
+		_ = filepath.WalkDir(commandsSubdir, func(path string, d fs.DirEntry, werr error) error {
+			if werr != nil || d.IsDir() {
+				return werr
+			}
+			if !strings.HasSuffix(path, ".md") {
+				return nil
+			}
+			base := filepath.Base(path)
+			if _, ok := seen[base]; !ok {
+				seen[base] = struct{}{}
+				out = append(out, filepath.Join(claudeDir, base))
+			}
+			return nil
+		})
+	}
+
+	_ = filepath.WalkDir(b.packPath, func(path string, d fs.DirEntry, werr error) error {
+		if werr != nil || d.IsDir() {
+			return werr
+		}
+		name := filepath.Base(path)
+		if !strings.HasPrefix(name, "bmad-") || !strings.HasSuffix(name, ".md") {
+			return nil
+		}
+		rel, _ := filepath.Rel(b.packPath, path)
+		if strings.HasPrefix(rel, "commands/") {
+			return nil
+		}
+		if _, ok := seen[name]; !ok {
+			seen[name] = struct{}{}
+			out = append(out, filepath.Join(claudeDir, name))
+		}
+		return nil
+	})
+
+	sort.Strings(out)
+	return out, nil
 }
 
 // Validate checks the binding's pack path exists. Content-level validation

--- a/internal/bindings/skill_dir.go
+++ b/internal/bindings/skill_dir.go
@@ -5,6 +5,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 )
 
@@ -128,6 +129,19 @@ func shouldRewrite(path string) bool {
 		return true
 	}
 	return false
+}
+
+// Artifacts returns the destination skill directories this binding owns
+// — one per skill dir the pack ships, mirroring exactly what Sync writes.
+func (b *SkillDirBinding) Artifacts() ([]string, error) {
+	dst := claudeSkillsDir()
+	ids := skillCanonicalIds(b.packPath)
+	out := make([]string, 0, len(ids))
+	for id := range ids {
+		out = append(out, filepath.Join(dst, id))
+	}
+	sort.Strings(out)
+	return out, nil
 }
 
 // Validate checks that the pack's .claude/skills/ directory contains at

--- a/internal/distribute/distribute.go
+++ b/internal/distribute/distribute.go
@@ -566,9 +566,12 @@ func distributeCustomBridge(repoRoot string, bridge CustomBridgeArtifact, opts O
 
 	var actions []Action
 
-	// 1. Per-repo customization dir (checked in). Create with .gitkeep
-	// if absent; existing content is the user's data — never touched.
+	// 1. Per-repo customization dir (checked in). Create if absent —
+	// seeded from the pack's custom/ template when the pack ships one
+	// (bmad 6.4+ ships the four-file TOML scaffold), .gitkeep otherwise.
+	// Existing content is the user's data — never touched.
 	perRepoAbs := filepath.Join(repoRoot, perRepo)
+	templateDir := filepath.Join(opts.PackRoot, "custom")
 	dirAction := Action{Type: "custom_bridge", Path: perRepo + "/"}
 	if _, statErr := os.Stat(perRepoAbs); statErr == nil {
 		dirAction.Status = "skipped"
@@ -578,10 +581,20 @@ func distributeCustomBridge(repoRoot string, bridge CustomBridgeArtifact, opts O
 		dirAction.Detail = fmt.Sprintf("stat %s: %v", perRepo, statErr)
 	} else if opts.DryRun {
 		dirAction.Status = "wrote"
-		dirAction.Detail = "would create per-repo customization dir (+ .gitkeep)"
+		if hasTemplateContent(templateDir) {
+			dirAction.Detail = "would create per-repo customization dir (seeded from pack custom/ template)"
+		} else {
+			dirAction.Detail = "would create per-repo customization dir (+ .gitkeep)"
+		}
 	} else if mkErr := os.MkdirAll(perRepoAbs, 0o755); mkErr != nil {
 		dirAction.Status = "error"
 		dirAction.Detail = fmt.Sprintf("create dir: %v", mkErr)
+	} else if seeded, seedErr := seedCustomTemplate(templateDir, perRepoAbs); seedErr != nil {
+		dirAction.Status = "error"
+		dirAction.Detail = fmt.Sprintf("seed from pack custom/ template: %v", seedErr)
+	} else if seeded > 0 {
+		dirAction.Status = "wrote"
+		dirAction.Detail = fmt.Sprintf("created per-repo customization dir (seeded %d file(s) from pack custom/ template)", seeded)
 	} else if wErr := os.WriteFile(filepath.Join(perRepoAbs, ".gitkeep"), nil, 0o644); wErr != nil {
 		dirAction.Status = "error"
 		dirAction.Detail = fmt.Sprintf("write .gitkeep: %v", wErr)
@@ -604,6 +617,46 @@ func distributeCustomBridge(repoRoot string, bridge CustomBridgeArtifact, opts O
 	actions = append(actions, distributeGitignore(repoRoot, "/"+shimDir+"/", opts))
 
 	return actions
+}
+
+// hasTemplateContent reports whether a pack ships a non-empty custom/
+// template directory.
+func hasTemplateContent(templateDir string) bool {
+	entries, err := os.ReadDir(templateDir)
+	return err == nil && len(entries) > 0
+}
+
+// seedCustomTemplate copies the pack's custom/ template tree into the
+// freshly created per-repo customization dir. Returns the number of
+// files copied; (0, nil) when the pack ships no template.
+func seedCustomTemplate(templateDir, destDir string) (int, error) {
+	if !hasTemplateContent(templateDir) {
+		return 0, nil
+	}
+	count := 0
+	err := filepath.WalkDir(templateDir, func(path string, d os.DirEntry, werr error) error {
+		if werr != nil {
+			return werr
+		}
+		rel, relErr := filepath.Rel(templateDir, path)
+		if relErr != nil {
+			return relErr
+		}
+		target := filepath.Join(destDir, rel)
+		if d.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		if writeErr := os.WriteFile(target, data, 0o644); writeErr != nil {
+			return writeErr
+		}
+		count++
+		return nil
+	})
+	return count, err
 }
 
 // distributeGitignore appends a line to .gitignore if missing.

--- a/internal/distribute/distribute_test.go
+++ b/internal/distribute/distribute_test.go
@@ -814,3 +814,46 @@ distribute:
 		t.Error("manifest with custom_bridge should not be IsEmpty")
 	}
 }
+
+func TestCustomBridge_SeedsPackCustomTemplate(t *testing.T) {
+	t.Parallel()
+	repoRoot := t.TempDir()
+	packRoot := t.TempDir()
+
+	// Pack ships a custom/ template (bmad 6.4+ four-file scaffold shape).
+	tplDir := filepath.Join(packRoot, "custom")
+	if err := os.MkdirAll(tplDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for name, content := range map[string]string{
+		"config.toml":      "[agents]\n",
+		"config.user.toml": "# user overrides\n",
+	} {
+		if err := os.WriteFile(filepath.Join(tplDir, name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	opts := defaultOpts(packRoot)
+	actions := distributeCustomBridge(repoRoot, bmadBridge(), opts)
+	if actions[0].Status != "wrote" {
+		t.Fatalf("dir action = %q (%s), want wrote", actions[0].Status, actions[0].Detail)
+	}
+	if !strings.Contains(actions[0].Detail, "seeded") {
+		t.Errorf("dir action detail = %q, want seeded mention", actions[0].Detail)
+	}
+
+	// Template files landed; no .gitkeep when seeded.
+	if _, err := os.Stat(filepath.Join(repoRoot, "_bmad-custom", "config.toml")); err != nil {
+		t.Errorf("seeded config.toml missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(repoRoot, "_bmad-custom", ".gitkeep")); !os.IsNotExist(err) {
+		t.Error(".gitkeep should not be written when template seeds the dir")
+	}
+
+	// Existing customization is still never touched on a second pass.
+	second := distributeCustomBridge(repoRoot, bmadBridge(), opts)
+	if second[0].Status != "skipped" {
+		t.Errorf("second pass dir action = %q, want skipped", second[0].Status)
+	}
+}

--- a/internal/pack/activate_test.go
+++ b/internal/pack/activate_test.go
@@ -1,0 +1,125 @@
+package pack
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writePackYAML(t *testing.T, dir, version string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	content := "name: testpack\nversion: " + version + "\nschema_version: 0.1.0\n"
+	if err := os.WriteFile(filepath.Join(dir, "pack.yaml"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestActivateAndInstalledVersions(t *testing.T) {
+	t.Setenv("SIDESHOW_HOME", t.TempDir())
+
+	// Two installed versions, current pointing at 2.0.0.
+	for _, v := range []string{"1.0.0", "2.0.0"} {
+		writePackYAML(t, filepath.Join(PacksDir(), "testpack", v), v)
+	}
+	if err := os.Symlink("2.0.0", filepath.Join(PacksDir(), "testpack", "current")); err != nil {
+		t.Fatal(err)
+	}
+
+	versions, active, err := InstalledVersions("testpack")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(versions) != 2 || versions[0] != "1.0.0" || versions[1] != "2.0.0" {
+		t.Errorf("versions = %v, want [1.0.0 2.0.0]", versions)
+	}
+	if active != "2.0.0" {
+		t.Errorf("active = %q, want 2.0.0", active)
+	}
+
+	// Activate the other version.
+	if err := Activate("testpack", "1.0.0"); err != nil {
+		t.Fatal(err)
+	}
+	_, active, err = InstalledVersions("testpack")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if active != "1.0.0" {
+		t.Errorf("active after Activate = %q, want 1.0.0", active)
+	}
+
+	// Registry follows the flip.
+	reg, err := LoadRegistry()
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, p := range reg.Packs {
+		if p.Name == "testpack" {
+			found = true
+			if p.Version != "1.0.0" {
+				t.Errorf("registry version = %q, want 1.0.0", p.Version)
+			}
+		}
+	}
+	if !found {
+		t.Error("registry has no testpack entry after Activate")
+	}
+
+	// Activating a version that isn't installed fails.
+	if err := Activate("testpack", "9.9.9"); err == nil {
+		t.Error("Activate of uninstalled version should error")
+	}
+}
+
+func TestInstallFromLocal_NoActivateKeepsCurrent(t *testing.T) {
+	t.Setenv("SIDESHOW_HOME", t.TempDir())
+
+	src1 := t.TempDir()
+	writePackYAML(t, src1, "1.0.0")
+	// First install always activates, even with activate=false.
+	if err := InstallFromLocal("testpack", src1, false); err != nil {
+		t.Fatal(err)
+	}
+	_, active, err := InstalledVersions("testpack")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if active != "1.0.0" {
+		t.Fatalf("first install must activate; active = %q", active)
+	}
+
+	// Second install with activate=false: version lands, current stays.
+	src2 := t.TempDir()
+	writePackYAML(t, src2, "2.0.0")
+	if err := InstallFromLocal("testpack", src2, false); err != nil {
+		t.Fatal(err)
+	}
+	versions, active, err := InstalledVersions("testpack")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(versions) != 2 {
+		t.Errorf("versions = %v, want both installed", versions)
+	}
+	if active != "1.0.0" {
+		t.Errorf("active = %q after --no-activate install, want 1.0.0", active)
+	}
+
+	// Third install WITH activate: current flips.
+	src3 := t.TempDir()
+	writePackYAML(t, src3, "3.0.0")
+	if err := InstallFromLocal("testpack", src3, true); err != nil {
+		t.Fatal(err)
+	}
+	_, active, err = InstalledVersions("testpack")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if active != "3.0.0" {
+		t.Errorf("active = %q after activating install, want 3.0.0", active)
+	}
+}

--- a/internal/pack/pack.go
+++ b/internal/pack/pack.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -336,8 +337,64 @@ func detectPackYamlVersion(packPath string) string {
 	return m.Version
 }
 
+// Activate points a pack's current symlink at an installed version and
+// updates the registry to match. The version must already be installed.
+// Bindings are NOT synced here — callers run bindings.Sync after.
+func Activate(name, version string) error {
+	versionDir := filepath.Join(PacksDir(), name, version)
+	info, err := os.Stat(versionDir)
+	if err != nil || !info.IsDir() {
+		return fmt.Errorf("pack %s version %s is not installed at %s (run 'sideshow list' to see installed versions)", name, version, versionDir)
+	}
+
+	currentLink := filepath.Join(PacksDir(), name, "current")
+	_ = os.Remove(currentLink)
+	if err := os.Symlink(version, currentLink); err != nil {
+		return fmt.Errorf("update current symlink: %w", err)
+	}
+
+	reg, err := LoadRegistry()
+	if err != nil {
+		return fmt.Errorf("load registry: %w", err)
+	}
+	found := false
+	for i := range reg.Packs {
+		if reg.Packs[i].Name == name {
+			reg.Packs[i].Version = version
+			found = true
+		}
+	}
+	if !found {
+		reg.Packs = append(reg.Packs, InstalledPack{
+			Name:        name,
+			Version:     version,
+			Path:        currentLink,
+			InstalledAt: time.Now().UTC().Format(time.RFC3339),
+		})
+	}
+	return reg.Save()
+}
+
+// InstalledVersions returns every version directory installed for a pack
+// (sorted) plus the version the current symlink points at ("" if none).
+func InstalledVersions(name string) (versions []string, active string, err error) {
+	dir := filepath.Join(PacksDir(), name)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, "", err
+	}
+	for _, e := range entries {
+		if e.IsDir() && e.Name() != "current" {
+			versions = append(versions, e.Name())
+		}
+	}
+	sort.Strings(versions)
+	active, _ = os.Readlink(filepath.Join(dir, "current"))
+	return versions, active, nil
+}
+
 // InstallFromLocal copies a pack from a local path to the sideshow directory.
-func InstallFromLocal(name, sourcePath string) error {
+func InstallFromLocal(name, sourcePath string, activate bool) error {
 	// Expand ~ in source path
 	if strings.HasPrefix(sourcePath, "~/") {
 		home, _ := os.UserHomeDir()
@@ -430,8 +487,17 @@ func InstallFromLocal(name, sourcePath string) error {
 		return fmt.Errorf("copy pack: %w", err)
 	}
 
-	// Create current symlink
+	// Create/flip the current symlink. A first install always activates
+	// (current + registry must exist); later installs honor the caller's
+	// activate flag so installing is no longer silently activating.
 	currentLink := filepath.Join(PacksDir(), name, "current")
+	_, curErr := os.Lstat(currentLink)
+	firstInstall := os.IsNotExist(curErr)
+	if !activate && !firstInstall {
+		fmt.Printf("Installed %d files to %s\n", count, destDir)
+		fmt.Printf("Not activated: current stays as-is. Run 'sideshow use %s %s' to activate.\n", name, version)
+		return nil
+	}
 	_ = os.Remove(currentLink) // remove old symlink if exists
 	if err := os.Symlink(version, currentLink); err != nil {
 		return fmt.Errorf("create current symlink: %w", err)

--- a/internal/pack/pack_test.go
+++ b/internal/pack/pack_test.go
@@ -258,7 +258,7 @@ func TestInstallFromLocal(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := InstallFromLocal("testpack", src); err != nil {
+	if err := InstallFromLocal("testpack", src, true); err != nil {
 		t.Fatalf("InstallFromLocal() error: %v", err)
 	}
 
@@ -387,7 +387,7 @@ func TestInstallFromLocal_RejectsSourceTarballShape(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err := InstallFromLocal("bmad", source)
+	err := InstallFromLocal("bmad", source, true)
 	if err == nil {
 		t.Fatal("InstallFromLocal accepted upstream source tarball; expected rejection")
 	}
@@ -483,7 +483,7 @@ func TestInstallFromLocal_UnifiesInstallerSiblingLayout(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := InstallFromLocal("bmad", source); err != nil {
+	if err := InstallFromLocal("bmad", source, true); err != nil {
 		t.Fatalf("InstallFromLocal: %v", err)
 	}
 
@@ -537,7 +537,7 @@ func TestInstallFromLocal_AlreadyUnifiedPassesThrough(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := InstallFromLocal("bmad", source); err != nil {
+	if err := InstallFromLocal("bmad", source, true); err != nil {
 		t.Fatalf("InstallFromLocal: %v", err)
 	}
 


### PR DESCRIPTION
The pre-alpha batch making version flips honest (aae-orc-g8l9 P1 + aae-orc-4q9z), so the next brew upgrade delivers the custom bridge (#47) plus safe tandem-version workflows.

## The headline: sync reconciliation (g8l9)

Sync writes an ownership ledger (`sync-manifest.yaml`) of every artifact it writes (pack@version + destination path). The next sync removes recorded artifacts no longer owned by any active binding.

**Verified against real packs** (finding-072's exact repro): the 6.10.0→6.3.0 flip that used to strand 11 mixed-version skills (`bmad-prd`, `bmad-spec`, `bmad-customize`, `gds-gdd`…) now reports `Removed 11 stale artifact(s)` with final state exactly the active version's 97 skills.

Safety: only manifest-recorded paths inside `~/.claude/{commands,skills}` are ever removed. Pre-manifest strays and user-authored skills are never touched (test-covered).

## Also in the batch

- **`sideshow use <pack> <version>`** — the activation verb: validate → flip `current` → registry → reconciling sync. This is the surface the sideshow.toml/.tool-versions resolution (aae-orc-76sh) will drive.
- **`install --no-activate`** — installing no longer silently activates (first install still does).
- **`list`** reads the store: all installed versions per pack, active marked — non-active versions are no longer invisible.
- **Bridge seeds the pack's `custom/` template** — fresh `_<pack>-custom/` gets bmad 6.4+'s four-file scaffold instead of bare `.gitkeep` (finding-072 item 8).

## Tests

+5 new (reconciliation on flip, never-remove-unrecorded, Artifacts↔Sync parity, Activate/InstalledVersions, no-activate semantics, template seeding). All gates green (test/lint/build).

Refs: aae-orc-g8l9, aae-orc-4q9z, finding-072