### PR TITLE
docs: align session protocol with charter-as-renderer-output (orc F22)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,8 +16,11 @@ Read charter.md before any substantive work. It contains:
 3. Write an Exploration Brief in _kos/probes/
 4. Do the probe work
 5. Write a finding in _kos/findings/
-6. Harvest: update affected nodes, move files if confidence changed
-7. Update charter.md if bedrock changed
+6. Harvest: update affected NODES (`_kos/nodes/{bedrock,frontier,graveyard}/*.yaml`),
+   move files if confidence changed. Charter is renderer output (per orc F22,
+   `kos charter render`); do NOT hand-edit charter prose outside
+   `<!-- backdrop -->` blocks. Subrepo charter renderer extension tracked
+   in aae-orc-gezz.
 
 Cross-repo questions belong in the orchestrator's _kos/, not here.
 
@@ -37,6 +40,7 @@ Always accompany with a commit message explaining the evidence.
 ### Harvest Verification
 Before starting the next cycle, verify:
 - [ ] Finding written and committed
-- [ ] Charter updated if bedrock changed
+- [ ] Bedrock/frontier/graveyard NODES updated if state changed —
+      edit `_kos/nodes/{bedrock,frontier,graveyard}/*.yaml`, NOT charter prose
 - [ ] Frontier questions updated (closed, opened, or revised)
 - [ ] Exploration briefs marked complete or carried forward


### PR DESCRIPTION
## What

Updates CLAUDE.md's kos-process sections to the fleet-standard language:

- Session Protocol step 6: harvest updates NODES (`_kos/nodes/{bedrock,frontier,graveyard}/*.yaml`); charter is renderer output (`kos charter render`, orc F22) — no hand-edits outside `<!-- backdrop -->` blocks. Drops the old step 7 "Update charter.md if bedrock changed."
- Harvest Verification: "[ ] Charter updated if bedrock changed" → "[ ] NODES updated if state changed — edit nodes, NOT charter prose."

Text copied verbatim from sidestep/CLAUDE.md so sideshow matches its siblings.

## Why

An audit of instruction surfaces conflicting with the charter-light-touch rule (ArcavenAE/aae-orc#53) found sideshow was the last subrepo still carrying the pre-renderer protocol — the other 11 subrepo CLAUDE.mds were already updated. This closes that gap.

Refs: ArcavenAE/aae-orc#53