### PR TITLE
fix(pack): parse the activation contract; announce plugin-class packs

### DIFF
--- a/cmd/sideshow/main.go
+++ b/cmd/sideshow/main.go
@@ -665,6 +665,14 @@ func runStatus() error {
 
 	for _, p := range packs {
 		fmt.Printf("%s %s\n", p.Name, p.Version)
+		if act, actErr := pack.LoadActivation(p.Path); actErr == nil && act.PluginClass() {
+			scope := act.DefaultScope
+			if scope == "" {
+				scope = "per-repo"
+			}
+			fmt.Printf("  activation: %s (%s); bindings do not apply\n", act.Mechanism, scope)
+			continue
+		}
 		available, err := bindings.CountForPack(p.Name, p.Path)
 		if err != nil {
 			fmt.Printf("  available: error: %v\n", err)

--- a/internal/bindings/bindings.go
+++ b/internal/bindings/bindings.go
@@ -82,6 +82,15 @@ func Sync() error {
 	var all []Binding
 	packSkillOwners := make(map[string]string)
 	for _, p := range packs {
+		// Plugin-class packs activate outside the binding sync
+		// (per-repo, via their declared mechanism). Announce them
+		// instead of silently counting zero bindings, and never let
+		// their content leak into user-scope bindings.
+		if act, actErr := pack.LoadActivation(p.Path); actErr == nil && act.PluginClass() {
+			fmt.Printf("%s %s: plugin-class pack (%s); bindings do not apply, see the pack's enablement runbook\n",
+				p.Name, p.Version, act.Mechanism)
+			continue
+		}
 		discovered, err := DiscoverBindings(p)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "warning: discover %s: %v\n", p.Name, err)

--- a/internal/distribute/manifest.go
+++ b/internal/distribute/manifest.go
@@ -13,6 +13,8 @@ import (
 	"path/filepath"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/ArcavenAE/sideshow/internal/pack"
 )
 
 // Manifest is the distribute section of a pack.yaml.
@@ -75,9 +77,10 @@ type SymlinkArtifact struct {
 
 // PackYAML is the top-level pack.yaml with the distribute section.
 type PackYAML struct {
-	Name       string   `yaml:"name"`
-	Version    string   `yaml:"version"`
-	Distribute Manifest `yaml:"distribute"`
+	Name       string           `yaml:"name"`
+	Version    string           `yaml:"version"`
+	Activation *pack.Activation `yaml:"activation,omitempty"`
+	Distribute Manifest         `yaml:"distribute"`
 }
 
 // LoadPackYAML reads a pack.yaml file and returns its distribute manifest.

--- a/internal/pack/activation.go
+++ b/internal/pack/activation.go
@@ -1,0 +1,74 @@
+package pack
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Activation is the pack's activation contract from pack.yaml. Packs
+// with PerRepoRequired true are never active by default; Mechanism
+// names the binding kind that activates them (e.g. claude-plugin).
+type Activation struct {
+	DefaultScope          string `yaml:"default_scope"`
+	PerRepoRequired       bool   `yaml:"per_repo_required"`
+	Mechanism             string `yaml:"mechanism"`
+	Runbook               string `yaml:"runbook"`
+	ValidatedHarnessFloor string `yaml:"validated_harness_floor"`
+}
+
+// knownMechanisms are the activation mechanisms this sideshow version
+// recognizes. None are auto-activated yet; recognition only selects
+// the calmer install notice over the unrecognized-mechanism warning.
+var knownMechanisms = map[string]bool{
+	"claude-plugin": true,
+}
+
+// PluginClass reports whether the pack activates through a mechanism
+// outside sideshow's binding sync. Such packs must not be counted as
+// zero-binding defects, and the commands-sync hint does not apply.
+func (a *Activation) PluginClass() bool {
+	return a != nil && a.Mechanism != ""
+}
+
+// LoadActivation reads the activation block from root/pack.yaml.
+// Returns nil with no error when pack.yaml or the block is absent.
+func LoadActivation(root string) (*Activation, error) {
+	data, err := os.ReadFile(filepath.Join(root, "pack.yaml"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read pack.yaml: %w", err)
+	}
+	var doc struct {
+		Activation *Activation `yaml:"activation"`
+	}
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("parse pack.yaml: %w", err)
+	}
+	return doc.Activation, nil
+}
+
+// PrintInstallNotice announces the activation contract at install
+// time for plugin-class packs: the store copy is producer-validated
+// content only, nothing is enabled, and enablement is a documented
+// manual step.
+func (a *Activation) PrintInstallNotice() {
+	if !a.PluginClass() {
+		return
+	}
+	fmt.Printf("NOTE: this pack activates via %q, which sideshow does not activate yet.\n", a.Mechanism)
+	fmt.Println("The store copy is producer-validated content; nothing is enabled and 'commands sync' does not apply.")
+	if a.PerRepoRequired {
+		fmt.Println("Activation is per-repo only; never enable this pack at user scope.")
+	}
+	if a.Runbook != "" {
+		fmt.Printf("Enablement runbook: %s\n", a.Runbook)
+	}
+	if !knownMechanisms[a.Mechanism] {
+		fmt.Printf("WARNING: mechanism %q is not recognized by this sideshow version (recognized: claude-plugin); the pack may need a newer sideshow.\n", a.Mechanism)
+	}
+}

--- a/internal/pack/activation_test.go
+++ b/internal/pack/activation_test.go
@@ -1,0 +1,177 @@
+package pack
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadActivation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		yaml    string // empty means no pack.yaml at all
+		want    *Activation
+		wantErr bool
+		wantNil bool
+		hasYAML bool
+	}{
+		{
+			name:    "full block",
+			hasYAML: true,
+			yaml: "name: vsdd-factory\nversion: \"1.0.0-rc.23\"\n" +
+				"activation:\n  default_scope: per-repo\n  per_repo_required: true\n" +
+				"  mechanism: claude-plugin\n  runbook: https://example.com/runbook\n" +
+				"  validated_harness_floor: \"claude-code 2.1.220\"\n",
+			want: &Activation{
+				DefaultScope:          "per-repo",
+				PerRepoRequired:       true,
+				Mechanism:             "claude-plugin",
+				Runbook:               "https://example.com/runbook",
+				ValidatedHarnessFloor: "claude-code 2.1.220",
+			},
+		},
+		{
+			name:    "no activation block",
+			hasYAML: true,
+			yaml:    "name: plain\nversion: \"1.0.0\"\n",
+			wantNil: true,
+		},
+		{
+			name:    "no pack.yaml",
+			wantNil: true,
+		},
+		{
+			name:    "malformed yaml",
+			hasYAML: true,
+			yaml:    "activation: [not: a: map\n",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			root := t.TempDir()
+			if tt.hasYAML {
+				if err := os.WriteFile(filepath.Join(root, "pack.yaml"), []byte(tt.yaml), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			got, err := LoadActivation(root)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("LoadActivation: %v", err)
+			}
+			if tt.wantNil {
+				if got != nil {
+					t.Fatalf("expected nil activation, got %+v", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("expected activation, got nil")
+			}
+			if *got != *tt.want {
+				t.Errorf("activation = %+v, want %+v", *got, *tt.want)
+			}
+		})
+	}
+}
+
+func TestActivationPluginClass(t *testing.T) {
+	t.Parallel()
+	var nilAct *Activation
+	if nilAct.PluginClass() {
+		t.Error("nil activation must not be plugin-class")
+	}
+	if (&Activation{}).PluginClass() {
+		t.Error("empty mechanism must not be plugin-class")
+	}
+	if !(&Activation{Mechanism: "claude-plugin"}).PluginClass() {
+		t.Error("claude-plugin mechanism must be plugin-class")
+	}
+}
+
+// captureStdout runs fn with os.Stdout redirected and returns what it
+// printed.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+	t.Cleanup(func() { os.Stdout = old })
+	fn()
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = old
+	buf := make([]byte, 1<<16)
+	n, _ := r.Read(buf)
+	return string(buf[:n])
+}
+
+func TestInstallFromLocal_PluginClassNoticeReplacesSyncHint(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("SIDESHOW_HOME", home)
+	src := t.TempDir()
+	packYAML := "name: vsdd-factory\nversion: \"1.0.0-rc.23\"\n" +
+		"activation:\n  default_scope: per-repo\n  per_repo_required: true\n" +
+		"  mechanism: claude-plugin\n  runbook: https://example.com/runbook\n"
+	if err := os.WriteFile(filepath.Join(src, "pack.yaml"), []byte(packYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out := captureStdout(t, func() {
+		if err := InstallFromLocal("vsdd-factory", src, true); err != nil {
+			t.Errorf("InstallFromLocal: %v", err)
+		}
+	})
+
+	for _, want := range []string{
+		"activates via \"claude-plugin\"",
+		"nothing is enabled",
+		"per-repo only",
+		"https://example.com/runbook",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("install output missing %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "Run 'sideshow commands sync'") {
+		t.Errorf("sync hint must be suppressed for plugin-class packs:\n%s", out)
+	}
+	if strings.Contains(out, "WARNING") {
+		t.Errorf("recognized mechanism must not warn:\n%s", out)
+	}
+}
+
+func TestInstallFromLocal_UnknownMechanismWarns(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("SIDESHOW_HOME", home)
+	src := t.TempDir()
+	packYAML := "name: mystery\nversion: \"1.0.0\"\n" +
+		"activation:\n  mechanism: quantum-entangle\n"
+	if err := os.WriteFile(filepath.Join(src, "pack.yaml"), []byte(packYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out := captureStdout(t, func() {
+		if err := InstallFromLocal("mystery", src, true); err != nil {
+			t.Errorf("InstallFromLocal: %v", err)
+		}
+	})
+	if !strings.Contains(out, "WARNING") || !strings.Contains(out, "quantum-entangle") {
+		t.Errorf("unknown mechanism must warn by name:\n%s", out)
+	}
+}

--- a/internal/pack/pack.go
+++ b/internal/pack/pack.go
@@ -508,6 +508,11 @@ func InstallFromLocal(name, sourcePath string, activate bool) error {
 		return err
 	}
 
+	activation, err := LoadActivation(destDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "warning: read activation contract: %v\n", err)
+	}
+
 	// Create/flip the current symlink. A first install always activates
 	// (current + registry must exist); later installs honor the caller's
 	// activate flag so installing is no longer silently activating.
@@ -517,6 +522,7 @@ func InstallFromLocal(name, sourcePath string, activate bool) error {
 	if !activate && !firstInstall {
 		fmt.Printf("Installed %d files to %s\n", count, destDir)
 		fmt.Printf("Not activated: current stays as-is. Run 'sideshow use %s %s' to activate.\n", name, version)
+		activation.PrintInstallNotice()
 		return nil
 	}
 	_ = os.Remove(currentLink) // remove old symlink if exists
@@ -550,7 +556,11 @@ func InstallFromLocal(name, sourcePath string, activate bool) error {
 	}
 
 	fmt.Printf("Installed %d files to %s\n", count, destDir)
-	fmt.Println("Run 'sideshow commands sync' to update Claude Code commands.")
+	if activation.PluginClass() {
+		activation.PrintInstallNotice()
+	} else {
+		fmt.Println("Run 'sideshow commands sync' to update Claude Code commands.")
+	}
 	return nil
 }
 


### PR DESCRIPTION
A consumer installing the vsdd-factory pack today gets a silently inert 36.7MB store copy: the activation block in pack.yaml is dropped at parse time, install prints the commands-sync hint that does not apply, and sync counts zero artifacts without saying why. This closes that silent path with loud, accurate messaging at every surface a consumer touches.

Install now prints a producer-validated-only notice for plugin-class packs (nothing enabled, per-repo constraint, runbook pointer) and warns by name on mechanisms this sideshow version does not recognize. Sync announces plugin-class packs and excludes their content from binding discovery, which also guarantees per-repo-only content can never leak into user-scope bindings. Status shows the activation contract instead of misleading zero counts.

Coverage: table-driven LoadActivation tests, nil-safety, and two output-capture install tests (notice replaces hint; unknown mechanism warns). Smoke-tested against the real rc.23 store copy.

Interim slice ahead of aae-orc-f13j (Binding abstraction), which stays the structural home for full enforcement.

Refs: aae-orc-d3nq.2