### PR TITLE
feat: bind custom-built skills from _<pack>-custom/skills/ + help-flag safety

### DIFF
--- a/cmd/sideshow/main.go
+++ b/cmd/sideshow/main.go
@@ -34,7 +34,10 @@ Usage:
                                           Distribute pack artifacts to subrepos
   sideshow use <pack> <version>           Activate an installed version + sync bindings
   sideshow list                           List installed packs (all versions, active marked)
-  sideshow commands sync                  Sync commands to ~/.claude/commands/
+  sideshow commands sync                  Sync commands + skills bindings (pack content
+                                          and registered _<pack>-custom/skills/ sources)
+  sideshow project init <pack>            Apply consumer-repo convention to cwd and
+                                          register it as a custom-skills source
   sideshow status                         Show installation status
   sideshow version                        Show version
 
@@ -69,6 +72,16 @@ func main() {
 	if len(os.Args) < 2 {
 		usage()
 		os.Exit(1)
+	}
+
+	// Help anywhere on the command line prints usage and performs no
+	// action. This runs before dispatch so no subcommand can execute
+	// as a side effect of asking for help (sideshow#57).
+	for _, a := range os.Args[1:] {
+		if a == "-h" || a == "--help" {
+			usage()
+			return
+		}
 	}
 
 	var err error
@@ -161,6 +174,8 @@ func runInit(args []string) error {
 			}
 		case "--dry-run":
 			dryRun = true
+		default:
+			return fmt.Errorf("unknown flag for init: %s (see 'sideshow --help')", args[i])
 		}
 	}
 
@@ -608,6 +623,17 @@ func runProjectInitForPack(args []string) error {
 		return fmt.Errorf("distribute: %w", result.Error)
 	}
 
+	// Register this repo as a custom source so `commands sync` binds
+	// _<pack>-custom/skills/ from anywhere, not just from this cwd.
+	if !dryRun {
+		added, regErr := bindings.RegisterCustomSource(cwd, packName)
+		if regErr != nil {
+			fmt.Fprintf(os.Stderr, "  warning: register custom source: %v\n", regErr)
+		} else if added {
+			fmt.Printf("  registered custom source (binds %s/skills/ on sync)\n", filepath.Base(customDir))
+		}
+	}
+
 	wrote := 0
 	skipped := 0
 	for _, a := range result.Actions {
@@ -650,6 +676,18 @@ func runStatus() error {
 			fmt.Printf("  synced:    error: %v\n", err)
 		} else {
 			fmt.Printf("  synced:    %d\n", synced)
+		}
+	}
+
+	sources, err := bindings.ListCustomSources()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "warning: read custom sources: %v\n", err)
+		return nil
+	}
+	if len(sources) > 0 {
+		fmt.Println("\nCustom sources:")
+		for _, s := range sources {
+			fmt.Printf("  %s (pack %s)\n", s.Project, s.Pack)
 		}
 	}
 	return nil

--- a/docs/consumer-repo-convention.md
+++ b/docs/consumer-repo-convention.md
@@ -25,7 +25,9 @@ repo.
 
 project-repo/                            PROJECT-SCOPE (per-repo)
 ├── _bmad-custom/                        ── CHECKED IN: overrides
-│   ├── agents/                          ──   project-specific agents
+│   ├── agents/                          ──   project-specific agents (TOML)
+│   ├── skills/                          ──   custom-built skills (bmb output;
+│   │   └── <name>/SKILL.md              ──   bound to ~/.claude/skills/ on sync)
 │   ├── workflows/                       ──   per-workflow customize.toml
 │   ├── config.toml                      ──   pack-level customization
 │   └── memories/                        ──   project-specific context
