### PR TITLE
fix(sideshow): normalize _kos edge vocabulary to kos schema

### DIFF
--- a/_kos/nodes/bedrock/elem-orc-declared-shape.yaml
+++ b/_kos/nodes/bedrock/elem-orc-declared-shape.yaml
@@ -23,7 +23,7 @@ edges:
   - target: aae-orc::question-sideshow-install-architecture
     type: implements
   - target: question-sideshow-lock
-    type: related
+    type: supports
 provenance:
   created_by: human
   session: session-049

--- a/_kos/nodes/bedrock/elem-pack-content-gitignored.yaml
+++ b/_kos/nodes/bedrock/elem-pack-content-gitignored.yaml
@@ -19,9 +19,9 @@ content: |
   `elem-per-repo-customization`.
 edges:
   - target: elem-user-install-shape
-    type: related
+    type: supports
   - target: elem-per-repo-customization
-    type: related
+    type: supports
 provenance:
   created_by: human
   session: session-049

--- a/_kos/nodes/bedrock/elem-per-repo-customization.yaml
+++ b/_kos/nodes/bedrock/elem-per-repo-customization.yaml
@@ -22,9 +22,9 @@ content: |
   user-install link) does not touch `_{pack}-custom/`.
 edges:
   - target: question-customization-bridge
-    type: related
+    type: supports
   - target: elem-pack-content-gitignored
-    type: related
+    type: supports
 provenance:
   created_by: human
   session: session-049

--- a/_kos/nodes/bedrock/elem-per-repo-output.yaml
+++ b/_kos/nodes/bedrock/elem-per-repo-output.yaml
@@ -19,7 +19,7 @@ content: |
   Both survive pack version upgrades.
 edges:
   - target: elem-per-repo-customization
-    type: sibling
+    type: supports
 provenance:
   created_by: human
   session: session-049

--- a/_kos/nodes/bedrock/elem-user-install-shape.yaml
+++ b/_kos/nodes/bedrock/elem-user-install-shape.yaml
@@ -24,7 +24,7 @@ edges:
   - target: aae-orc::question-sideshow-install-architecture
     type: implements
   - target: elem-pack-content-gitignored
-    type: related
+    type: supports
   - target: grv-global-as-user-install-name
     type: supersedes
 provenance:

--- a/_kos/nodes/frontier/question-cross-orchestrator-precedence.yaml
+++ b/_kos/nodes/frontier/question-cross-orchestrator-precedence.yaml
@@ -40,7 +40,7 @@ edges:
   - target: grv-update-alternatives-default
     type: discovered_from
   - target: elem-user-install-shape
-    type: related
+    type: derives
 provenance:
   created_by: human
   session: session-049

--- a/_kos/nodes/frontier/question-customization-bridge.yaml
+++ b/_kos/nodes/frontier/question-customization-bridge.yaml
@@ -42,11 +42,9 @@ content: |
     inherently fragile in a Git checkout?
 edges:
   - target: aae-orc::question-bmad-65-sideshow-readiness
-    type: related
+    type: supports
   - target: elem-per-repo-customization
     type: implements
-  - target: question-immutable-base-overlays
-    type: blocks
 provenance:
   created_by: human
   session: session-049

--- a/_kos/nodes/frontier/question-five-layer-doctor.yaml
+++ b/_kos/nodes/frontier/question-five-layer-doctor.yaml
@@ -41,11 +41,11 @@ edges:
   - target: aae-orc::question-sideshow-install-architecture
     type: derives
   - target: question-sideshow-lock
-    type: depends-on
+    type: derives
   - target: question-pack-weaving-engine
-    type: related
+    type: supports
   - target: question-immutable-base-overlays
-    type: related
+    type: supports
 provenance:
   created_by: human
   session: session-049

--- a/_kos/nodes/frontier/question-frozen-composition-pipeline.yaml
+++ b/_kos/nodes/frontier/question-frozen-composition-pipeline.yaml
@@ -50,7 +50,7 @@ edges:
   - target: question-source-material-provenance
     type: implements
   - target: question-immutable-base-overlays
-    type: related
+    type: supports
 provenance:
   created_by: human
   session: session-049

