### PR TITLE
fix(pack): preserve source file modes on install, verify exec-manifest

### DIFF
--- a/internal/pack/pack.go
+++ b/internal/pack/pack.go
@@ -473,18 +473,39 @@ func InstallFromLocal(name, sourcePath string, activate bool) error {
 			return os.MkdirAll(destPath, 0o755)
 		}
 
+		info, err := d.Info()
+		if err != nil {
+			return fmt.Errorf("stat %s: %w", path, err)
+		}
+		perm := info.Mode().Perm()
+
 		data, err := os.ReadFile(path)
 		if err != nil {
 			return fmt.Errorf("read %s: %w", path, err)
 		}
-		if err := os.WriteFile(destPath, data, 0o644); err != nil {
+		if err := os.WriteFile(destPath, data, perm); err != nil {
 			return fmt.Errorf("write %s: %w", destPath, err)
+		}
+		// WriteFile applies perm only at create time (and subject to
+		// umask); force the exact source mode so exec bits survive
+		// reinstalls over an existing tree. Read-only store freeze
+		// (aae-orc-dihj) must map 0755 -> 0555 here, never 0444.
+		if err := os.Chmod(destPath, perm); err != nil {
+			return fmt.Errorf("chmod %s: %w", destPath, err)
 		}
 		count++
 		return nil
 	})
 	if err != nil {
 		return fmt.Errorf("copy pack: %w", err)
+	}
+
+	// When the pack ships an executable census, the installed tree must
+	// match it. The build pipeline treats exec bits as a fatal invariant;
+	// the install path must not silently destroy the property at the
+	// last hop.
+	if err := verifyExecManifest(sourcePath, destDir); err != nil {
+		return err
 	}
 
 	// Create/flip the current symlink. A first install always activates
@@ -530,6 +551,49 @@ func InstallFromLocal(name, sourcePath string, activate bool) error {
 
 	fmt.Printf("Installed %d files to %s\n", count, destDir)
 	fmt.Println("Run 'sideshow commands sync' to update Claude Code commands.")
+	return nil
+}
+
+// execManifestName is the optional executable census emitted by the
+// sideshow-packs build pipeline: one pack-root-relative path per line,
+// each of which must carry an exec bit in the installed tree.
+const execManifestName = "exec-manifest.txt"
+
+// verifyExecManifest checks the installed tree at destDir against the
+// pack's exec-manifest.txt when the source ships one. Absence of the
+// manifest is not an error; any listed path that is missing or
+// non-executable after install is.
+func verifyExecManifest(sourcePath, destDir string) error {
+	data, err := os.ReadFile(filepath.Join(sourcePath, execManifestName))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read %s: %w", execManifestName, err)
+	}
+
+	var drift []string
+	for _, line := range strings.Split(string(data), "\n") {
+		rel := strings.TrimSpace(line)
+		if rel == "" || strings.HasPrefix(rel, "#") {
+			continue
+		}
+		info, err := os.Stat(filepath.Join(destDir, filepath.FromSlash(rel)))
+		switch {
+		case err != nil:
+			drift = append(drift, rel+" (missing)")
+		case info.Mode().Perm()&0o100 == 0:
+			drift = append(drift, rel+" (not executable)")
+		}
+	}
+	if len(drift) > 0 {
+		return fmt.Errorf(
+			"%s verification failed: installed tree at %s does not match "+
+				"the pack's executable census (%d of its entries drifted); "+
+				"the store copy should not be used:\n  %s",
+			execManifestName, destDir, len(drift), strings.Join(drift, "\n  "),
+		)
+	}
 	return nil
 }
 

--- a/internal/pack/pack_test.go
+++ b/internal/pack/pack_test.go
@@ -549,3 +549,88 @@ func TestInstallFromLocal_AlreadyUnifiedPassesThrough(t *testing.T) {
 		t.Errorf("expected core/config.yaml: %v", err)
 	}
 }
