### PR TITLE
feat: runtime_links shim + read-only fallback footer (fixes #52, #53)

### DIFF
--- a/internal/bindings/manifest_test.go
+++ b/internal/bindings/manifest_test.go
@@ -3,6 +3,7 @@ package bindings
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -113,5 +114,14 @@ func TestArtifacts_MatchSyncDestinations(t *testing.T) {
 	}
 	if len(arts) != 2 || arts[0] != want[0] || arts[1] != want[1] {
 		t.Errorf("Artifacts() = %v, want %v", arts, want)
+	}
+}
+
+func TestFallbackFooter_ReadOnlyClause(t *testing.T) {
+	out := appendFallbackFooter("body", "/tmp/pack")
+	for _, want := range []string{"READ-ONLY", "Never write", "_bmad-custom"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("footer missing read-only clause fragment %q", want)
+		}
 	}
 }

--- a/internal/bindings/rewrite.go
+++ b/internal/bindings/rewrite.go
@@ -77,6 +77,8 @@ Workflow files inside this pack may reference paths of the form X{project-root}/
    X__PACK_PATH__/X
 
 3. Per-repo paths (X{project-root}/_bmad-custom/X, X{project-root}/_bmad-output/X) stay relative to the invoking project — these are per-repo, not pack content.
+
+**This substitution is READ-ONLY.** Never write, move, rename, or delete through the substituted pack path — pack content is immutable shared state, not project state. Project-local writes belong in X{project-root}/_bmad-custom/X or X{project-root}/_bmad-output/X. If a workflow requires a writable X{project-root}/_bmad/X, STOP and tell the user instead of substituting.
 <!-- sideshow:fallback-resolution:end -->
 `
 	footer := strings.ReplaceAll(tmpl, "X", "`")

--- a/internal/distribute/distribute.go
+++ b/internal/distribute/distribute.go
@@ -96,6 +96,15 @@ func ToRepo(repo project.Subrepo, manifest *Manifest, opts Options) Result {
 		result.Actions = append(result.Actions, actions...)
 	}
 
+	if len(manifest.RuntimeLinks) > 0 {
+		shimDir := "_" + opts.PackName
+		if manifest.CustomBridge != nil {
+			shimDir = filepath.Dir(filepath.Clean(manifest.CustomBridge.UpstreamPath))
+		}
+		actions := distributeRuntimeLinks(repo.AbsPath, shimDir, manifest.RuntimeLinks, opts)
+		result.Actions = append(result.Actions, actions...)
+	}
+
 	for _, line := range manifest.Gitignore {
 		action := distributeGitignore(repo.AbsPath, line, opts)
 		result.Actions = append(result.Actions, action)
@@ -615,6 +624,91 @@ func distributeCustomBridge(repoRoot string, bridge CustomBridgeArtifact, opts O
 	// 3. Gitignore the shim dir. Idempotent append; packs that already
 	// declare the same line in distribute.gitignore dedupe here.
 	actions = append(actions, distributeGitignore(repoRoot, "/"+shimDir+"/", opts))
+
+	return actions
+}
+
+// distributeRuntimeLinks creates the read-surface symlinks a pack's
+// runtime expects at {project-root}/<shim>/ (aae-orc-rpnd; sideshow#52).
+// Every link routes through the store's `current` pointer so version
+// flips keep working. Safety: a link whose target does not exist in the
+// active version is REFUSED (a dangling link is worse than a missing
+// one); existing files/dirs/foreign symlinks are reported, never
+// replaced. The store itself is read-only (finding-074), so upstream
+// write attempts through these links fail loudly.
+func distributeRuntimeLinks(repoRoot, shimDir string, links []RuntimeLink, opts Options) []Action {
+	var actions []Action
+	currentRoot := filepath.Join(pack.PacksDir(), opts.PackName, "current")
+
+	for _, l := range links {
+		linkRel := filepath.Join(shimDir, filepath.Clean(l.Link))
+		action := Action{Type: "runtime_link", Path: linkRel}
+
+		if filepath.IsAbs(l.Link) || filepath.IsAbs(l.Target) ||
+			strings.HasPrefix(filepath.Clean(l.Link), "..") ||
+			strings.HasPrefix(filepath.Clean(l.Target), "..") {
+			action.Status = "error"
+			action.Detail = "invalid runtime_link: link and target must be relative, inside shim and pack"
+			actions = append(actions, action)
+			continue
+		}
+
+		target := filepath.Join(currentRoot, filepath.Clean(l.Target))
+		if _, err := os.Stat(target); err != nil {
+			action.Status = "error"
+			action.Detail = fmt.Sprintf("target %s not present in active pack version — refusing to create a dangling link", l.Target)
+			actions = append(actions, action)
+			continue
+		}
+
+		linkPath := filepath.Join(repoRoot, linkRel)
+		if info, lstatErr := os.Lstat(linkPath); lstatErr == nil {
+			if info.Mode()&os.ModeSymlink != 0 {
+				existing, _ := os.Readlink(linkPath)
+				if existing == target {
+					action.Status = "skipped"
+					action.Detail = "runtime link already correct"
+				} else {
+					action.Status = "conflict"
+					action.Detail = fmt.Sprintf("symlink exists but points to %q (expected %q)", existing, target)
+				}
+			} else {
+				action.Status = "conflict"
+				action.Detail = "real file or directory exists at runtime-link path (per-project install?) — left untouched"
+			}
+			actions = append(actions, action)
+			continue
+		}
+
+		if opts.DryRun {
+			action.Status = "wrote"
+			action.Detail = fmt.Sprintf("would link %s → %s", linkRel, target)
+			actions = append(actions, action)
+			continue
+		}
+
+		if err := os.MkdirAll(filepath.Dir(linkPath), 0o755); err != nil {
+			action.Status = "error"
+			action.Detail = fmt.Sprintf("create shim dir: %v", err)
+			actions = append(actions, action)
+			continue
+		}
+		if err := os.Symlink(target, linkPath); err != nil {
+			action.Status = "error"
+			action.Detail = fmt.Sprintf("create symlink: %v", err)
+			actions = append(actions, action)
+			continue
+		}
+
+		action.Status = "wrote"
+		action.Detail = fmt.Sprintf("linked %s → %s", linkRel, target)
+		action.Artifact = pack.DistributedArtifact{
+			Type:   "symlink",
+			Path:   linkRel,
+			Target: target,
+		}
+		actions = append(actions, action)
+	}
 
 	return actions
 }

--- a/internal/distribute/distribute_test.go
+++ b/internal/distribute/distribute_test.go
@@ -857,3 +857,129 @@ func TestCustomBridge_SeedsPackCustomTemplate(t *testing.T) {
 		t.Errorf("second pass dir action = %q, want skipped", second[0].Status)
 	}
 }