@@ -53,6 +55,7 @@ project-repo/                            PROJECT-SCOPE (per-repo)
 | `_<pack>/custom/` (symlink) | **Gitignore** (the link itself; target is checked in) | Customization-bridge symlink → `../_<pack>-custom/`. Created at `sideshow project init` for packs that ship an upstream `custom/` sub-convention (bmad 6.4+). Lets upstream's `bmad-customize` skill and runtime resolver write to the checked-in per-repo dir. See [`customization-bridge.md`](customization-bridge.md). |
 | `.claude/commands/<pack>-*.md` | **Gitignore** | sideshow syncs to `~/.claude/commands/` at user-scope. Per-project duplicates conflict. |
 | `.claude/skills/<pack>-*/`     | **Gitignore** | sideshow syncs to `~/.claude/skills/` at user-scope. Per-project duplicates conflict. |
+| `_<pack>-custom/skills/<name>/` | **Check in** | Custom-built skills (bmb-authored agents, project-local skills). Each dir needs a `SKILL.md` entry point. Bound to `~/.claude/skills/` on `commands sync` via the custom-sources registry (repo registered by `sideshow project init <pack>`, or auto-registered when sync runs inside the repo). Pack canonical ids win name collisions. Copied verbatim — no path rewrites, no fallback footer. |
 | `sideshow.lock`       | **Check in**  | Pins the pack version the repo was last known to work against. See aae-orc-333y. |
 
 **Previous design note:** sideshow's original charter said

--- a/docs/customization-bridge.md
+++ b/docs/customization-bridge.md
@@ -81,6 +81,32 @@ The bridge applies *only* where an upstream pack defines a `custom/`
 sub-convention. Other packs use `_<pack>-custom/` exactly as before,
 with no symlink, no bridge, no collision.
 
+## Custom-built skills and builder output routing
+
+`_<pack>-custom/skills/<name>/` holds custom-built skills — chiefly
+agents authored by bmad's builder (bmb) — and sideshow binds them to
+`~/.claude/skills/` on `commands sync` (see
+`consumer-repo-convention.md` for the binding rules).
+
+**Builder output must be routed through the bridge.** Upstream's
+`bmad_builder_output_folder` lives in `_bmad/config.toml`, which in
+consumer repos is a symlink into the shared user-scope pack store —
+editing it changes builder routing for every consumer repo on the
+machine. Instead, point the builder at
+`{project-root}/_bmad/custom/skills`: the bridge symlink resolves this
+to the checked-in `_bmad-custom/skills/`, so built skills land in
+project territory, survive pack version swaps, and are picked up by
+the custom-skill binding on the next sync. (The per-repo config
+mechanism for overriding `bmad_builder_output_folder` — upstream's
+four-file chain vs an explicit flag at build time — is upstream
+behavior; until it's verified, setting the output folder explicitly
+when invoking the builder is the reliable path.)
+
+Failure mode this prevents (aae-orc finding-076): a bmb-built agent
+written to a nested `.claude/skills/` inside a subrepo is complete but
+undiscoverable — no session anchored above it reads that directory,
+and sideshow does not bind it.
+
 ## Boundary table
 
 | Path | Owner | Persistence | Bridge applies? |

--- a/internal/bindings/bindings.go
+++ b/internal/bindings/bindings.go
@@ -62,8 +62,12 @@ func DiscoverBindings(p pack.InstalledPack) ([]Binding, error) {
 	return result, nil
 }
 
