### PR TITLE
feat(coexist): read-only foreign-install census and coexistence findings

### DIFF
--- a/cmd/sideshow/coexist.go
+++ b/cmd/sideshow/coexist.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/ArcavenAE/sideshow/internal/foreign"
+	"github.com/ArcavenAE/sideshow/internal/pack"
+)
+
+// runCoexist is the read-only coexistence census:
+//
+//	sideshow coexist <pack> [--repo <path>] [--sideshow-active]
+//
+// It reports foreign installs of the pack (any marketplace, matched
+// by name), the repo-level effective/suppressed/orphaned enablement,
+// and doctor-graded findings. It never mutates harness state.
+// --sideshow-active asserts that sideshow bindings for the pack are
+// effective in the repo; once the repo-bindings ledger ships (.7)
+// that signal is read from the ledger instead.
+func runCoexist(args []string) error {
+	if len(args) < 1 || len(args[0]) == 0 || args[0][0] == '-' {
+		return fmt.Errorf("usage: sideshow coexist <pack> [--repo <path>] [--sideshow-active]")
+	}
+	packName := args[0]
+	repoDir, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("resolve working directory: %w", err)
+	}
+	sideshowActive := false
+	for i := 1; i < len(args); i++ {
+		switch args[i] {
+		case "--repo":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--repo requires a path")
+			}
+			i++
+			repoDir = args[i]
+		case "--sideshow-active":
+			sideshowActive = true
+		default:
+			return fmt.Errorf("unknown flag: %s", args[i])
+		}
+	}
+
+	census, err := foreign.TakeCensus(foreign.ConfigDir(), packName)
+	if err != nil {
+		return err
+	}
+	view, err := census.ResolveRepo(repoDir)
+	if err != nil {
+		return err
+	}
+
+	// The per-repo mandate comes from the installed pack's activation
+	// contract when the pack is in the store; a pack that is not
+	// installed is graded conservatively (a guard that under-warns is
+	// worse than one that over-warns).
+	perRepoRequired := true
+	if p := findInstalledPack(packName); p != nil {
+		if act, actErr := pack.LoadActivation(p.Path); actErr == nil && act != nil {
+			perRepoRequired = act.PerRepoRequired
+		}
+	}
+
+	fmt.Printf("Foreign installs of %s (machine level):\n", packName)
+	if len(census.Installs) == 0 {
+		fmt.Println("  none")
+	}
+	for _, in := range census.Installs {
+		legacy := ""
+		if in.Legacy {
+			legacy = "  [LEGACY pre-rc.7 identity]"
+		}
+		treeNote := in.TreeVersion
+		if treeNote == "" {
+			treeNote = "unreadable"
+		}
+		fmt.Printf("  %s  scope=%s  registry=%s  tree=%s  sha=%s%s\n",
+			in.Identity, in.Scope, in.Version, treeNote, in.GitCommitSha, legacy)
+		if in.TreeVersion != "" && in.TreeVersion != in.Version {
+			fmt.Printf("    note: tree version differs from the registry label; the tree is the authority (git-subdir sources drift)\n")
+		}
+	}
+
+	fmt.Printf("\nRepo %s:\n", repoDir)
+	fmt.Printf("  effectively enabled: %v\n", orNone(view.EffectivelyEnabled))
+	fmt.Printf("  suppressed here:     %v\n", orNone(view.Suppressed))
+	if len(view.Orphans) > 0 {
+		fmt.Println("  orphaned enables:")
+		for _, o := range view.Orphans {
+			fmt.Printf("    %s (%s scope, %s)\n", o.Identity, o.Scope, o.Path)
+		}
+	}
+
+	findings := foreign.Diagnose(census, view, sideshowActive, perRepoRequired)
+	if len(findings) > 0 {
+		fmt.Println()
+		for _, f := range findings {
+			fmt.Printf("%s [%s]: %s\n", f.Severity, f.Code, f.Message)
+		}
+	}
+	return nil
+}
+
+func orNone(items []string) string {
+	if len(items) == 0 {
+		return "none"
+	}
+	out := items[0]
+	for _, s := range items[1:] {
+		out += ", " + s
+	}
+	return out
+}
+
+// findInstalledPack returns the registry entry for a pack in the
+// sideshow store, or nil.
+func findInstalledPack(name string) *pack.InstalledPack {
+	packs, err := pack.List()
+	if err != nil {
+		return nil
+	}
+	for i := range packs {
+		if packs[i].Name == name {
+			return &packs[i]
+		}
+	}
+	return nil
+}