+
+// --- Runtime links tests (aae-orc-rpnd; sideshow#52) ---
+
+func testRuntimeLinks() []RuntimeLink {
+	return []RuntimeLink{
+		{Link: "scripts", Target: "scripts"},
+		{Link: "_config", Target: "_config"},
+		{Link: "config.toml", Target: "config.toml"},
+		{Link: "config.user.toml", Target: "config.user.toml"},
+	}
+}
+
+// seedFakeStore creates a fake user store with a current symlink so link
+// targets resolve, returning the store pack dir. SIDESHOW_HOME scoping
+// keeps pack.PacksDir() inside the test sandbox.
+func seedFakeStore(t *testing.T, packName string) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("SIDESHOW_HOME", home)
+	versionDir := filepath.Join(home, "packs", packName, "9.9.9")
+	for _, d := range []string{"scripts", "_config"} {
+		if err := os.MkdirAll(filepath.Join(versionDir, d), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, f := range []string{"config.toml", "config.user.toml"} {
+		if err := os.WriteFile(filepath.Join(versionDir, f), []byte("# t\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.Symlink("9.9.9", filepath.Join(home, "packs", packName, "current")); err != nil {
+		t.Fatal(err)
+	}
+	return versionDir
+}
+
+func TestRuntimeLinks_FreshRepoCreatesAllThroughCurrent(t *testing.T) {
+	seedFakeStore(t, "bmad")
+	repoRoot := t.TempDir()
+	opts := Options{PackName: "bmad", PackVersion: "9.9.9", PackRoot: t.TempDir()}
+
+	actions := distributeRuntimeLinks(repoRoot, "_bmad", testRuntimeLinks(), opts)
+	for _, a := range actions {
+		if a.Status != "wrote" {
+			t.Errorf("%s: status = %q (%s), want wrote", a.Path, a.Status, a.Detail)
+		}
+	}
+	// Links exist, resolve, and point through current (not the version dir).
+	target, err := os.Readlink(filepath.Join(repoRoot, "_bmad", "scripts"))
+	if err != nil {
+		t.Fatalf("scripts link missing: %v", err)
+	}
+	if !strings.Contains(target, "current") {
+		t.Errorf("link target %q must route through current", target)
+	}
+	if _, err := os.Stat(filepath.Join(repoRoot, "_bmad", "config.toml")); err != nil {
+		t.Errorf("config.toml link does not resolve: %v", err)
+	}
+}
+
+func TestRuntimeLinks_Idempotent(t *testing.T) {
+	seedFakeStore(t, "bmad")
+	repoRoot := t.TempDir()
+	opts := Options{PackName: "bmad", PackVersion: "9.9.9", PackRoot: t.TempDir()}
+
+	distributeRuntimeLinks(repoRoot, "_bmad", testRuntimeLinks(), opts)
+	second := distributeRuntimeLinks(repoRoot, "_bmad", testRuntimeLinks(), opts)
+	for _, a := range second {
+		if a.Status != "skipped" {
+			t.Errorf("re-run %s: status = %q, want skipped", a.Path, a.Status)
+		}
+	}
+}
+
+func TestRuntimeLinks_RefusesConflict(t *testing.T) {
+	seedFakeStore(t, "bmad")
+	repoRoot := t.TempDir()
+	// A real directory occupies _bmad/scripts (e.g. a genuine per-project install).
+	if err := os.MkdirAll(filepath.Join(repoRoot, "_bmad", "scripts"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	opts := Options{PackName: "bmad", PackVersion: "9.9.9", PackRoot: t.TempDir()}
+
+	actions := distributeRuntimeLinks(repoRoot, "_bmad", testRuntimeLinks()[:1], opts)
+	if actions[0].Status != "conflict" {
+		t.Errorf("status = %q (%s), want conflict", actions[0].Status, actions[0].Detail)
+	}
+	// The real dir is untouched.
+	if fi, err := os.Lstat(filepath.Join(repoRoot, "_bmad", "scripts")); err != nil || fi.Mode()&os.ModeSymlink != 0 {
+		t.Error("pre-existing real directory was replaced")
+	}
+}
+
+func TestRuntimeLinks_RefusesDanglingTarget(t *testing.T) {
+	seedFakeStore(t, "bmad")
+	repoRoot := t.TempDir()
+	opts := Options{PackName: "bmad", PackVersion: "9.9.9", PackRoot: t.TempDir()}
+
+	actions := distributeRuntimeLinks(repoRoot, "_bmad",
+		[]RuntimeLink{{Link: "nope", Target: "does-not-exist"}}, opts)
+	if actions[0].Status != "error" {
+		t.Errorf("status = %q (%s), want error for dangling target", actions[0].Status, actions[0].Detail)
+	}
+	if _, err := os.Lstat(filepath.Join(repoRoot, "_bmad", "nope")); !os.IsNotExist(err) {
+		t.Error("dangling link was created — worse than none (Sam's clause)")
+	}
+}
+
+func TestRuntimeLinks_NoDeclarationNoOp(t *testing.T) {
+	t.Setenv("SIDESHOW_HOME", t.TempDir())
+	repoRoot := t.TempDir()
+	repo := project.Subrepo{Name: "r", AbsPath: repoRoot, Present: true}
+	m := &Manifest{Gitignore: []string{"/x/"}}
+
+	result := ToRepo(repo, m, Options{PackName: "bmad", PackRoot: t.TempDir()})
+	for _, a := range result.Actions {
+		if a.Type == "runtime_link" {
+			t.Errorf("runtime_link action emitted without declaration: %+v", a)
+		}
+	}
+	if _, err := os.Lstat(filepath.Join(repoRoot, "_bmad")); err == nil {
+		if entries, _ := os.ReadDir(filepath.Join(repoRoot, "_bmad")); len(entries) > 0 {
+			t.Error("_bmad populated without runtime_links declaration")
+		}
+	}
+}

--- a/internal/distribute/manifest.go
+++ b/internal/distribute/manifest.go
@@ -23,6 +23,18 @@ type Manifest struct {
 	Symlinks     []SymlinkArtifact     `yaml:"symlinks,omitempty"`
 	Gitignore    []string              `yaml:"gitignore,omitempty"`
 	CustomBridge *CustomBridgeArtifact `yaml:"custom_bridge,omitempty"`
+	RuntimeLinks []RuntimeLink         `yaml:"runtime_links,omitempty"`
+}
+
+// RuntimeLink declares one read surface the pack's runtime expects at
+// {project-root}/<shim>/<link> (e.g. _bmad/scripts). Distribution
+// creates a symlink into the user store THROUGH the current pointer so
+// version flips keep working. Enumerated deliberately — the reference
+// scanner proposes new entries per version, humans ratify (party-mode
+// design round, 2026-07-12; sideshow#52).
+type RuntimeLink struct {
+	Link   string `yaml:"link"`   // entry name inside the shim dir (e.g. scripts)
+	Target string `yaml:"target"` // path inside the pack store root (e.g. scripts)
 }
 
 // CustomBridgeArtifact declares the customization bridge for packs whose
@@ -93,5 +105,6 @@ func (m *Manifest) IsEmpty() bool {
 		len(m.ClaudeMD) == 0 &&
 		len(m.Symlinks) == 0 &&
 		len(m.Gitignore) == 0 &&
-		m.CustomBridge == nil
+		m.CustomBridge == nil &&
+		len(m.RuntimeLinks) == 0
 }


### PR DESCRIPTION
Party-mode design verdict implemented red/green. Enumerated `runtime_links` in pack.yaml (scanner proposes additions — sideshow-packs#2); links through `current`; dangling-target + conflict refusal; READ-ONLY footer clause. E2E: roster resolves 21 members via the real tool on a scratch consumer. Spec: aae-orc-rpnd notes; analysis: finding-074.