-// Sync discovers and syncs every binding for every installed pack, printing
-// a human-readable summary to stdout for CLI consumption.
+// Sync discovers and syncs every binding for every installed pack plus
+// every registered custom source, printing a human-readable summary to
+// stdout for CLI consumption. When run inside a consumer repo that has
+// bindable custom skills for an installed pack, the repo is
+// auto-registered as a custom source so later syncs from elsewhere
+// keep its skills alive.
 func Sync() error {
 	packs, err := pack.List()
 	if err != nil {
@@ -76,6 +80,7 @@ func Sync() error {
 	}
 
 	var all []Binding
+	packSkillOwners := make(map[string]string)
 	for _, p := range packs {
 		discovered, err := DiscoverBindings(p)
 		if err != nil {
@@ -83,7 +88,23 @@ func Sync() error {
 			continue
 		}
 		all = append(all, discovered...)
+
+		if resolved, evalErr := filepath.EvalSymlinks(p.Path); evalErr == nil {
+			for id := range skillCanonicalIds(resolved) {
+				packSkillOwners[id] = p.Name
+			}
+		}
 	}
+
+	if cwd, cwdErr := os.Getwd(); cwdErr == nil {
+		autoRegisterCustomSources(cwd, packs)
+	}
+
+	custom, err := discoverCustomBindings(packs, packSkillOwners)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "warning: discover custom sources: %v\n", err)
+	}
+	all = append(all, custom...)
 
 	totalSynced, removed, err := runSync(all)
 	if err != nil {
@@ -95,6 +116,90 @@ func Sync() error {
 		fmt.Printf("Removed %d stale artifact(s) from a previously active version\n", removed)
 	}
 	return nil
+}
+
+// autoRegisterCustomSources registers the working directory as a custom
+// source for every installed pack it carries bindable custom skills
+// for. Best-effort: registration failures warn, never fail the sync.
+func autoRegisterCustomSources(cwd string, packs []pack.InstalledPack) {
+	for _, p := range packs {
+		if !hasCustomSkillContent(cwd, p.Name) {
+			continue
+		}
+		added, err := RegisterCustomSource(cwd, p.Name)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: register custom source %s: %v\n", cwd, err)
+			continue
+		}
+		if added {
+			fmt.Printf("Registered custom source %s (pack %s)\n", cwd, p.Name)
+		}
+	}
+}
+
+// discoverCustomBindings loads the custom-source registry and returns a
+// binding per source that still exists, has its pack installed, and has
+// bindable skills. Skill names already owned by a pack (canonical id)
+// or claimed by an earlier source are skipped with a warning — pack
+// content wins collisions. Sources whose project directory no longer
+// exists are pruned from the registry; their previously synced skills
+// fall out via manifest reconciliation.
+func discoverCustomBindings(packs []pack.InstalledPack, packSkillOwners map[string]string) ([]Binding, error) {
+	reg, err := loadCustomSources()
+	if err != nil {
+		return nil, err
+	}
+	if len(reg.Sources) == 0 {
+		return nil, nil
+	}
+
+	installed := make(map[string]struct{}, len(packs))
+	for _, p := range packs {
+		installed[p.Name] = struct{}{}
+	}
+
+	var kept []CustomSource
+	pruned := false
+	claimed := make(map[string]string) // skill name -> claiming project
+	var out []Binding
+
+	for _, s := range reg.Sources {
+		if _, statErr := os.Stat(s.Project); statErr != nil {
+			fmt.Fprintf(os.Stderr, "warning: custom source %s missing on disk — pruning from registry\n", s.Project)
+			pruned = true
+			continue
+		}
+		kept = append(kept, s)
+
+		if _, ok := installed[s.Pack]; !ok {
+			continue
+		}
+
+		var skills []string
+		for _, name := range customSkillIds(s.Project, s.Pack) {
+			if owner, ok := packSkillOwners[name]; ok {
+				fmt.Fprintf(os.Stderr, "warning: skipping custom skill %s from %s: name owned by pack %s\n", name, s.Project, owner)
+				continue
+			}
+			if prev, ok := claimed[name]; ok {
+				fmt.Fprintf(os.Stderr, "warning: skipping custom skill %s from %s: already bound from %s\n", name, s.Project, prev)
+				continue
+			}
+			claimed[name] = s.Project
+			skills = append(skills, name)
+		}
+		if len(skills) == 0 {
+			continue
+		}
+		out = append(out, NewCustomSkillDirBinding(s.Pack, s.Project, skills))
+	}
+
+	if pruned {
+		if saveErr := saveCustomSources(kept); saveErr != nil {
+			fmt.Fprintf(os.Stderr, "warning: save custom sources after prune: %v\n", saveErr)
+		}
+	}
+	return out, nil
 }
 
 // runSync syncs every binding, then reconciles the sync manifest:

--- a/internal/bindings/custom_skill_dir.go
+++ b/internal/bindings/custom_skill_dir.go
@@ -1,0 +1,157 @@
+package bindings
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// CustomSkillDirBinding binds custom-built skills — bmb-authored agents
+// and other project-local skills — from a consumer repo's
+// _<pack>-custom/skills/<name>/ directories into ~/.claude/skills/.
+//
+// Unlike SkillDirBinding, content is copied verbatim: no path rewrites
+// and no fallback-resolution footer. Custom skills live in checked-in
+// project territory, not the user-scope pack store, so store-relative
+// rewrites do not apply. The skill set is fixed at construction time
+// (collision filtering against pack-owned canonical ids happens during
+// discovery), so Sync writes exactly the listed skills.
+type CustomSkillDirBinding struct {
+	pack       string
+	projectDir string
+	skills     []string
+}
+
+// NewCustomSkillDirBinding constructs a binding for the given consumer
+// repo, pack, and pre-filtered skill list.
+func NewCustomSkillDirBinding(packName, projectDir string, skills []string) *CustomSkillDirBinding {
+	return &CustomSkillDirBinding{
+		pack:       packName,
+		projectDir: projectDir,
+		skills:     skills,
+	}
+}
+
+// Kind returns the binding type identifier.
+func (b *CustomSkillDirBinding) Kind() string { return "custom-skill-dir" }
+
+// PackName returns the pack this customization layer belongs to.
+func (b *CustomSkillDirBinding) PackName() string { return b.pack }
+
+// PackVersion returns "custom" — custom skills are project content and
+// do not track the active pack version.
+func (b *CustomSkillDirBinding) PackVersion() string { return "custom" }
+
+// skillsSrcDir returns the consumer repo's custom skills directory.
+func (b *CustomSkillDirBinding) skillsSrcDir() string {
+	return customSkillsDir(b.projectDir, b.pack)
+}
+
+// Sync copies each listed skill directory verbatim into
+// ~/.claude/skills/<name>/. Returns the number of skills synced.
+func (b *CustomSkillDirBinding) Sync() (int, error) {
+	dst := claudeSkillsDir()
+	if err := os.MkdirAll(dst, 0o755); err != nil {
+		return 0, fmt.Errorf("create skills dir: %w", err)
+	}
+
+	synced := 0
+	for _, name := range b.skills {
+		src := filepath.Join(b.skillsSrcDir(), name)
+		if err := copyTree(src, filepath.Join(dst, name)); err != nil {
+			return synced, fmt.Errorf("sync custom skill %s: %w", name, err)
+		}
+		synced++
+	}
+	return synced, nil
+}
+
+// Artifacts returns the destination skill directories this binding owns.
+func (b *CustomSkillDirBinding) Artifacts() ([]string, error) {
+	dst := claudeSkillsDir()
+	out := make([]string, 0, len(b.skills))
+	for _, name := range b.skills {
+		out = append(out, filepath.Join(dst, name))
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+// Validate checks that every listed skill directory still has its
+// SKILL.md entry point.
+func (b *CustomSkillDirBinding) Validate() error {
+	var missing []string
+	for _, name := range b.skills {
+		entry := filepath.Join(b.skillsSrcDir(), name, "SKILL.md")
+		if _, err := os.Stat(entry); err != nil {
+			missing = append(missing, name)
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("custom skills missing SKILL.md entry point: %v", missing)
+	}
+	return nil
+}
+
+// copyTree recursively copies src into dst with no content transforms.
+func copyTree(src, dst string) error {
+	return filepath.WalkDir(src, func(path string, d fs.DirEntry, werr error) error {
+		if werr != nil {
+			return werr
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return fmt.Errorf("compute rel path: %w", err)
+		}
+		target := filepath.Join(dst, rel)
+
+		if d.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("read %s: %w", path, err)
+		}
+		if err := os.WriteFile(target, data, 0o644); err != nil {
+			return fmt.Errorf("write %s: %w", target, err)
+		}
+		return nil
+	})
+}
+
+// customSkillsDir returns the custom skills directory for a consumer
+// repo + pack pair: <project>/_<pack>-custom/skills.
+func customSkillsDir(projectDir, packName string) string {
+	return filepath.Join(projectDir, fmt.Sprintf("_%s-custom", packName), "skills")
+}
+
+// customSkillIds returns the names of skill directories (containing a
+// SKILL.md entry point) under a consumer repo's custom skills dir.
+// Directories without SKILL.md are ignored — half-authored skills must
+// not break sync.
+func customSkillIds(projectDir, packName string) []string {
+	entries, err := os.ReadDir(customSkillsDir(projectDir, packName))
+	if err != nil {
+		return nil
+	}
+	var ids []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		entry := filepath.Join(customSkillsDir(projectDir, packName), e.Name(), "SKILL.md")
+		if _, err := os.Stat(entry); err == nil {
+			ids = append(ids, e.Name())
+		}
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+// hasCustomSkillContent reports whether a consumer repo has at least
+// one bindable custom skill for the pack.
+func hasCustomSkillContent(projectDir, packName string) bool {
+	return len(customSkillIds(projectDir, packName)) > 0
+}

--- a/internal/bindings/custom_skill_dir_test.go
+++ b/internal/bindings/custom_skill_dir_test.go
@@ -1,0 +1,216 @@
+package bindings
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/ArcavenAE/sideshow/internal/pack"
+)
+
+func TestCustomSkillDirBinding_Kind(t *testing.T) {
+	t.Parallel()
+	b := NewCustomSkillDirBinding("bmad", "/tmp/whatever", []string{"eos-coach"})
+	if b.Kind() != "custom-skill-dir" {
+		t.Errorf("Kind() = %q, want %q", b.Kind(), "custom-skill-dir")
+	}
+	if b.PackVersion() != "custom" {
+		t.Errorf("PackVersion() = %q, want %q", b.PackVersion(), "custom")
+	}
+}
+
+func TestCustomSkillIds(t *testing.T) {
+	t.Parallel()
+	project := t.TempDir()
+	base := filepath.Join(project, "_bmad-custom", "skills")
+
+	writeFile(t, filepath.Join(base, "eos-coach", "SKILL.md"), "# coach\n")
+	writeFile(t, filepath.Join(base, "zeta", "SKILL.md"), "# zeta\n")
+	writeFile(t, filepath.Join(base, "half-authored", "notes.md"), "no entry point\n")
+	writeFile(t, filepath.Join(base, "stray-file.md"), "not a dir\n")
+
+	got := customSkillIds(project, "bmad")
+	want := []string{"eos-coach", "zeta"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("customSkillIds = %v, want %v", got, want)
+	}
+
+	if customSkillIds(t.TempDir(), "bmad") != nil {
+		t.Error("customSkillIds on empty project should be nil")
+	}
+	if !hasCustomSkillContent(project, "bmad") {
+		t.Error("hasCustomSkillContent = false, want true")
+	}
+}
+
+func TestCustomSkillDirBinding_Sync_CopiesVerbatim(t *testing.T) {
+	project := t.TempDir()
+	destRoot := t.TempDir()
+	t.Setenv("HOME", destRoot)
+
+	base := filepath.Join(project, "_bmad-custom", "skills", "eos-coach")
+	content := "# Coach\nReads {project-root}/_bmad/config.yaml verbatim\n"
+	writeFile(t, filepath.Join(base, "SKILL.md"), content)
+	writeFile(t, filepath.Join(base, "nested", "helper.md"), "helper\n")
+
+	b := NewCustomSkillDirBinding("bmad", project, []string{"eos-coach"})
+	n, err := b.Sync()
+	if err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("Sync synced %d, want 1", n)
+	}
+
+	got, err := os.ReadFile(filepath.Join(destRoot, ".claude", "skills", "eos-coach", "SKILL.md"))
+	if err != nil {
+		t.Fatalf("read synced SKILL.md: %v", err)
+	}
+	if string(got) != content {
+		t.Errorf("SKILL.md not copied verbatim:\ngot:  %q\nwant: %q", got, content)
+	}
+	if strings.Contains(string(got), "fallback") {
+		t.Error("custom skill must not receive the pack fallback footer")
+	}
+	if _, err := os.Stat(filepath.Join(destRoot, ".claude", "skills", "eos-coach", "nested", "helper.md")); err != nil {
+		t.Errorf("nested file not copied: %v", err)
+	}
+}
+
+func TestCustomSkillDirBinding_ArtifactsAndValidate(t *testing.T) {
+	project := t.TempDir()
+	destRoot := t.TempDir()
+	t.Setenv("HOME", destRoot)
+
+	base := filepath.Join(project, "_bmad-custom", "skills")
+	writeFile(t, filepath.Join(base, "eos-coach", "SKILL.md"), "# coach\n")
+
+	b := NewCustomSkillDirBinding("bmad", project, []string{"eos-coach"})
+	arts, err := b.Artifacts()
+	if err != nil {
+		t.Fatalf("Artifacts: %v", err)
+	}
+	want := []string{filepath.Join(destRoot, ".claude", "skills", "eos-coach")}
+	if !reflect.DeepEqual(arts, want) {
+		t.Errorf("Artifacts = %v, want %v", arts, want)
+	}
+	if err := b.Validate(); err != nil {
+		t.Errorf("Validate: %v", err)
+	}
+
+	missing := NewCustomSkillDirBinding("bmad", project, []string{"ghost"})
+	if err := missing.Validate(); err == nil {
+		t.Error("Validate should fail for a skill without SKILL.md")
+	}
+}
+
+func TestDiscoverCustomBindings_CollisionsAndPrune(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv("SIDESHOW_HOME", dataDir)
+
+	projectA := t.TempDir()
+	projectB := t.TempDir()
+	writeFile(t, filepath.Join(projectA, "_bmad-custom", "skills", "eos-coach", "SKILL.md"), "# a\n")
+	writeFile(t, filepath.Join(projectA, "_bmad-custom", "skills", "bmad-agent-dev", "SKILL.md"), "# collides with pack\n")
+	writeFile(t, filepath.Join(projectB, "_bmad-custom", "skills", "eos-coach", "SKILL.md"), "# b duplicate\n")
+	writeFile(t, filepath.Join(projectB, "_bmad-custom", "skills", "b-only", "SKILL.md"), "# b\n")
+
+	for _, p := range []string{projectA, projectB, filepath.Join(dataDir, "gone-project")} {
+		if _, err := RegisterCustomSource(p, "bmad"); err != nil {
+			t.Fatalf("register %s: %v", p, err)
+		}
+	}
+	// Re-register is a no-op.
+	added, err := RegisterCustomSource(projectA, "bmad")
+	if err != nil {
+		t.Fatalf("re-register: %v", err)
+	}
+	if added {
+		t.Error("re-register should not add a duplicate")
+	}
+
+	packs := []pack.InstalledPack{{Name: "bmad", Version: "6.3.0"}}
+	owners := map[string]string{"bmad-agent-dev": "bmad"}
+
+	got, err := discoverCustomBindings(packs, owners)
+	if err != nil {
+		t.Fatalf("discoverCustomBindings: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d bindings, want 2", len(got))
+	}
+
+	a := got[0].(*CustomSkillDirBinding)
+	b := got[1].(*CustomSkillDirBinding)
+	if !reflect.DeepEqual(a.skills, []string{"eos-coach"}) {
+		t.Errorf("project A skills = %v, want [eos-coach] (pack collision must be skipped)", a.skills)
+	}
+	if !reflect.DeepEqual(b.skills, []string{"b-only"}) {
+		t.Errorf("project B skills = %v, want [b-only] (cross-source duplicate must be skipped)", b.skills)
+	}
+
+	// The missing project must have been pruned from the registry.
+	sources, err := ListCustomSources()
+	if err != nil {
+		t.Fatalf("ListCustomSources: %v", err)
+	}
+	if len(sources) != 2 {
+		t.Errorf("registry has %d sources after prune, want 2: %v", len(sources), sources)
+	}
+	for _, s := range sources {
+		if strings.Contains(s.Project, "gone-project") {
+			t.Error("missing project not pruned from registry")
+		}
+	}
+}
+
+func TestDiscoverCustomBindings_PackNotInstalled(t *testing.T) {
+	t.Setenv("SIDESHOW_HOME", t.TempDir())
+
+	project := t.TempDir()
+	writeFile(t, filepath.Join(project, "_spectacle-custom", "skills", "spec-thing", "SKILL.md"), "# s\n")
+	if _, err := RegisterCustomSource(project, "spectacle"); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	got, err := discoverCustomBindings([]pack.InstalledPack{{Name: "bmad"}}, nil)
+	if err != nil {
+		t.Fatalf("discoverCustomBindings: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("got %d bindings for uninstalled pack, want 0", len(got))
+	}
+}
+
+func TestRunSync_RemovesCustomSkillWhenSourceGone(t *testing.T) {
+	destRoot := t.TempDir()
+	t.Setenv("HOME", destRoot)
+	t.Setenv("SIDESHOW_HOME", t.TempDir())
+
+	project := t.TempDir()
+	writeFile(t, filepath.Join(project, "_bmad-custom", "skills", "eos-coach", "SKILL.md"), "# coach\n")
+
+	b := NewCustomSkillDirBinding("bmad", project, []string{"eos-coach"})
+	if _, _, err := runSync([]Binding{b}); err != nil {
+		t.Fatalf("first runSync: %v", err)
+	}
+	synced := filepath.Join(destRoot, ".claude", "skills", "eos-coach")
+	if _, err := os.Stat(synced); err != nil {
+		t.Fatalf("custom skill not synced: %v", err)
+	}
+
+	// Next sync discovers no custom binding (source dropped) —
+	// reconcile must remove the stale skill.
+	_, removed, err := runSync(nil)
+	if err != nil {
+		t.Fatalf("second runSync: %v", err)
+	}
+	if removed != 1 {
+		t.Errorf("removed = %d, want 1", removed)
+	}
+	if _, err := os.Stat(synced); !os.IsNotExist(err) {
+		t.Errorf("stale custom skill still present: %v", err)
+	}
+}

--- a/internal/bindings/custom_sources.go
+++ b/internal/bindings/custom_sources.go
@@ -1,0 +1,107 @@
+package bindings
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/ArcavenAE/sideshow/internal/pack"
+	"gopkg.in/yaml.v3"
+)
+
+// CustomSources records consumer repos whose _<pack>-custom/skills/
+// content is bound on every sync. Without this registry, a sync run
+// from outside the consumer repo would not rediscover its custom
+// skills and the manifest reconcile would remove them as stale.
+type CustomSources struct {
+	SchemaVersion string         `yaml:"schema_version"`
+	UpdatedAt     string         `yaml:"updated_at"`
+	Sources       []CustomSource `yaml:"sources"`
+}
+
+// CustomSource is one registered consumer repo + pack pair.
+type CustomSource struct {
+	Project string `yaml:"project"` // absolute path to the consumer repo root
+	Pack    string `yaml:"pack"`
+}
+
+// customSourcesPath returns the registry location inside the sideshow
+// data dir (sibling of packs/, like sync-manifest.yaml).
+func customSourcesPath() string {
+	return filepath.Join(filepath.Dir(pack.PacksDir()), "custom-sources.yaml")
+}
+
+// loadCustomSources reads the registry. A missing file returns an
+// empty registry, not an error.
+func loadCustomSources() (*CustomSources, error) {
+	data, err := os.ReadFile(customSourcesPath())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &CustomSources{}, nil
+		}
+		return nil, fmt.Errorf("read custom sources: %w", err)
+	}
+	var s CustomSources
+	if err := yaml.Unmarshal(data, &s); err != nil {
+		return nil, fmt.Errorf("parse custom sources: %w", err)
+	}
+	return &s, nil
+}
+
+// saveCustomSources persists the registry.
+func saveCustomSources(sources []CustomSource) error {
+	s := CustomSources{
+		SchemaVersion: "0.1.0",
+		UpdatedAt:     time.Now().UTC().Format(time.RFC3339),
+		Sources:       sources,
+	}
+	data, err := yaml.Marshal(&s)
+	if err != nil {
+		return fmt.Errorf("marshal custom sources: %w", err)
+	}
+	path := customSourcesPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create sideshow dir: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("write custom sources: %w", err)
+	}
+	return nil
+}
+
+// RegisterCustomSource adds a consumer repo + pack pair to the
+// registry. The project path is normalized to absolute. Returns true
+// if the pair was newly added, false if it was already registered.
+func RegisterCustomSource(project, packName string) (bool, error) {
+	abs, err := filepath.Abs(project)
+	if err != nil {
+		return false, fmt.Errorf("resolve project path: %w", err)
+	}
+
+	reg, err := loadCustomSources()
+	if err != nil {
+		return false, err
+	}
+
+	for _, s := range reg.Sources {
+		if s.Project == abs && s.Pack == packName {
+			return false, nil
+		}
+	}
+
+	reg.Sources = append(reg.Sources, CustomSource{Project: abs, Pack: packName})
+	if err := saveCustomSources(reg.Sources); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// ListCustomSources returns the registered sources for status display.
+func ListCustomSources() ([]CustomSource, error) {
+	reg, err := loadCustomSources()
+	if err != nil {
+		return nil, err
+	}
+	return reg.Sources, nil
+}


### PR DESCRIPTION
## What

**Custom-skill bindings (closes #56).** New `custom-skill-dir` binding: consumer-repo `_<pack>-custom/skills/<name>/` dirs (with a `SKILL.md` entry point) are bound into `~/.claude/skills/` on `commands sync`, alongside pack skills.

Because the sync-manifest reconcile removes anything not re-discovered, custom skills need durable discovery: a **custom-sources registry** (`custom-sources.yaml`, sibling of `sync-manifest.yaml`) records consumer repos. Registration happens at `sideshow project init <pack>` or automatically when `commands sync` runs inside a repo with bindable custom skills. Missing projects prune from the registry; their artifacts reconcile away.

Rules: pack canonical ids win name collisions (warn + skip); cross-source duplicates skip (first registered wins); content copied verbatim — no store-path rewrites, no fallback footer (custom skills live in checked-in project territory, not the store).

**Help-flag safety (closes #57).** `-h`/`--help` anywhere on the command line prints usage before dispatch — previously `sideshow init --help` silently RAN init with defaults. Unknown `init` flags now error instead of being ignored.

Also: `status` lists registered custom sources; docs gain the `_<pack>-custom/skills/` convention and builder-output routing through the customization bridge (point bmb at `{project-root}/_bmad/custom/skills` so output resolves into checked-in `_bmad-custom/skills/`).

## Why

A bmb-built custom agent (eos-orc's `eos-coach`) was complete but unresolvable — built into a nested `.claude/skills/` nothing reads, with no sanctioned route from built to bound. Full analysis: aae-orc `_kos/findings/finding-076`.

## Testing

- 7 new tests: discovery filtering (SKILL.md required), verbatim copy, artifacts/validate, pack + cross-source collision handling, registry prune, reconcile removal when a source drops
- `go test ./...` green, `golangci-lint run` 0 issues
- E2E on eos-orc/eos follows on this branch's binary

Refs: aae-orc-gr1q, aae-orc-e8vq