+
+// makeModeFixture creates a sideshow-native source pack containing one
+// executable and one plain file, returning its path.
+func makeModeFixture(t *testing.T) string {
+	t.Helper()
+	src := t.TempDir()
+	if err := os.WriteFile(filepath.Join(src, "pack.yaml"), []byte("name: modes\nversion: \"1.0.0\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(src, "bin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "bin", "tool.sh"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "doc.md"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return src
+}
+
+func TestInstallFromLocal_PreservesFileModes(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("SIDESHOW_HOME", home)
+	src := makeModeFixture(t)
+
+	if err := InstallFromLocal("modes", src, true); err != nil {
+		t.Fatalf("InstallFromLocal: %v", err)
+	}
+
+	packRoot := filepath.Join(home, "packs", "modes", "1.0.0")
+	tests := []struct {
+		rel  string
+		want os.FileMode
+	}{
+		{filepath.Join("bin", "tool.sh"), 0o755},
+		{"doc.md", 0o644},
+	}
+	for _, tt := range tests {
+		info, err := os.Stat(filepath.Join(packRoot, tt.rel))
+		if err != nil {
+			t.Fatalf("stat %s: %v", tt.rel, err)
+		}
+		if got := info.Mode().Perm(); got != tt.want {
+			t.Errorf("%s mode = %o, want %o", tt.rel, got, tt.want)
+		}
+	}
+}
+
+func TestInstallFromLocal_ExecManifestVerified(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("SIDESHOW_HOME", home)
+	src := makeModeFixture(t)
+	if err := os.WriteFile(filepath.Join(src, "exec-manifest.txt"), []byte("bin/tool.sh\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := InstallFromLocal("modes", src, true); err != nil {
+		t.Fatalf("InstallFromLocal with satisfied exec-manifest: %v", err)
+	}
+}
+
+func TestInstallFromLocal_ExecManifestDriftFailsLoudly(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("SIDESHOW_HOME", home)
+	src := makeModeFixture(t)
+	// Census references an entry the source does not satisfy: the listed
+	// path exists but is not executable, plus one missing path.
+	if err := os.Chmod(filepath.Join(src, "bin", "tool.sh"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "exec-manifest.txt"), []byte("bin/tool.sh\nbin/absent.sh\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := InstallFromLocal("modes", src, true)
+	if err == nil {
+		t.Fatal("InstallFromLocal succeeded despite exec-manifest drift")
+	}
+	for _, want := range []string{"exec-manifest.txt", "bin/tool.sh (not executable)", "bin/absent.sh (missing)"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q missing %q", err.Error(), want)
+		}
+	}
+}


### PR DESCRIPTION
Sideshow's install path silently destroys a property the build pipeline treats as fatal: every file lands in the store as 0644, so a pack that ships executables (vsdd-factory: 112 of them, including 5 dispatcher binaries and 21 bin/ scripts) installs broken and fails at first hook dispatch. The fix closes the last unprotected hop of the mode-bit chain.

Two changes in `InstallFromLocal`:

- The copy propagates each source entry's `Mode().Perm()`, with an explicit `Chmod` so the exact mode survives umask and reinstalls over an existing tree. A comment marks the coordination point for the store read-only freeze (aae-orc-dihj): freeze must map 0755 to 0555, never 0444.
- When the source root carries `exec-manifest.txt` (the sideshow-packs build pipeline's executable census), the installed tree is verified against it after copy; drift fails the install loudly, naming each missing or non-executable entry.

Coverage: three regression tests (0755 fixture survives, satisfied census passes, drifted census fails with named entries). Verified end-to-end against the real vsdd-factory rc.23 prototype tarball in a sandboxed `SIDESHOW_HOME`: 112/112 exec bits survive and the store census matches the signed manifest exactly.

Additive only; packs without a census see no behavior change beyond correct modes.

Refs: aae-orc-d3nq.1 (extends aae-orc-7dri parity scope; gates aae-orc-wk92's fetch path)