--- a/cmd/sideshow/main.go
+++ b/cmd/sideshow/main.go
@@ -39,6 +39,7 @@ Usage:
   sideshow project init <pack>            Apply consumer-repo convention to cwd and
                                           register it as a custom-skills source
   sideshow status                         Show installation status
+  sideshow coexist <pack> [--repo <path>]  Read-only foreign-install census and coexistence findings
   sideshow version                        Show version
 
 Install options:
@@ -121,6 +122,8 @@ func main() {
 		}
 	case "status":
 		err = runStatus()
+	case "coexist":
+		err = runCoexist(os.Args[2:])
 	case "version", "--version", "-V":
 		fmt.Printf("sideshow %s\n", version)
 	case "help", "--help", "-h":

--- a/internal/foreign/census.go
+++ b/internal/foreign/census.go
@@ -1,0 +1,301 @@
+// Package foreign reads and classifies FOREIGN harness plugin state:
+// claude-mp (or any marketplace) installs of packs that sideshow
+// delivers by repo bindings. It is the conversion-side surface behind
+// the coexistence guard (aae-orc-paqn), coexist-check, and adopt.
+//
+// Everything in this package is READ-ONLY. Sideshow never
+// auto-retires, auto-disables, or auto-uninstalls a foreign install;
+// mutations of foreign state happen only through documented claude
+// verbs with explicit consent, outside this package.
+//
+// Ground truth for every parsed shape: aae-orc finding-091 addendum 3
+// (executed trials, Claude Code 2.1.220) and
+// docs/claude-plugin-conversion-reference.md.
+package foreign
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// ConfigDir returns the harness config directory: CLAUDE_CONFIG_DIR
+// when set, else ~/.claude.
+func ConfigDir() string {
+	if d := os.Getenv("CLAUDE_CONFIG_DIR"); d != "" {
+		return d
+	}
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".claude")
+}
+
+// Install is one entry of a foreign identity's install array in
+// installed_plugins.json (format version 2).
+type Install struct {
+	Identity     string // vsdd-factory@claude-mp
+	PluginName   string // vsdd-factory
+	Marketplace  string // claude-mp
+	Scope        string // user | project | local
+	InstallPath  string
+	Version      string // registry-recorded; NOT authoritative for git-subdir sources
+	GitCommitSha string
+	ProjectPath  string // present on project-scope installs
+	// TreeVersion is the version read from the installed tree's
+	// .claude-plugin/plugin.json — the version authority (the
+	// marketplace serves ref-pinned content under a static label).
+	// Empty when the installPath is missing or unreadable.
+	TreeVersion string
+	// Legacy marks the pre-rc.7 identity registered through the
+	// retired drbothen/vsdd-factory marketplace.
+	Legacy bool
+}
+
+// OrphanedEnable is an enabledPlugins entry naming an identity with
+// no install record behind it. The harness is SILENT about these at
+// both the CLI and session layers (trial T14); only a census finds
+// them.
+type OrphanedEnable struct {
+	Identity string
+	Scope    string // user | project | local
+	Enabled  bool
+	Path     string // settings file carrying the entry
+}
+
+// enableEntry is one scope's enabledPlugins verdict for an identity.
+type enableEntry struct {
+	value bool
+	path  string
+}
+
+// Census is the machine-level view of foreign installs for one pack.
+type Census struct {
+	Pack        string
+	ConfigDir   string
+	Installs    []Install
+	userEnables map[string]enableEntry // identity -> user-scope entry
+	installed   map[string]bool        // identity -> has install record
+}
+
+// legacyMarketplaces are marketplace names whose identities predate
+// the current upstream channel (README migration note; register
+// wrinkle plugin-identity-registration).
+var legacyMarketplaces = map[string]bool{
+	"vsdd-factory": true,
+}
+
+// installedPluginsFile mirrors the v2 format observed in trials.
+type installedPluginsFile struct {
+	Version int                       `json:"version"`
+	Plugins map[string][]installEntry `json:"plugins"`
+}
+
+type installEntry struct {
+	Scope        string `json:"scope"`
+	InstallPath  string `json:"installPath"`
+	Version      string `json:"version"`
+	GitCommitSha string `json:"gitCommitSha"`
+	ProjectPath  string `json:"projectPath"`
+}
+
+type settingsFile struct {
+	EnabledPlugins map[string]bool `json:"enabledPlugins"`
+}
+
+// splitIdentity separates <plugin>@<marketplace>. The marketplace
+// name is everything after the FIRST @ (plugin names carry no @).
+func splitIdentity(identity string) (plugin, marketplace string) {
+	if i := strings.Index(identity, "@"); i >= 0 {
+		return identity[:i], identity[i+1:]
+	}
+	return identity, ""
+}
+
+// readEnables loads the enabledPlugins map from one settings file.
+// A missing file is an empty map; an unreadable or malformed file is
+// an error (the guard must not classify on partial state).
+func readEnables(path string) (map[string]enableEntry, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return map[string]enableEntry{}, nil
+		}
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	var s settingsFile
+	if err := json.Unmarshal(data, &s); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	out := make(map[string]enableEntry, len(s.EnabledPlugins))
+	for id, v := range s.EnabledPlugins {
+		out[id] = enableEntry{value: v, path: path}
+	}
+	return out, nil
+}
+
+// treeVersion reads the version authority from an installed tree.
+func treeVersion(installPath string) string {
+	data, err := os.ReadFile(filepath.Join(installPath, ".claude-plugin", "plugin.json"))
+	if err != nil {
+		return ""
+	}
+	var m struct {
+		Version string `json:"version"`
+	}
+	if err := json.Unmarshal(data, &m); err != nil {
+		return ""
+	}
+	return m.Version
+}
+
+// TakeCensus reads the machine-level foreign state for one pack from
+// a harness config dir: every install record whose plugin name
+// matches the pack (any marketplace, per the name-field-only
+// detection rule), plus the user-scope enable entries.
+func TakeCensus(configDir, pack string) (*Census, error) {
+	c := &Census{
+		Pack:        pack,
+		ConfigDir:   configDir,
+		userEnables: map[string]enableEntry{},
+		installed:   map[string]bool{},
+	}
+
+	regPath := filepath.Join(configDir, "plugins", "installed_plugins.json")
+	data, err := os.ReadFile(regPath)
+	switch {
+	case os.IsNotExist(err):
+		// No plugin registry at all: nothing installed.
+	case err != nil:
+		return nil, fmt.Errorf("read %s: %w", regPath, err)
+	default:
+		var reg installedPluginsFile
+		if err := json.Unmarshal(data, &reg); err != nil {
+			return nil, fmt.Errorf("parse %s: %w", regPath, err)
+		}
+		for identity, entries := range reg.Plugins {
+			plugin, mp := splitIdentity(identity)
+			if plugin != pack {
+				continue
+			}
+			c.installed[identity] = true
+			for _, e := range entries {
+				c.Installs = append(c.Installs, Install{
+					Identity:     identity,
+					PluginName:   plugin,
+					Marketplace:  mp,
+					Scope:        e.Scope,
+					InstallPath:  e.InstallPath,
+					Version:      e.Version,
+					GitCommitSha: e.GitCommitSha,
+					ProjectPath:  e.ProjectPath,
+					TreeVersion:  treeVersion(e.InstallPath),
+					Legacy:       legacyMarketplaces[mp],
+				})
+			}
+		}
+		sort.Slice(c.Installs, func(i, j int) bool {
+			if c.Installs[i].Identity != c.Installs[j].Identity {
+				return c.Installs[i].Identity < c.Installs[j].Identity
+			}
+			return c.Installs[i].Scope < c.Installs[j].Scope
+		})
+	}
+
+	c.userEnables, err = readEnables(filepath.Join(configDir, "settings.json"))
+	if err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+// RepoView resolves the census against one repo's settings scopes.
+type RepoView struct {
+	RepoDir string
+	// EffectivelyEnabled are foreign identities of the pack that a
+	// session started in this repo would load.
+	EffectivelyEnabled []string
+	// Suppressed are identities enabled at a wider scope but disabled
+	// by a narrower one in this repo (the native suppression lever,
+	// trial T10).
+	Suppressed []string
+	// Orphans are enable entries for the pack, at any scope visible
+	// from this repo, with no install record behind them.
+	Orphans []OrphanedEnable
+}
+
+// ResolveRepo computes effective enablement for identities of the
+// census pack in one repo. Precedence: local over project over user.
+// The project-vs-user edge is trial-verified in both directions
+// (T3, T10); local-over-project follows the harness's
+// personal-over-shared model and is asserted, not yet trialed.
+func (c *Census) ResolveRepo(repoDir string) (*RepoView, error) {
+	projEnables, err := readEnables(filepath.Join(repoDir, ".claude", "settings.json"))
+	if err != nil {
+		return nil, err
+	}
+	localEnables, err := readEnables(filepath.Join(repoDir, ".claude", "settings.local.json"))
+	if err != nil {
+		return nil, err
+	}
+
+	// Collect every identity of this pack mentioned anywhere.
+	identities := map[string]bool{}
+	for id := range c.installed {
+		identities[id] = true
+	}
+	for _, scope := range []map[string]enableEntry{c.userEnables, projEnables, localEnables} {
+		for id := range scope {
+			if plugin, _ := splitIdentity(id); plugin == c.Pack {
+				identities[id] = true
+			}
+		}
+	}
+
+	view := &RepoView{RepoDir: repoDir}
+	for id := range identities {
+		var effective, found, widerEnabled bool
+		if e, ok := c.userEnables[id]; ok {
+			effective, found = e.value, true
+			widerEnabled = e.value
+		}
+		if e, ok := projEnables[id]; ok {
+			if found && widerEnabled && !e.value {
+				view.Suppressed = append(view.Suppressed, id)
+			}
+			effective, found = e.value, true
+			widerEnabled = widerEnabled || e.value
+		}
+		if e, ok := localEnables[id]; ok {
+			if found && widerEnabled && !e.value {
+				view.Suppressed = append(view.Suppressed, id)
+			}
+			effective, found = e.value, true
+		}
+		if found && effective {
+			view.EffectivelyEnabled = append(view.EffectivelyEnabled, id)
+		}
+
+		if !c.installed[id] {
+			for scope, m := range map[string]map[string]enableEntry{
+				"user": c.userEnables, "project": projEnables, "local": localEnables,
+			} {
+				if e, ok := m[id]; ok {
+					view.Orphans = append(view.Orphans, OrphanedEnable{
+						Identity: id, Scope: scope, Enabled: e.value, Path: e.path,
+					})
+				}
+			}
+		}
+	}
+	sort.Strings(view.EffectivelyEnabled)
+	sort.Strings(view.Suppressed)
+	sort.Slice(view.Orphans, func(i, j int) bool {
+		if view.Orphans[i].Identity != view.Orphans[j].Identity {
+			return view.Orphans[i].Identity < view.Orphans[j].Identity
+		}
+		return view.Orphans[i].Scope < view.Orphans[j].Scope
+	})
+	return view, nil
+}

--- a/internal/foreign/census_test.go
+++ b/internal/foreign/census_test.go
@@ -1,0 +1,202 @@
+package foreign
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdirall %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// fixtureConfig builds a harness config dir in the v2 shape observed
+// in the finding-091 addendum-3 trials.
+func fixtureConfig(t *testing.T, installedJSON, userSettings string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if installedJSON != "" {
+		writeFile(t, filepath.Join(dir, "plugins", "installed_plugins.json"), installedJSON)
+	}
+	if userSettings != "" {
+		writeFile(t, filepath.Join(dir, "settings.json"), userSettings)
+	}
+	return dir
+}
+
+func TestTakeCensus_MatchesByNameAcrossMarketplaces(t *testing.T) {
+	dir := t.TempDir()
+	installPath := filepath.Join(dir, "cache", "claude-mp", "vsdd-factory", "1.0.0-rc.23")
+	writeFile(t, filepath.Join(installPath, ".claude-plugin", "plugin.json"),
+		`{"name":"vsdd-factory","version":"1.0.0-rc.24"}`)
+
+	cfg := fixtureConfig(t, `{
+	  "version": 2,
+	  "plugins": {
+	    "vsdd-factory@claude-mp": [
+	      {"scope":"user","installPath":"`+installPath+`","version":"1.0.0-rc.23","gitCommitSha":"80e5cd7b"}
+	    ],
+	    "vsdd-factory@vsdd-factory": [
+	      {"scope":"user","installPath":"/nonexistent","version":"1.0.0-rc.6","gitCommitSha":"deadbeef"}
+	    ],
+	    "other-pack@claude-mp": [
+	      {"scope":"user","installPath":"/x","version":"1.0.0"}
+	    ]
+	  }
+	}`, "")
+
+	c, err := TakeCensus(cfg, "vsdd-factory")
+	if err != nil {
+		t.Fatalf("TakeCensus: %v", err)
+	}
+	if len(c.Installs) != 2 {
+		t.Fatalf("Installs = %d, want 2 (other-pack must be excluded): %+v", len(c.Installs), c.Installs)
+	}
+	current, legacy := c.Installs[0], c.Installs[1]
+	if current.Marketplace != "claude-mp" || current.Legacy {
+		t.Errorf("current install misclassified: %+v", current)
+	}
+	// The registry says rc.23 but the tree says rc.24: the tree is
+	// the authority (git-subdir sources drift under a static label).
+	if current.TreeVersion != "1.0.0-rc.24" {
+		t.Errorf("TreeVersion = %q, want 1.0.0-rc.24 (tree is the version authority)", current.TreeVersion)
+	}
+	if !legacy.Legacy || legacy.Marketplace != "vsdd-factory" {
+		t.Errorf("legacy identity not flagged: %+v", legacy)
+	}
+	if legacy.TreeVersion != "" {
+		t.Errorf("missing tree must yield empty TreeVersion, got %q", legacy.TreeVersion)
+	}
+}
+
+func TestResolveRepo_SuppressionPrecedence(t *testing.T) {
+	cfg := fixtureConfig(t, `{
+	  "version": 2,
+	  "plugins": {"vsdd-factory@claude-mp": [{"scope":"user","installPath":"/x","version":"1"}]}
+	}`, `{"enabledPlugins": {"vsdd-factory@claude-mp": true}}`)
+
+	c, err := TakeCensus(cfg, "vsdd-factory")
+	if err != nil {
+		t.Fatalf("TakeCensus: %v", err)
+	}
+
+	// T10: project-scope false suppresses a user-scope enable.
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, ".claude", "settings.json"),
+		`{"enabledPlugins": {"vsdd-factory@claude-mp": false}}`)
+	view, err := c.ResolveRepo(repo)
+	if err != nil {
+		t.Fatalf("ResolveRepo: %v", err)
+	}
+	if len(view.EffectivelyEnabled) != 0 {
+		t.Errorf("suppressed identity reported effective: %v", view.EffectivelyEnabled)
+	}
+	if len(view.Suppressed) != 1 || view.Suppressed[0] != "vsdd-factory@claude-mp" {
+		t.Errorf("Suppressed = %v, want the claude-mp identity", view.Suppressed)
+	}
+
+	// No repo settings at all: the user-scope enable is effective.
+	bare := t.TempDir()
+	view, err = c.ResolveRepo(bare)
+	if err != nil {
+		t.Fatalf("ResolveRepo(bare): %v", err)
+	}
+	if len(view.EffectivelyEnabled) != 1 {
+		t.Errorf("user-scope enable not effective in a bare repo: %+v", view)
+	}
+
+	// Local false over project true (personal-over-shared).
+	repo2 := t.TempDir()
+	writeFile(t, filepath.Join(repo2, ".claude", "settings.json"),
+		`{"enabledPlugins": {"vsdd-factory@claude-mp": true}}`)
+	writeFile(t, filepath.Join(repo2, ".claude", "settings.local.json"),
+		`{"enabledPlugins": {"vsdd-factory@claude-mp": false}}`)
+	view, err = c.ResolveRepo(repo2)
+	if err != nil {
+		t.Fatalf("ResolveRepo(repo2): %v", err)
+	}
+	if len(view.EffectivelyEnabled) != 0 {
+		t.Errorf("local false did not suppress project true: %+v", view)
+	}
+}
+
+func TestResolveRepo_Orphans(t *testing.T) {
+	cfg := fixtureConfig(t, `{"version":2,"plugins":{}}`,
+		`{"enabledPlugins": {"vsdd-factory@ghost-mp": true}}`)
+	c, err := TakeCensus(cfg, "vsdd-factory")
+	if err != nil {
+		t.Fatalf("TakeCensus: %v", err)
+	}
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, ".claude", "settings.json"),
+		`{"enabledPlugins": {"vsdd-factory@claude-mp": false}}`)
+	view, err := c.ResolveRepo(repo)
+	if err != nil {
+		t.Fatalf("ResolveRepo: %v", err)
+	}
+	if len(view.Orphans) != 2 {
+		t.Fatalf("Orphans = %+v, want ghost-mp (user) and claude-mp (project)", view.Orphans)
+	}
+	if view.Orphans[0].Identity != "vsdd-factory@claude-mp" || view.Orphans[0].Scope != "project" {
+		t.Errorf("orphan[0] = %+v", view.Orphans[0])
+	}
+	if view.Orphans[1].Identity != "vsdd-factory@ghost-mp" || !view.Orphans[1].Enabled {
+		t.Errorf("orphan[1] = %+v", view.Orphans[1])
+	}
+}
+
+func TestCensus_FailsClosedOnMalformedState(t *testing.T) {
+	cfg := fixtureConfig(t, `{"version": 2, "plugins": {`, "")
+	if _, err := TakeCensus(cfg, "vsdd-factory"); err == nil {
+		t.Error("malformed installed_plugins.json must error, not classify on partial state")
+	}
+
+	cfg2 := fixtureConfig(t, `{"version":2,"plugins":{}}`, `{"enabledPlugins": [`)
+	if _, err := TakeCensus(cfg2, "vsdd-factory"); err == nil {
+		t.Error("malformed settings.json must error")
+	}
+
+	c, err := TakeCensus(fixtureConfig(t, "", ""), "vsdd-factory")
+	if err != nil {
+		t.Fatalf("empty config dir must census cleanly: %v", err)
+	}
+	repo := t.TempDir()
+	writeFile(t, filepath.Join(repo, ".claude", "settings.json"), "{broken")
+	if _, err := c.ResolveRepo(repo); err == nil {
+		t.Error("malformed repo settings must error")
+	}
+}
+
+func TestSplitIdentity(t *testing.T) {
+	tests := []struct {
+		in, plugin, mp string
+	}{
+		{"vsdd-factory@claude-mp", "vsdd-factory", "claude-mp"},
+		{"vsdd-factory@vsdd-factory", "vsdd-factory", "vsdd-factory"},
+		{"bare", "bare", ""},
+	}
+	for _, tt := range tests {
+		p, m := splitIdentity(tt.in)
+		if p != tt.plugin || m != tt.mp {
+			t.Errorf("splitIdentity(%q) = %q,%q want %q,%q", tt.in, p, m, tt.plugin, tt.mp)
+		}
+	}
+}
+
+func TestConfigDir_EnvOverride(t *testing.T) {
+	t.Setenv("CLAUDE_CONFIG_DIR", "/custom/cfg")
+	if got := ConfigDir(); got != "/custom/cfg" {
+		t.Errorf("ConfigDir() = %q, want env override", got)
+	}
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
+	if got := ConfigDir(); !strings.HasSuffix(got, filepath.Join("", ".claude")) {
+		t.Errorf("ConfigDir() = %q, want ~/.claude fallback", got)
+	}
+}

