### PR TITLE
feat(bindings): plugin-layout discovery, refused from user-scope sync

### DIFF
--- a/internal/bindings/bindings.go
+++ b/internal/bindings/bindings.go
@@ -5,6 +5,7 @@
 package bindings
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -47,6 +48,15 @@ func DiscoverBindings(p pack.InstalledPack) ([]Binding, error) {
 	packPath, err := filepath.EvalSymlinks(p.Path)
 	if err != nil {
 		return nil, fmt.Errorf("resolve pack path %s: %w", p.Path, err)
+	}
+
+	// Plugin-layout trees are refused here structurally, independent of
+	// the activation-block guard in Sync: even a plugin pack with no
+	// pack.yaml at all (so the activation guard cannot fire) never has
+	// its content discovered for user scope. The per-repo path uses
+	// DiscoverPluginLayout instead.
+	if IsPluginLayout(packPath) {
+		return nil, fmt.Errorf("%s %s: %w", p.Name, p.Version, ErrPluginLayout)
 	}
 
 	var result []Binding
@@ -106,6 +116,11 @@ func Sync() error {
 			continue
 		}
 		discovered, err := DiscoverBindings(p)
+		if errors.Is(err, ErrPluginLayout) {
+			fmt.Fprintf(os.Stderr, "ERROR: %s %s: plugin-layout tree with no readable activation contract; excluded from user-scope sync\n",
+				p.Name, p.Version)
+			continue
+		}
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "warning: discover %s: %v\n", p.Name, err)
 			continue

