### PR TITLE
fix(bindings): fail closed on unreadable activation, refuse user-scope sync for per-repo packs

### DIFF
--- a/cmd/sideshow/main.go
+++ b/cmd/sideshow/main.go
@@ -665,12 +665,23 @@ func runStatus() error {
 
 	for _, p := range packs {
 		fmt.Printf("%s %s\n", p.Name, p.Version)
-		if act, actErr := pack.LoadActivation(p.Path); actErr == nil && act.PluginClass() {
+		act, actErr := pack.LoadActivation(p.Path)
+		if actErr != nil {
+			// Fail closed, matching the sync loop: no binding counts
+			// for a pack whose activation contract cannot be read.
+			fmt.Printf("  activation: ERROR: %v; excluded from user-scope sync\n", actErr)
+			continue
+		}
+		if act.PluginClass() {
 			scope := act.DefaultScope
 			if scope == "" {
 				scope = "per-repo"
 			}
 			fmt.Printf("  activation: %s (%s); bindings do not apply\n", act.Mechanism, scope)
+			continue
+		}
+		if act != nil && act.PerRepoRequired {
+			fmt.Printf("  activation: per-repo required; user-scope bindings do not apply\n")
 			continue
 		}
 		available, err := bindings.CountForPack(p.Name, p.Path)

--- a/cmd/sideshow/main_test.go
+++ b/cmd/sideshow/main_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// captureStdout runs fn with os.Stdout redirected and returns what was
+// written.
+func captureStdout(t *testing.T, fn func() error) (string, error) {
+	t.Helper()
+	old := os.Stdout
+	r, w, pipeErr := os.Pipe()
+	if pipeErr != nil {
+		t.Fatalf("stdout pipe: %v", pipeErr)
+	}
+	os.Stdout = w
+	defer func() { os.Stdout = old }()
+
+	err := fn()
+	_ = w.Close()
+	var buf bytes.Buffer
+	if _, copyErr := io.Copy(&buf, r); copyErr != nil {
+		t.Fatalf("read stdout pipe: %v", copyErr)
+	}
+	return buf.String(), err
+}
+
+func TestRunStatus_FailsClosedOnUnreadableActivation(t *testing.T) {
+	home := t.TempDir()
+	store := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("SIDESHOW_HOME", store)
+
+	packPath := filepath.Join(store, "packs", "vsdd-factory", "1.0.0-rc.23")
+	if err := os.MkdirAll(packPath, 0o755); err != nil {
+		t.Fatalf("mkdirall: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(packPath, "pack.yaml"), []byte("activation: [unclosed\n"), 0o644); err != nil {
+		t.Fatalf("write pack.yaml: %v", err)
+	}
+	reg := fmt.Sprintf("packs:\n  - name: vsdd-factory\n    version: 1.0.0-rc.23\n    path: %s\n", packPath)
+	if err := os.WriteFile(filepath.Join(store, "registry.yaml"), []byte(reg), 0o644); err != nil {
+		t.Fatalf("write registry.yaml: %v", err)
+	}
+
+	out, err := captureStdout(t, runStatus)
+	if err != nil {
+		t.Fatalf("runStatus() error: %v", err)
+	}
+	if !strings.Contains(out, "activation: ERROR:") {
+		t.Errorf("status output missing activation ERROR line, got: %q", out)
+	}
+	if strings.Contains(out, "available:") {
+		t.Errorf("status evaluated bindings for a pack with unreadable activation (fail open), got: %q", out)
+	}
+}

--- a/internal/bindings/bindings.go
+++ b/internal/bindings/bindings.go
@@ -86,9 +86,23 @@ func Sync() error {
 		// (per-repo, via their declared mechanism). Announce them
 		// instead of silently counting zero bindings, and never let
 		// their content leak into user-scope bindings.
-		if act, actErr := pack.LoadActivation(p.Path); actErr == nil && act.PluginClass() {
+		act, actErr := pack.LoadActivation(p.Path)
+		if actErr != nil {
+			// Fail closed: an unreadable activation block could be
+			// hiding a per-repo-only declaration, so the pack is
+			// excluded from user-scope sync entirely.
+			fmt.Fprintf(os.Stderr, "ERROR: %s %s: activation unreadable (%v); excluded from user-scope sync\n",
+				p.Name, p.Version, actErr)
+			continue
+		}
+		if act.PluginClass() {
 			fmt.Printf("%s %s: plugin-class pack (%s); bindings do not apply, see the pack's enablement runbook\n",
 				p.Name, p.Version, act.Mechanism)
+			continue
+		}
+		if act != nil && act.PerRepoRequired {
+			fmt.Printf("%s %s: per-repo-required pack; user-scope bindings do not apply, see the pack's enablement runbook\n",
+				p.Name, p.Version)
 			continue
 		}
 		discovered, err := DiscoverBindings(p)

--- a/internal/bindings/bindings_test.go
+++ b/internal/bindings/bindings_test.go
@@ -1,0 +1,120 @@
+package bindings
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// captureOutput runs fn with os.Stdout and os.Stderr redirected and
+// returns what was written to each.
+func captureOutput(t *testing.T, fn func() error) (stdout, stderr string, err error) {
+	t.Helper()
+	oldOut, oldErr := os.Stdout, os.Stderr
+	rOut, wOut, pipeErr := os.Pipe()
+	if pipeErr != nil {
+		t.Fatalf("stdout pipe: %v", pipeErr)
+	}
+	rErr, wErr, pipeErr := os.Pipe()
+	if pipeErr != nil {
+		t.Fatalf("stderr pipe: %v", pipeErr)
+	}
+	os.Stdout, os.Stderr = wOut, wErr
+	defer func() { os.Stdout, os.Stderr = oldOut, oldErr }()
+
+	err = fn()
+	_ = wOut.Close()
+	_ = wErr.Close()
+	var bufOut, bufErr bytes.Buffer
+	if _, copyErr := io.Copy(&bufOut, rOut); copyErr != nil {
+		t.Fatalf("read stdout pipe: %v", copyErr)
+	}
+	if _, copyErr := io.Copy(&bufErr, rErr); copyErr != nil {
+		t.Fatalf("read stderr pipe: %v", copyErr)
+	}
+	return bufOut.String(), bufErr.String(), err
+}
+
+// registerTestPack writes a registry.yaml under sideshowHome listing a
+// single installed pack at packPath.
+func registerTestPack(t *testing.T, sideshowHome, name, version, packPath string) {
+	t.Helper()
+	reg := fmt.Sprintf("packs:\n  - name: %s\n    version: %s\n    path: %s\n", name, version, packPath)
+	writeFile(t, filepath.Join(sideshowHome, "registry.yaml"), reg)
+}
+
+// syncTestPack lays down a pack with bindable skill-dir content (which
+// WOULD be written to user scope if discovery ran) plus the given
+// pack.yaml content ("" means no pack.yaml at all), registers it, and
+// runs Sync.
+func syncTestPack(t *testing.T, packYAML string) (home, stdout, stderr string) {
+	t.Helper()
+	home = t.TempDir()
+	store := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("SIDESHOW_HOME", store)
+
+	packPath := filepath.Join(store, "packs", "vsdd-factory", "1.0.0-rc.23")
+	writeFile(t, filepath.Join(packPath, ".claude", "skills", "vsdd-probe", "SKILL.md"), "# probe\n")
+	if packYAML != "" {
+		writeFile(t, filepath.Join(packPath, "pack.yaml"), packYAML)
+	}
+	registerTestPack(t, store, "vsdd-factory", "1.0.0-rc.23", packPath)
+
+	stdout, stderr, err := captureOutput(t, Sync)
+	if err != nil {
+		t.Fatalf("Sync() error: %v", err)
+	}
+	return home, stdout, stderr
+}
+
+func TestSync_FailsClosedOnUnreadableActivation(t *testing.T) {
+	home, _, stderr := syncTestPack(t, "activation: [unclosed\n")
+
+	if !strings.Contains(stderr, "activation unreadable") {
+		t.Errorf("stderr missing fail-closed ERROR, got: %q", stderr)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".claude", "skills")); !os.IsNotExist(err) {
+		t.Errorf("user-scope skills dir exists: pack with unreadable activation was synced (fail open)")
+	}
+}
+
+func TestSync_SkipsPerRepoRequiredPack(t *testing.T) {
+	home, stdout, _ := syncTestPack(t, "activation:\n  per_repo_required: true\n")
+
+	if !strings.Contains(stdout, "per-repo-required pack") {
+		t.Errorf("stdout missing per-repo-required announcement, got: %q", stdout)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".claude", "skills")); !os.IsNotExist(err) {
+		t.Errorf("user-scope skills dir exists: per-repo-required pack was synced at user scope")
+	}
+}
+
+func TestSync_PluginClassPackStillSkipped(t *testing.T) {
+	home, stdout, _ := syncTestPack(t, "activation:\n  mechanism: claude-plugin\n  per_repo_required: true\n")
+
+	if !strings.Contains(stdout, "plugin-class pack") {
+		t.Errorf("stdout missing plugin-class announcement, got: %q", stdout)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".claude", "skills")); !os.IsNotExist(err) {
+		t.Errorf("user-scope skills dir exists: plugin-class pack was synced at user scope")
+	}
+}
+
+// The positive control: a pack with no pack.yaml syncs normally, which
+// proves the fixture WOULD write to user scope if the guards above
+// failed open.
+func TestSync_PositiveControl_PlainPackSyncs(t *testing.T) {
+	home, stdout, _ := syncTestPack(t, "")
+
+	if !strings.Contains(stdout, "Synced") {
+		t.Errorf("stdout missing sync summary, got: %q", stdout)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".claude", "skills", "vsdd-probe", "SKILL.md")); err != nil {
+		t.Errorf("expected synced skill at user scope, stat: %v", err)
+	}
+}


### PR DESCRIPTION
The plugin-class guard failed open: an unreadable or malformed pack.yaml bypassed the skip at both call sites, and binding discovery ran anyway. Harmless today only by accident of layout; once the plugin-layout discoverer lands, that accident goes away and a truncated pack.yaml on a vsdd store version would let a user-scope sync write 126 skill dirs machine-wide with no consent (the exact injection the per-repo containment mandate forbids).

Sync and status now skip any pack whose activation block cannot be read, reporting it as an ERROR, and packs declaring per_repo_required are refused at user scope even when they declare no mechanism. Proven by test at both call sites, including a positive control showing the fixture would write user-scope content if the guards failed open.

Additive guard only; packs with readable pack.yaml (or none) behave exactly as before.

Refs: aae-orc-d3nq.8, finding-094