--- a/internal/foreign/diagnose.go
+++ b/internal/foreign/diagnose.go
@@ -1,0 +1,94 @@
+package foreign
+
+import "fmt"
+
+// Severity grades a coexistence finding for the doctor surface.
+type Severity string
+
+const (
+	Info  Severity = "INFO"
+	Warn  Severity = "WARN"
+	Error Severity = "ERROR"
+)
+
+// Finding is one doctor-shaped coexistence observation.
+type Finding struct {
+	Severity Severity
+	Code     string
+	Message  string
+}
+
+// Diagnose grades the coexistence posture of one repo against the
+// ratified severities (aae-orc-paqn clause e, finding-093):
+//
+//   - dual-channel presence at MACHINE level is INFO — the supported
+//     testing-the-waters posture, not a defect;
+//   - a foreign identity effectively enabled in a repo where sideshow
+//     bindings are active is ERROR — same-repo double-dispatch, two
+//     hook chains against one .factory state (verified live, trial
+//     T11), refused on class-1 grounds;
+//   - a user-scope enable of a per_repo_required pack is ERROR — the
+//     containment mandate;
+//   - orphaned enables are WARN — silent to the harness (trial T14),
+//     visible only here.
+//
+// sideshowActive reports whether sideshow bindings for the pack are
+// effective in this repo (the caller reads it from the repo-bindings
+// ledger once .7 lands; until then from the presence of materialized
+// bindings).
+func Diagnose(c *Census, view *RepoView, sideshowActive, perRepoRequired bool) []Finding {
+	var out []Finding
+
+	if len(c.Installs) > 0 && sideshowActive {
+		out = append(out, Finding{
+			Info, "dual-channel-machine",
+			fmt.Sprintf("%s is installed via %d foreign identity/identities beside the sideshow channel; machine-level coexistence is supported", c.Pack, len(c.Installs)),
+		})
+	}
+
+	if perRepoRequired {
+		for id, e := range c.userEnables {
+			if plugin, _ := splitIdentity(id); plugin == c.Pack && e.value {
+				out = append(out, Finding{
+					Error, "user-scope-enable",
+					fmt.Sprintf("%s is enabled at USER scope (%s): a per-repo-required pack would activate in every repo on this machine; suppress or move the enable per repo", id, e.path),
+				})
+			}
+		}
+	}
+
+	if sideshowActive {
+		for _, id := range view.EffectivelyEnabled {
+			out = append(out, Finding{
+				Error, "same-repo-double-dispatch",
+				fmt.Sprintf("%s is effectively enabled in %s where sideshow bindings are active: two hook chains would fire per event against one .factory state; refuse enable/adopt until one channel is suppressed here", id, view.RepoDir),
+			})
+		}
+	}
+
+	for _, o := range view.Orphans {
+		state := "disabled"
+		if o.Enabled {
+			state = "enabled"
+		}
+		out = append(out, Finding{
+			Warn, "orphaned-enable",
+			fmt.Sprintf("%s is %s at %s scope (%s) with no install behind it; the harness is silent about this entry", o.Identity, state, o.Scope, o.Path),
+		})
+	}
+
+	return out
+}
+
+// RefusalOptions is the consent-gated menu offered when enable or
+// adopt refuses on same-repo double-dispatch (paqn clause c). Nothing
+// here acts; the caller presents and the operator chooses.
+func RefusalOptions(identity, repoDir string) string {
+	return fmt.Sprintf(`another %s channel is effectively enabled in this repo (%s).
+Sideshow will not run two dispatch chains against one .factory state. Options:
+  1. Convert this repo to the sideshow channel (sideshow adopt; reversible, dry-runnable).
+  2. Suppress the foreign identity in THIS repo only (one settings line, no uninstall):
+       {"enabledPlugins": {%q: false}} in .claude/settings.local.json
+  3. Abort and leave the repo as it is.
+Sideshow never auto-disables or auto-uninstalls a foreign install.`, identity, repoDir, identity)
+}