--- a/internal/bindings/plugin_layout.go
+++ b/internal/bindings/plugin_layout.go
@@ -1,0 +1,146 @@
+package bindings
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/ArcavenAE/sideshow/internal/pack"
+)
+
+// ErrPluginLayout marks a pack whose tree is plugin-shaped
+// (.claude-plugin/plugin.json plus top-level content dirs). Such packs
+// activate per repo through the unshaping path (docs/unshaping-spec.md)
+// and must never be swept into user-scope binding sync: their skills
+// alone would put a hundred-plus entries into $HOME/.claude with no
+// per-repo consent.
+var ErrPluginLayout = errors.New("plugin-layout pack: activates per repo, not via user-scope sync")
+
+// pluginContentDirs are the top-level directories whose presence
+// (beside .claude-plugin/plugin.json) identifies the plugin layout.
+var pluginContentDirs = []string{"skills", "agents", "hooks", "commands"}
+
+// pluginExcludedSkills are upstream skill dirs the unshaping spec
+// replaces rather than materializes: both write into the frozen shared
+// store (activate renders hooks.json into it, deactivate deletes it).
+// Sideshow-authored replacements ship separately (aae-orc-d3nq.60).
+var pluginExcludedSkills = map[string]bool{
+	"activate":   true,
+	"deactivate": true,
+}
+
+// IsPluginLayout reports whether packPath holds a plugin-shaped tree:
+// .claude-plugin/plugin.json at the root plus at least one recognized
+// top-level content directory.
+func IsPluginLayout(packPath string) bool {
+	manifest := filepath.Join(packPath, ".claude-plugin", "plugin.json")
+	if info, err := os.Stat(manifest); err != nil || info.IsDir() {
+		return false
+	}
+	for _, dir := range pluginContentDirs {
+		if info, err := os.Stat(filepath.Join(packPath, dir)); err == nil && info.IsDir() {
+			return true
+		}
+	}
+	return false
+}
+
+// PluginInventory is the discovery surface of a plugin-shaped tree:
+// the units the unshaping spec materializes into a repo (skills,
+// agents) plus the hook platform templates the enable path reads to
+// derive the settings event set. Store-referenced units (bin/,
+// hook-plugins/, templates/, ...) are deliberately absent: they never
+// enter a repo (docs/unshaping-spec.md).
+type PluginInventory struct {
+	// SkillDirs are top-level skills/<name>/ entries carrying a
+	// SKILL.md, relative to the pack root, excluded pairs removed.
+	SkillDirs []string
+	// ExcludedSkills are the replace-disposition skill dirs found in
+	// the tree (skills/activate, skills/deactivate when present).
+	ExcludedSkills []string
+	// AgentFiles are every file under agents/, relative to the pack
+	// root. Nested layouts are preserved: the harness loads them and
+	// addresses agents by bare frontmatter name (trial T20).
+	AgentFiles []string
+	// HookTemplates are hooks/hooks.json.<platform> template paths,
+	// relative to the pack root.
+	HookTemplates []string
+}
+
+// DiscoverPluginLayout inventories a plugin-shaped pack for the
+// per-repo enable path.
+//
+// CONTAINMENT: this function must only be called from an explicit
+// repo-scope enable request naming one repo. It is intentionally not
+// called from DiscoverBindings or Sync; those refuse plugin-layout
+// packs with ErrPluginLayout, and TestSync_RefusesPluginLayoutPack
+// locks the refusal in.
+func DiscoverPluginLayout(p pack.InstalledPack) (*PluginInventory, error) {
+	packPath, err := filepath.EvalSymlinks(p.Path)
+	if err != nil {
+		return nil, fmt.Errorf("resolve pack path %s: %w", p.Path, err)
+	}
+	if !IsPluginLayout(packPath) {
+		return nil, fmt.Errorf("%s %s: not a plugin-layout tree", p.Name, p.Version)
+	}
+
+	inv := &PluginInventory{}
+
+	skillEntries, err := os.ReadDir(filepath.Join(packPath, "skills"))
+	if err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("read skills dir: %w", err)
+	}
+	for _, e := range skillEntries {
+		if !e.IsDir() {
+			continue
+		}
+		rel := filepath.Join("skills", e.Name())
+		if pluginExcludedSkills[e.Name()] {
+			inv.ExcludedSkills = append(inv.ExcludedSkills, rel)
+			continue
+		}
+		if _, err := os.Stat(filepath.Join(packPath, rel, "SKILL.md")); err == nil {
+			inv.SkillDirs = append(inv.SkillDirs, rel)
+		}
+	}
+
+	agentsRoot := filepath.Join(packPath, "agents")
+	if _, err := os.Stat(agentsRoot); err == nil {
+		walkErr := filepath.WalkDir(agentsRoot, func(path string, d os.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() {
+				return nil
+			}
+			rel, relErr := filepath.Rel(packPath, path)
+			if relErr != nil {
+				return relErr
+			}
+			inv.AgentFiles = append(inv.AgentFiles, rel)
+			return nil
+		})
+		if walkErr != nil {
+			return nil, fmt.Errorf("walk agents dir: %w", walkErr)
+		}
+	}
+
+	hookEntries, err := os.ReadDir(filepath.Join(packPath, "hooks"))
+	if err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("read hooks dir: %w", err)
+	}
+	for _, e := range hookEntries {
+		if !e.IsDir() && strings.HasPrefix(e.Name(), "hooks.json.") {
+			inv.HookTemplates = append(inv.HookTemplates, filepath.Join("hooks", e.Name()))
+		}
+	}
+
+	sort.Strings(inv.SkillDirs)
+	sort.Strings(inv.ExcludedSkills)
+	sort.Strings(inv.AgentFiles)
+	sort.Strings(inv.HookTemplates)
+	return inv, nil
+}