--- a/_kos/nodes/frontier/question-immutable-base-overlays.yaml
+++ b/_kos/nodes/frontier/question-immutable-base-overlays.yaml
@@ -42,12 +42,14 @@ content: |
   - At what point does accumulated overlay debt force a re-issue
     instead of another overlay?
 edges:
+  - target: question-customization-bridge
+    type: derives
   - target: aae-orc::question-sideshow-install-architecture
     type: derives
   - target: question-source-material-provenance
-    type: related
+    type: supports
   - target: question-five-layer-doctor
-    type: related
+    type: supports
 provenance:
   created_by: human
   session: session-049

--- a/_kos/nodes/frontier/question-pack-weaving-engine.yaml
+++ b/_kos/nodes/frontier/question-pack-weaving-engine.yaml
@@ -45,11 +45,11 @@ edges:
   - target: aae-orc::question-sideshow-install-architecture
     type: derives
   - target: question-five-layer-doctor
-    type: related
+    type: supports
   - target: question-immutable-base-overlays
-    type: related
+    type: supports
   - target: elem-per-repo-customization
-    type: related
+    type: supports
 provenance:
   created_by: human
   session: session-049

--- a/_kos/nodes/frontier/question-pluggable-source-backends.yaml
+++ b/_kos/nodes/frontier/question-pluggable-source-backends.yaml
@@ -40,7 +40,7 @@ edges:
   - target: aae-orc::question-sideshow-install-architecture
     type: derives
   - target: question-frozen-composition-pipeline
-    type: related
+    type: supports
 provenance:
   created_by: human
   session: session-049

--- a/_kos/nodes/frontier/question-sideshow-lock.yaml
+++ b/_kos/nodes/frontier/question-sideshow-lock.yaml
@@ -39,7 +39,7 @@ edges:
   - target: elem-orc-declared-shape
     type: implements
   - target: question-immutable-base-overlays
-    type: depends-on
+    type: derives
 provenance:
   created_by: human
   session: session-049

--- a/_kos/nodes/frontier/question-source-material-provenance.yaml
+++ b/_kos/nodes/frontier/question-source-material-provenance.yaml
@@ -47,7 +47,7 @@ edges:
   - target: grv-npm-installer-on-user-machines
     type: discovered_from
   - target: question-sideshow-lock
-    type: related
+    type: supports
 provenance:
   created_by: human
   session: session-049

--- a/_kos/nodes/frontier/question-unified-binding-abstraction.yaml
+++ b/_kos/nodes/frontier/question-unified-binding-abstraction.yaml
@@ -40,7 +40,7 @@ edges:
   - target: aae-orc::question-sideshow-install-architecture
     type: derives
   - target: elem-command-sync
-    type: related
+    type: supports
 provenance:
   created_by: human
   session: session-049


### PR DESCRIPTION
## Summary

Repairs schema drift from the graph's charter-extraction bootstrap (`f30e65f`): `related` ×19, `depends-on` ×2, `sibling`, `blocks` are not kos schema v0.3 vocabulary, so kos loaders silently skipped most of this graph (ArcavenAE/kos#86). Fleet inventory: ArcavenAE/kos#51 (comment).

## Mapping decisions

- `related` / `sibling` → `supports` — the weakest ratified bears-on edge. **Deliberately lossy:** if a symmetric `related` type is later ratified via the typed-edge-policy deliberation (`aae-orc/_kos/ideas/typed-edge-policy-not-global-dag.md`), these edges are the revisit candidates.
- `depends-on` → `derives` — kos's blocking grounded-in edge.
- `question-cross-orchestrator-precedence` `related` → `derives` (genuinely grounded in `elem-user-install-shape`).
- The one work-sequencing `blocks` edge (`question-customization-bridge` → `question-immutable-base-overlays`) moved to the dependent node as `derives → question-customization-bridge`, expressing the same constraint in kos's own vocabulary and direction.

## Verification

`kos validate` on the graph (standalone, since `--merged` fail-fasts upstream per ArcavenAE/kos#85): **23 nodes: 0 parse errors** — remaining warnings are pre-existing (cross-graph `aae-orc::` targets, graveyard sections predating this change).

Refs: ArcavenAE/kos#51, ArcavenAE/kos#85, ArcavenAE/kos#86