--- a/internal/foreign/diagnose_test.go
+++ b/internal/foreign/diagnose_test.go
@@ -1,0 +1,98 @@
+package foreign
+
+import (
+	"strings"
+	"testing"
+)
+
+func findingCodes(fs []Finding) map[string]Severity {
+	out := map[string]Severity{}
+	for _, f := range fs {
+		out[f.Code] = f.Severity
+	}
+	return out
+}
+
+func TestDiagnose_Severities(t *testing.T) {
+	c := &Census{
+		Pack: "vsdd-factory",
+		Installs: []Install{
+			{Identity: "vsdd-factory@claude-mp", Scope: "user"},
+		},
+		userEnables: map[string]enableEntry{
+			"vsdd-factory@claude-mp": {value: true, path: "/cfg/settings.json"},
+		},
+		installed: map[string]bool{"vsdd-factory@claude-mp": true},
+	}
+
+	tests := []struct {
+		name            string
+		view            *RepoView
+		sideshowActive  bool
+		perRepoRequired bool
+		want            map[string]Severity
+		absent          []string
+	}{
+		{
+			name:            "machine coexistence alone is INFO plus the user-scope ERROR",
+			view:            &RepoView{RepoDir: "/r"},
+			sideshowActive:  true,
+			perRepoRequired: true,
+			want:            map[string]Severity{"dual-channel-machine": Info, "user-scope-enable": Error},
+			absent:          []string{"same-repo-double-dispatch"},
+		},
+		{
+			name:            "same-repo double dispatch is ERROR",
+			view:            &RepoView{RepoDir: "/r", EffectivelyEnabled: []string{"vsdd-factory@claude-mp"}},
+			sideshowActive:  true,
+			perRepoRequired: true,
+			want:            map[string]Severity{"same-repo-double-dispatch": Error},
+		},
+		{
+			name:            "foreign enable without sideshow bindings raises no dispatch error",
+			view:            &RepoView{RepoDir: "/r", EffectivelyEnabled: []string{"vsdd-factory@claude-mp"}},
+			sideshowActive:  false,
+			perRepoRequired: true,
+			absent:          []string{"same-repo-double-dispatch", "dual-channel-machine"},
+		},
+		{
+			name:            "user-scope enable is fine for packs without the per-repo mandate",
+			view:            &RepoView{RepoDir: "/r"},
+			sideshowActive:  false,
+			perRepoRequired: false,
+			absent:          []string{"user-scope-enable"},
+		},
+		{
+			name: "orphaned enable is WARN",
+			view: &RepoView{RepoDir: "/r", Orphans: []OrphanedEnable{
+				{Identity: "vsdd-factory@ghost-mp", Scope: "user", Enabled: true, Path: "/cfg/settings.json"},
+			}},
+			want: map[string]Severity{"orphaned-enable": Warn},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := findingCodes(Diagnose(c, tt.view, tt.sideshowActive, tt.perRepoRequired))
+			for code, sev := range tt.want {
+				if got[code] != sev {
+					t.Errorf("finding %s = %q, want %q (all: %v)", code, got[code], sev, got)
+				}
+			}
+			for _, code := range tt.absent {
+				if _, ok := got[code]; ok {
+					t.Errorf("finding %s present, want absent (all: %v)", code, got)
+				}
+			}
+		})
+	}
+}
+
+func TestRefusalOptions_OffersNeverActs(t *testing.T) {
+	msg := RefusalOptions("vsdd-factory@claude-mp", "/some/repo")
+	for _, want := range []string{"adopt", "settings.local.json", "Abort", "never auto-"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("refusal message missing %q:\n%s", want, msg)
+		}
+	}
+}