--- a/internal/bindings/plugin_layout_test.go
+++ b/internal/bindings/plugin_layout_test.go
@@ -1,0 +1,152 @@
+package bindings
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ArcavenAE/sideshow/internal/pack"
+)
+
+// writePluginTree lays down a minimal plugin-shaped tree: manifest,
+// three skills (one excluded pair member), flat + nested agents, hook
+// platform templates, and a decoy .claude/skills dir that user-scope
+// discovery would bind if the layout refusal failed.
+func writePluginTree(t *testing.T, root string) {
+	t.Helper()
+	writeFile(t, filepath.Join(root, ".claude-plugin", "plugin.json"), `{"name":"vsdd-factory","version":"1.0.0-rc.23"}`)
+	writeFile(t, filepath.Join(root, "skills", "pr-manager", "SKILL.md"), "# pr-manager\n")
+	writeFile(t, filepath.Join(root, "skills", "check-state-health", "SKILL.md"), "# check-state-health\n")
+	writeFile(t, filepath.Join(root, "skills", "activate", "SKILL.md"), "# activate\n")
+	writeFile(t, filepath.Join(root, "skills", "deactivate", "SKILL.md"), "# deactivate\n")
+	writeFile(t, filepath.Join(root, "skills", "no-entrypoint", "notes.txt"), "not a skill\n")
+	writeFile(t, filepath.Join(root, "agents", "adversary.md"), "---\nname: adversary\n---\n")
+	writeFile(t, filepath.Join(root, "agents", "orchestrator", "orchestrator.md"), "---\nname: orchestrator\n---\n")
+	writeFile(t, filepath.Join(root, "agents", "orchestrator", "sequence-01.md"), "# seq\n")
+	writeFile(t, filepath.Join(root, "hooks", "hooks.json.darwin-arm64"), "{}\n")
+	writeFile(t, filepath.Join(root, "hooks", "hooks.json.template"), "{}\n")
+	writeFile(t, filepath.Join(root, "hooks", "guard.sh"), "#!/bin/sh\n")
+	writeFile(t, filepath.Join(root, ".claude", "skills", "decoy", "SKILL.md"), "# decoy\n")
+}
+
+func TestIsPluginLayout(t *testing.T) {
+	root := t.TempDir()
+	if IsPluginLayout(root) {
+		t.Error("empty dir reported as plugin layout")
+	}
+	writePluginTree(t, root)
+	if !IsPluginLayout(root) {
+		t.Error("plugin tree not recognized")
+	}
+
+	// Manifest alone, no content dirs: not the layout.
+	bare := t.TempDir()
+	writeFile(t, filepath.Join(bare, ".claude-plugin", "plugin.json"), "{}")
+	if IsPluginLayout(bare) {
+		t.Error("manifest without content dirs reported as plugin layout")
+	}
+
+	// Content dirs without the manifest: not the layout (bmad-shaped
+	// packs have .claude/ content and must keep binding normally).
+	noManifest := t.TempDir()
+	writeFile(t, filepath.Join(noManifest, "skills", "x", "SKILL.md"), "# x\n")
+	if IsPluginLayout(noManifest) {
+		t.Error("content dirs without plugin.json reported as plugin layout")
+	}
+}
+
+func TestDiscoverPluginLayout_Inventory(t *testing.T) {
+	root := t.TempDir()
+	writePluginTree(t, root)
+
+	inv, err := DiscoverPluginLayout(pack.InstalledPack{Name: "vsdd-factory", Version: "1.0.0-rc.23", Path: root})
+	if err != nil {
+		t.Fatalf("DiscoverPluginLayout: %v", err)
+	}
+
+	wantSkills := []string{"skills/check-state-health", "skills/pr-manager"}
+	if len(inv.SkillDirs) != len(wantSkills) {
+		t.Fatalf("SkillDirs = %v, want %v", inv.SkillDirs, wantSkills)
+	}
+	for i, w := range wantSkills {
+		if inv.SkillDirs[i] != w {
+			t.Errorf("SkillDirs[%d] = %q, want %q", i, inv.SkillDirs[i], w)
+		}
+	}
+
+	wantExcluded := []string{"skills/activate", "skills/deactivate"}
+	if len(inv.ExcludedSkills) != 2 || inv.ExcludedSkills[0] != wantExcluded[0] || inv.ExcludedSkills[1] != wantExcluded[1] {
+		t.Errorf("ExcludedSkills = %v, want %v", inv.ExcludedSkills, wantExcluded)
+	}
+
+	wantAgents := []string{"agents/adversary.md", "agents/orchestrator/orchestrator.md", "agents/orchestrator/sequence-01.md"}
+	if len(inv.AgentFiles) != len(wantAgents) {
+		t.Fatalf("AgentFiles = %v, want %v", inv.AgentFiles, wantAgents)
+	}
+	for i, w := range wantAgents {
+		if inv.AgentFiles[i] != w {
+			t.Errorf("AgentFiles[%d] = %q, want %q", i, inv.AgentFiles[i], w)
+		}
+	}
+
+	wantHooks := []string{"hooks/hooks.json.darwin-arm64", "hooks/hooks.json.template"}
+	if len(inv.HookTemplates) != 2 || inv.HookTemplates[0] != wantHooks[0] || inv.HookTemplates[1] != wantHooks[1] {
+		t.Errorf("HookTemplates = %v, want %v", inv.HookTemplates, wantHooks)
+	}
+}
+
+// The containment lock (aae-orc-d3nq.49): a plugin-layout pack with NO
+// pack.yaml (so the activation-block guard cannot fire) and a decoy
+// .claude/skills dir that would otherwise bind is still refused by
+// user-scope sync with zero writes.
+func TestSync_RefusesPluginLayoutPack(t *testing.T) {
+	home := t.TempDir()
+	store := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("SIDESHOW_HOME", store)
+
+	packPath := filepath.Join(store, "packs", "vsdd-factory", "1.0.0-rc.23")
+	writePluginTree(t, packPath)
+	registerTestPack(t, store, "vsdd-factory", "1.0.0-rc.23", packPath)
+
+	_, stderr, err := captureOutput(t, Sync)
+	if err != nil {
+		t.Fatalf("Sync() error: %v", err)
+	}
+	if !strings.Contains(stderr, "plugin-layout tree") {
+		t.Errorf("stderr missing plugin-layout refusal, got: %q", stderr)
+	}
+	if _, statErr := os.Stat(filepath.Join(home, ".claude", "skills")); !os.IsNotExist(statErr) {
+		t.Errorf("user-scope skills dir exists: plugin-layout pack content leaked into user scope")
+	}
+}
+
+// Env-gated check against a real vsdd-factory tree. Run manually:
+//
+//	VSDD_TREE=/path/to/vsdd-factory/plugins/vsdd-factory go test ./internal/bindings/ -run RealTree
+//
+// At v1.0.0-rc.23 the expected counts are 124 skill dirs (126 minus
+// the activate/deactivate pair), 44 agent files, 6 hook templates.
+func TestDiscoverPluginLayout_RealTree(t *testing.T) {
+	tree := os.Getenv("VSDD_TREE")
+	if tree == "" {
+		t.Skip("VSDD_TREE not set; real-tree inventory check skipped")
+	}
+	inv, err := DiscoverPluginLayout(pack.InstalledPack{Name: "vsdd-factory", Version: "real-tree", Path: tree})
+	if err != nil {
+		t.Fatalf("DiscoverPluginLayout: %v", err)
+	}
+	if got := len(inv.SkillDirs); got != 124 {
+		t.Errorf("SkillDirs = %d, want 124", got)
+	}
+	if got := len(inv.ExcludedSkills); got != 2 {
+		t.Errorf("ExcludedSkills = %d, want 2", got)
+	}
+	if got := len(inv.AgentFiles); got != 44 {
+		t.Errorf("AgentFiles = %d, want 44", got)
+	}
+	if got := len(inv.HookTemplates); got != 6 {
+		t.Errorf("HookTemplates = %d, want 6", got)
+	}
+}


### PR DESCRIPTION
The unshaping build chain needs a discoverer that recognizes plugin-shaped trees and emits the binding set the unshaping spec declares. It also needs the opposite guarantee: that user-scope sync can NEVER reach that content, because a plugin pack's skills alone would put 126 entries into $HOME/.claude with no per-repo consent.

This PR adds both. DiscoverPluginLayout inventories skills (minus the activate/deactivate replace pair), agent files (nested layouts preserved), and hook platform templates, for the per-repo enable path only. DiscoverBindings structurally refuses plugin-layout trees with a sentinel error, independent of the activation-block guard, so even a pack with no pack.yaml at all (where the fail-closed guard from #63 cannot fire) stays out of user scope; the test plants a decoy .claude/skills dir inside the plugin tree and asserts zero writes.

An env-gated test verifies the discoverer produces the exact declared rc.23 set (124 skill dirs, 44 agent files, 6 templates) against a real tree; run locally, passing.

Refs: aae-orc-d3nq.49