### PR DESCRIPTION
Foreign claude-mp installs of a pack and sideshow's repo bindings can now coexist on one machine without either channel firing hooks twice in the same repo — but only if sideshow can *see* the foreign channel. This PR gives it eyes: a read-only census of foreign installs plus doctor-graded coexistence findings, so the upcoming enable/adopt verbs can refuse same-repo double-dispatch instead of silently creating it. Additive only; nothing here mutates harness state.

## What ships

- **`internal/foreign`** — READ-ONLY census package. Matches foreign installs by plugin NAME across marketplaces (including the legacy pre-rc.7 `vsdd-factory@vsdd-factory` identity), parses v2 `installed_plugins.json`, treats the installed tree's `plugin.json` version as authority over registry labels (git-subdir sources drift), resolves per-repo enablement with local > project > user precedence, detects orphaned enables, and fails closed on malformed state.
- **`Diagnose`** — grades the ratified severities: dual-channel machine presence INFO (supported posture), same-repo double-dispatch ERROR (verified live in trials: both hook chains fired at one SessionStart), user-scope enable of a per-repo-required pack ERROR, orphaned enable WARN.
- **`RefusalOptions`** — the consent menu (convert / suppress in this repo only / abort). Offers only, never acts: the package never disables or uninstalls a foreign install.
- **`sideshow coexist <pack> [--repo <path>] [--sideshow-active]`** — prints machine installs, the repo view, and findings. Packs absent from the store grade conservatively as per-repo-required.

Enforcement (the enable refusal and the preflight) lands with the repo-bindings ledger verbs; this package is what they consume.

Refs: aae-orc-paqn, finding-091, finding-093