### PR TITLE
feat(bindings): repo-scoped materialization with hybrid strategy, ownership records, clobber protection

### DIFF
--- a/internal/bindings/custom_skill_dir.go
+++ b/internal/bindings/custom_skill_dir.go
@@ -114,7 +114,7 @@ func copyTree(src, dst string) error {
 		if err != nil {
 			return fmt.Errorf("read %s: %w", path, err)
 		}
-		if err := os.WriteFile(target, data, 0o644); err != nil {
+		if err := writeWithSourceMode(target, data, path); err != nil {
 			return fmt.Errorf("write %s: %w", target, err)
 		}
 		return nil

--- a/internal/bindings/markdown_command.go
+++ b/internal/bindings/markdown_command.go
@@ -69,7 +69,7 @@ func (b *MarkdownCommandBinding) Sync() (int, error) {
 			content = appendFallbackFooter(content, b.packPath)
 
 			destPath := filepath.Join(claudeDir, filepath.Base(path))
-			if err := os.WriteFile(destPath, []byte(content), 0o644); err != nil {
+			if err := writeWithSourceMode(destPath, []byte(content), path); err != nil {
 				return fmt.Errorf("write command %s: %w", destPath, err)
 			}
 			synced++
@@ -108,7 +108,7 @@ func (b *MarkdownCommandBinding) Sync() (int, error) {
 		content = appendFallbackFooter(content, b.packPath)
 
 		destPath := filepath.Join(claudeDir, name)
-		if err := os.WriteFile(destPath, []byte(content), 0o644); err != nil {
+		if err := writeWithSourceMode(destPath, []byte(content), path); err != nil {
 			return nil // skip on write error
 		}
 		synced++

--- a/internal/bindings/repo_materialize.go
+++ b/internal/bindings/repo_materialize.go
@@ -1,0 +1,377 @@
+package bindings
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// execManifestName is the pack-root executable census emitted by the
+// sideshow-packs build pipeline (same contract as the install-time
+// check in internal/pack).
+const execManifestName = "exec-manifest.txt"
+
+// RepoScope selects the D1 materialization strategy (finding-094
+// ratification addendum, hybrid by scope).
+type RepoScope string
+
+const (
+	// ScopeLocal symlinks bindings into the repo. The store copy is the
+	// only copy: exec bits live there, drift is structurally impossible,
+	// and nothing binding-sized enters the repo's history. Trial-backed
+	// on macOS (finding-091 addendum 2, T17: the harness follows
+	// symlinked skill dirs AND symlinked agent files); the Linux half is
+	// untested, so no cross-platform claim yet.
+	ScopeLocal RepoScope = "local"
+
+	// ScopeProject materializes full copies, because absolute symlinks
+	// do not cross machines and committed bindings must be
+	// self-contained bytes. Copies carry the source's permission bits
+	// and are verified against the pack's exec-manifest.txt census.
+	ScopeProject RepoScope = "project"
+)
+
+// RepoTarget names where bindings materialize inside one repo.
+//
+// HarnessDir is a parameter rather than a constant as the recorded
+// cross-harness seam (aae-orc-d3nq.57): the same bindings later project
+// into .agents/skills/, .opencode/, .crush/ by supplying a different
+// value. Nothing beyond the parameter is built today.
+type RepoTarget struct {
+	RepoDir    string
+	HarnessDir string // "" means ".claude"
+	Scope      RepoScope
+}
+
+func (t RepoTarget) harness() string {
+	if t.HarnessDir == "" {
+		return ".claude"
+	}
+	return t.HarnessDir
+}
+
+// harnessRoot returns the absolute directory all materialization is
+// contained to.
+func (t RepoTarget) harnessRoot() string {
+	return filepath.Join(t.RepoDir, t.harness())
+}
+
+// ErrWouldClobber marks a refused materialization: a destination path
+// already exists and is not sideshow's to overwrite. Enable never
+// clobbers pre-existing repo content; the operator resolves the
+// collision first (coexist-check reads this signal).
+var ErrWouldClobber = errors.New("destination already exists; sideshow never overwrites pre-existing repo content")
+
+// Artifact kinds recorded per materialized path. The ledger row
+// (docs/repo-bindings-ledger.md) carries these so disable replays the
+// exact set in reverse.
+const (
+	// ArtifactSkillDir is a materialized skill directory unit — a
+	// symlink at local scope, a copied tree at project scope. Removed
+	// whole on disable.
+	ArtifactSkillDir = "skill-dir"
+	// ArtifactAgentFile is a materialized agent file — a symlink at
+	// local scope, a mode-preserving copy at project scope.
+	ArtifactAgentFile = "agent-file"
+	// ArtifactParentDir is a directory created on the way to a unit
+	// (including the harness dir itself when absent). Removed on
+	// disable only if empty; user content that arrived later survives.
+	ArtifactParentDir = "parent-dir"
+)
+
+// RepoArtifact is one materialized path: repo-relative, slash-separated,
+// with the kind that decides its removal semantics.
+type RepoArtifact struct {
+	Kind string `yaml:"kind"`
+	Path string `yaml:"path"`
+}
+
+// unit is one (source, destination) materialization pair.
+type unit struct {
+	srcRel string // pack-root-relative, e.g. skills/pr-manager
+	dstRel string // repo-relative, e.g. .claude/skills/pr-manager
+	kind   string
+}
+
+// MaterializeRepo writes a plugin-shaped pack's discovery surface
+// (skills, agents — the materialize dispositions of the unshaping
+// spec) into one repo. storeRoot must be the resolved absolute
+// packs/<pack>/<version>/ path, never the `current` symlink, so a
+// store-level flip can never retarget a bound repo.
+//
+// The write is all-or-nothing: a clobber preflight refuses before any
+// write if any destination exists, and a mid-write failure rolls back
+// everything already created. The returned artifact list is the exact
+// removal set for RemoveRepoArtifacts (ledger `artifacts:` rows).
+//
+// Content transforms (binding-prefix, namespace-rewrite) layer on in
+// aae-orc-d3nq.51; the env shim, settings hooks, and compat symlink are
+// .50/.52/.58. This function materializes source bytes as-is.
+func MaterializeRepo(storeRoot string, inv *PluginInventory, t RepoTarget) ([]RepoArtifact, error) {
+	if t.Scope != ScopeLocal && t.Scope != ScopeProject {
+		return nil, fmt.Errorf("unknown repo scope %q (want %q or %q)", t.Scope, ScopeLocal, ScopeProject)
+	}
+	repoDir, err := filepath.Abs(t.RepoDir)
+	if err != nil {
+		return nil, fmt.Errorf("resolve repo dir: %w", err)
+	}
+	t.RepoDir = repoDir
+	if _, err := os.Stat(repoDir); err != nil {
+		return nil, fmt.Errorf("repo dir %s: %w", repoDir, err)
+	}
+
+	units := planUnits(inv, t)
+
+	// Clobber preflight: check every destination before writing any.
+	var clobbers []string
+	for _, u := range units {
+		if _, err := os.Lstat(filepath.Join(repoDir, filepath.FromSlash(u.dstRel))); err == nil {
+			clobbers = append(clobbers, u.dstRel)
+		}
+	}
+	if len(clobbers) > 0 {
+		return nil, fmt.Errorf("%w:\n  %s", ErrWouldClobber, strings.Join(clobbers, "\n  "))
+	}
+
+	var created []RepoArtifact
+	rollback := func() {
+		if _, rmErr := RemoveRepoArtifacts(t, created); rmErr != nil {
+			fmt.Fprintf(os.Stderr, "warning: rollback after failed materialization: %v\n", rmErr)
+		}
+	}
+
+	for _, u := range units {
+		dst := filepath.Join(repoDir, filepath.FromSlash(u.dstRel))
+		parents, mkErr := mkdirsRecording(t, filepath.Dir(dst))
+		created = append(created, parents...)
+		if mkErr != nil {
+			rollback()
+			return nil, mkErr
+		}
+
+		src := filepath.Join(storeRoot, filepath.FromSlash(u.srcRel))
+		var writeErr error
+		if t.Scope == ScopeLocal {
+			writeErr = os.Symlink(src, dst)
+		} else {
+			writeErr = copyPreservingMode(src, dst)
+		}
+		if writeErr != nil {
+			rollback()
+			return nil, fmt.Errorf("materialize %s: %w", u.dstRel, writeErr)
+		}
+		created = append(created, RepoArtifact{Kind: u.kind, Path: u.dstRel})
+	}
+
+	if t.Scope == ScopeProject {
+		if err := verifyRepoExec(storeRoot, t, units); err != nil {
+			rollback()
+			return nil, err
+		}
+	}
+
+	return created, nil
+}
+
+// planUnits maps the plugin inventory onto repo destinations. Skills
+// keep their unit-directory shape; agents keep their nested layout
+// (bare-name addressing per trial T20).
+func planUnits(inv *PluginInventory, t RepoTarget) []unit {
+	harness := t.harness()
+	units := make([]unit, 0, len(inv.SkillDirs)+len(inv.AgentFiles))
+	for _, s := range inv.SkillDirs {
+		units = append(units, unit{
+			srcRel: filepath.ToSlash(s),
+			dstRel: filepath.ToSlash(filepath.Join(harness, s)),
+			kind:   ArtifactSkillDir,
+		})
+	}
+	for _, a := range inv.AgentFiles {
+		units = append(units, unit{
+			srcRel: filepath.ToSlash(a),
+			dstRel: filepath.ToSlash(filepath.Join(harness, a)),
+			kind:   ArtifactAgentFile,
+		})
+	}
+	return units
+}
+
+// mkdirsRecording creates dir (and missing parents) inside the repo,
+// recording every directory it actually creates so disable can prune
+// them. Creation outside the harness root is refused.
+func mkdirsRecording(t RepoTarget, dir string) ([]RepoArtifact, error) {
+	root := t.harnessRoot()
+	relFromRepo, err := filepath.Rel(t.RepoDir, dir)
+	if err != nil || strings.HasPrefix(relFromRepo, "..") {
+		return nil, fmt.Errorf("refusing to create %s: outside repo %s", dir, t.RepoDir)
+	}
+	relFromRoot, err := filepath.Rel(root, dir)
+	if err != nil || strings.HasPrefix(relFromRoot, "..") {
+		return nil, fmt.Errorf("refusing to create %s: outside binding root %s", dir, root)
+	}
+
+	// Walk from the harness root down, creating what's missing.
+	var toCreate []string
+	cur := dir
+	for {
+		if _, statErr := os.Stat(cur); statErr == nil {
+			break
+		}
+		toCreate = append([]string{cur}, toCreate...)
+		if cur == root {
+			break
+		}
+		cur = filepath.Dir(cur)
+	}
+
+	var created []RepoArtifact
+	for _, d := range toCreate {
+		if err := os.Mkdir(d, 0o755); err != nil {
+			return created, fmt.Errorf("create %s: %w", d, err)
+		}
+		rel, relErr := filepath.Rel(t.RepoDir, d)
+		if relErr != nil {
+			return created, relErr
+		}
+		created = append(created, RepoArtifact{Kind: ArtifactParentDir, Path: filepath.ToSlash(rel)})
+	}
+	return created, nil
+}
+
+// copyPreservingMode copies a file or a directory tree, carrying each
+// source file's permission bits (project-scope copies must keep the
+// pack's executables executable; the exec-manifest census verifies).
+func copyPreservingMode(src, dst string) error {
+	info, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() {
+		data, err := os.ReadFile(src)
+		if err != nil {
+			return err
+		}
+		return writeWithSourceMode(dst, data, src)
+	}
+	return filepath.WalkDir(src, func(path string, d fs.DirEntry, werr error) error {
+		if werr != nil {
+			return werr
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+		if d.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		return writeWithSourceMode(target, data, path)
+	})
+}
+
+// verifyRepoExec checks project-scope copies against the pack's
+// exec-manifest.txt census (validation rule 3 of the unshaping spec):
+// every census entry falling under a materialized unit must carry an
+// exec bit at its repo destination. A pack without the census file
+// passes vacuously — mode-preserving copy is still in effect.
+func verifyRepoExec(storeRoot string, t RepoTarget, units []unit) error {
+	data, err := os.ReadFile(filepath.Join(storeRoot, execManifestName))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read %s: %w", execManifestName, err)
+	}
+
+	var drift []string
+	for _, line := range strings.Split(string(data), "\n") {
+		rel := strings.TrimSpace(line)
+		if rel == "" || strings.HasPrefix(rel, "#") {
+			continue
+		}
+		for _, u := range units {
+			if rel != u.srcRel && !strings.HasPrefix(rel, u.srcRel+"/") {
+				continue
+			}
+			dst := filepath.Join(t.RepoDir, t.harness(), filepath.FromSlash(rel))
+			info, statErr := os.Stat(dst)
+			switch {
+			case statErr != nil:
+				drift = append(drift, rel+" (missing)")
+			case info.Mode().Perm()&0o100 == 0:
+				drift = append(drift, rel+" (not executable)")
+			}
+			break
+		}
+	}
+	if len(drift) > 0 {
+		return fmt.Errorf("%s verification failed for repo copies under %s (%d entries drifted):\n  %s",
+			execManifestName, t.harnessRoot(), len(drift), strings.Join(drift, "\n  "))
+	}
+	return nil
+}
+
+// RemoveRepoArtifacts replays a recorded artifact list in reverse — the
+// exact inverse of MaterializeRepo. Removal never guesses: only
+// recorded paths go, every path must sit inside the repo's binding
+// root (the repo-rooted containment predicate; a corrupt ledger row
+// fails closed rather than deleting outside), and parent dirs are
+// pruned only when empty so user content that arrived after enable
+// survives. Returns the number of paths removed.
+func RemoveRepoArtifacts(t RepoTarget, artifacts []RepoArtifact) (int, error) {
+	repoDir, err := filepath.Abs(t.RepoDir)
+	if err != nil {
+		return 0, fmt.Errorf("resolve repo dir: %w", err)
+	}
+	t.RepoDir = repoDir
+	root := t.harnessRoot()
+
+	// Containment preflight over the whole set before touching anything.
+	// The binding root itself is a legal artifact only as a parent-dir
+	// (Remove-if-empty is safe there); every other kind must sit
+	// strictly inside it.
+	abs := make([]string, len(artifacts))
+	for i, a := range artifacts {
+		p := filepath.Join(repoDir, filepath.FromSlash(a.Path))
+		rel, relErr := filepath.Rel(root, p)
+		rootAsParentDir := rel == "." && a.Kind == ArtifactParentDir
+		if relErr != nil || strings.HasPrefix(rel, "..") || filepath.IsAbs(a.Path) ||
+			(rel == "." && !rootAsParentDir) {
+			return 0, fmt.Errorf("refusing removal: artifact %q resolves outside binding root %s", a.Path, root)
+		}
+		abs[i] = p
+	}
+
+	removed := 0
+	for i := len(artifacts) - 1; i >= 0; i-- {
+		a := artifacts[i]
+		p := abs[i]
+		if _, statErr := os.Lstat(p); statErr != nil {
+			continue // already gone
+		}
+		switch a.Kind {
+		case ArtifactParentDir:
+			if rmErr := os.Remove(p); rmErr != nil {
+				// Non-empty means user content arrived; leave it.
+				continue
+			}
+		case ArtifactSkillDir:
+			if rmErr := os.RemoveAll(p); rmErr != nil {
+				return removed, fmt.Errorf("remove %s: %w", a.Path, rmErr)
+			}
+		default: // ArtifactAgentFile and future file-shaped kinds
+			if rmErr := os.Remove(p); rmErr != nil {
+				return removed, fmt.Errorf("remove %s: %w", a.Path, rmErr)
+			}
+		}
+		removed++
+	}
+	return removed, nil
+}

--- a/internal/bindings/repo_materialize_test.go
+++ b/internal/bindings/repo_materialize_test.go
@@ -1,0 +1,371 @@
+package bindings
+
+import (
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeRepoFixtureStore builds a resolved store version root carrying
+// two skills (one with an executable helper), a nested agent layout,
+// and an exec-manifest census.
+func writeRepoFixtureStore(t *testing.T) string {
+	t.Helper()
+	store := t.TempDir()
+
+	mustWrite := func(rel, content string, mode os.FileMode) {
+		t.Helper()
+		p := filepath.Join(store, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(content), mode); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	mustWrite("skills/pr-manager/SKILL.md", "# pr-manager\n", 0o644)
+	mustWrite("skills/pr-manager/bin/helper.sh", "#!/bin/sh\necho ok\n", 0o755)
+	mustWrite("skills/adversary/SKILL.md", "# adversary\n", 0o644)
+	mustWrite("agents/reviewer.md", "---\nname: reviewer\n---\n", 0o644)
+	mustWrite("agents/orchestrator/planner.md", "---\nname: planner\n---\n", 0o644)
+	mustWrite("exec-manifest.txt", "skills/pr-manager/bin/helper.sh\n", 0o644)
+
+	return store
+}
+
+func fixtureInventory() *PluginInventory {
+	return &PluginInventory{
+		SkillDirs:  []string{"skills/adversary", "skills/pr-manager"},
+		AgentFiles: []string{"agents/orchestrator/planner.md", "agents/reviewer.md"},
+	}
+}
+
+// writeRepoWithUserContent builds a repo that already carries user
+// content the materialization must neither touch nor remove.
+func writeRepoWithUserContent(t *testing.T) string {
+	t.Helper()
+	repo := t.TempDir()
+	for rel, content := range map[string]string{
+		".claude/settings.json":        `{"user": true}` + "\n",
+		".claude/skills/mine/SKILL.md": "# mine\n",
+		"README.md":                    "user repo\n",
+	} {
+		p := filepath.Join(repo, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return repo
+}
+
+// snapshotTree fingerprints every entry under dir: type, perm, and
+// content hash (or symlink target), keyed by relative path.
+func snapshotTree(t *testing.T, dir string) map[string]string {
+	t.Helper()
+	snap := map[string]string{}
+	err := filepath.WalkDir(dir, func(path string, d os.DirEntry, werr error) error {
+		if werr != nil {
+			return werr
+		}
+		rel, err := filepath.Rel(dir, path)
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			return nil
+		}
+		info, err := os.Lstat(path)
+		if err != nil {
+			return err
+		}
+		switch {
+		case info.Mode()&os.ModeSymlink != 0:
+			target, err := os.Readlink(path)
+			if err != nil {
+				return err
+			}
+			snap[rel] = "link -> " + target
+		case info.IsDir():
+			snap[rel] = "dir"
+		default:
+			data, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			snap[rel] = fmt.Sprintf("file %o %x", info.Mode().Perm(), sha256.Sum256(data))
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return snap
+}
+
+func diffSnapshots(before, after map[string]string) []string {
+	var out []string
+	for k, v := range after {
+		if bv, ok := before[k]; !ok {
+			out = append(out, "added "+k)
+		} else if bv != v {
+			out = append(out, "changed "+k)
+		}
+	}
+	for k := range before {
+		if _, ok := after[k]; !ok {
+			out = append(out, "removed "+k)
+		}
+	}
+	return out
+}
+
+// The .48 done criterion: enable and disable are exact inverses on a
+// repo containing pre-existing user content, at both D1 scopes.
+func TestMaterializeThenRemove_ExactInverse(t *testing.T) {
+	t.Parallel()
+	for _, scope := range []RepoScope{ScopeLocal, ScopeProject} {
+		t.Run(string(scope), func(t *testing.T) {
+			t.Parallel()
+			store := writeRepoFixtureStore(t)
+			repo := writeRepoWithUserContent(t)
+			target := RepoTarget{RepoDir: repo, Scope: scope}
+
+			before := snapshotTree(t, repo)
+
+			artifacts, err := MaterializeRepo(store, fixtureInventory(), target)
+			if err != nil {
+				t.Fatalf("MaterializeRepo: %v", err)
+			}
+			if len(artifacts) == 0 {
+				t.Fatal("no artifacts recorded")
+			}
+
+			if _, err := RemoveRepoArtifacts(target, artifacts); err != nil {
+				t.Fatalf("RemoveRepoArtifacts: %v", err)
+			}
+
+			after := snapshotTree(t, repo)
+			if diff := diffSnapshots(before, after); len(diff) > 0 {
+				t.Errorf("repo not restored exactly:\n  %s", strings.Join(diff, "\n  "))
+			}
+		})
+	}
+}
+
+// Every write lands inside <repo>/.claude — nothing else in the repo
+// changes on enable.
+func TestMaterializeRepo_WritesOnlyUnderBindingRoot(t *testing.T) {
+	t.Parallel()
+	store := writeRepoFixtureStore(t)
+	repo := writeRepoWithUserContent(t)
+	target := RepoTarget{RepoDir: repo, Scope: ScopeLocal}
+
+	before := snapshotTree(t, repo)
+	artifacts, err := MaterializeRepo(store, fixtureInventory(), target)
+	if err != nil {
+		t.Fatalf("MaterializeRepo: %v", err)
+	}
+	after := snapshotTree(t, repo)
+
+	for _, d := range diffSnapshots(before, after) {
+		if !strings.HasPrefix(d, "added .claude/") {
+			t.Errorf("write outside binding root: %s", d)
+		}
+	}
+	for _, a := range artifacts {
+		if a.Path != ".claude" && !strings.HasPrefix(a.Path, ".claude/") {
+			t.Errorf("artifact outside binding root: %+v", a)
+		}
+	}
+}
+
+func TestMaterializeRepo_LocalScopeSymlinksToStore(t *testing.T) {
+	t.Parallel()
+	store := writeRepoFixtureStore(t)
+	repo := t.TempDir()
+
+	if _, err := MaterializeRepo(store, fixtureInventory(), RepoTarget{RepoDir: repo, Scope: ScopeLocal}); err != nil {
+		t.Fatalf("MaterializeRepo: %v", err)
+	}
+
+	link := filepath.Join(repo, ".claude", "skills", "pr-manager")
+	targetPath, err := os.Readlink(link)
+	if err != nil {
+		t.Fatalf("skill unit is not a symlink: %v", err)
+	}
+	if want := filepath.Join(store, "skills", "pr-manager"); targetPath != want {
+		t.Errorf("symlink target = %s, want %s", targetPath, want)
+	}
+	// The store copy stays the only copy carrying exec bits.
+	if _, err := os.Stat(filepath.Join(link, "bin", "helper.sh")); err != nil {
+		t.Errorf("symlinked skill content unreachable: %v", err)
+	}
+	if _, err := os.Readlink(filepath.Join(repo, ".claude", "agents", "orchestrator", "planner.md")); err != nil {
+		t.Errorf("nested agent file is not a symlink: %v", err)
+	}
+}
+
+func TestMaterializeRepo_ProjectScopeCopiesWithExecBits(t *testing.T) {
+	t.Parallel()
+	store := writeRepoFixtureStore(t)
+	repo := t.TempDir()
+
+	if _, err := MaterializeRepo(store, fixtureInventory(), RepoTarget{RepoDir: repo, Scope: ScopeProject}); err != nil {
+		t.Fatalf("MaterializeRepo: %v", err)
+	}
+
+	helper := filepath.Join(repo, ".claude", "skills", "pr-manager", "bin", "helper.sh")
+	info, err := os.Lstat(helper)
+	if err != nil {
+		t.Fatalf("copied helper missing: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		t.Fatal("project scope produced a symlink; committed bindings must be self-contained bytes")
+	}
+	if info.Mode().Perm()&0o100 == 0 {
+		t.Errorf("copied executable lost its exec bit: mode %o", info.Mode().Perm())
+	}
+	if info, err := os.Lstat(filepath.Join(repo, ".claude", "agents", "reviewer.md")); err != nil || info.Mode()&os.ModeSymlink != 0 {
+		t.Errorf("agent file should be a regular copy (err=%v)", err)
+	}
+}
+
+// Clobber protection: a pre-existing destination refuses the whole
+// materialization before anything is written.
+func TestMaterializeRepo_RefusesClobber(t *testing.T) {
+	t.Parallel()
+	store := writeRepoFixtureStore(t)
+	repo := t.TempDir()
+	pre := filepath.Join(repo, ".claude", "skills", "pr-manager")
+	if err := os.MkdirAll(pre, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pre, "SKILL.md"), []byte("theirs\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	before := snapshotTree(t, repo)
+	_, err := MaterializeRepo(store, fixtureInventory(), RepoTarget{RepoDir: repo, Scope: ScopeLocal})
+	if !errors.Is(err, ErrWouldClobber) {
+		t.Fatalf("err = %v, want ErrWouldClobber", err)
+	}
+	if diff := diffSnapshots(before, snapshotTree(t, repo)); len(diff) > 0 {
+		t.Errorf("refused materialization still wrote:\n  %s", strings.Join(diff, "\n  "))
+	}
+}
+
+// The repo-rooted containment predicate: recorded paths outside
+// <repo>/.claude fail closed instead of being removed.
+func TestRemoveRepoArtifacts_ContainmentFailsClosed(t *testing.T) {
+	t.Parallel()
+	repo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repo, ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	victim := filepath.Join(repo, "README.md")
+	if err := os.WriteFile(victim, []byte("keep me\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	target := RepoTarget{RepoDir: repo, Scope: ScopeLocal}
+
+	for _, bad := range []RepoArtifact{
+		{Kind: ArtifactAgentFile, Path: "README.md"},
+		{Kind: ArtifactAgentFile, Path: ".claude/../README.md"},
+		{Kind: ArtifactSkillDir, Path: ".claude"},
+		{Kind: ArtifactAgentFile, Path: victim},
+	} {
+		if _, err := RemoveRepoArtifacts(target, []RepoArtifact{bad}); err == nil {
+			t.Errorf("artifact %+v: removal accepted, want refusal", bad)
+		}
+	}
+	if _, err := os.Stat(victim); err != nil {
+		t.Fatalf("containment breach: README.md removed")
+	}
+}
+
+// Parent dirs created by enable are pruned only when empty; user
+// content that arrived after enable survives disable.
+func TestRemoveRepoArtifacts_SparesUserContentInParents(t *testing.T) {
+	t.Parallel()
+	store := writeRepoFixtureStore(t)
+	repo := t.TempDir()
+	target := RepoTarget{RepoDir: repo, Scope: ScopeLocal}
+
+	artifacts, err := MaterializeRepo(store, fixtureInventory(), target)
+	if err != nil {
+		t.Fatalf("MaterializeRepo: %v", err)
+	}
+
+	// User adds a skill of their own after enable.
+	mine := filepath.Join(repo, ".claude", "skills", "mine")
+	if err := os.MkdirAll(mine, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(mine, "SKILL.md"), []byte("# mine\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := RemoveRepoArtifacts(target, artifacts); err != nil {
+		t.Fatalf("RemoveRepoArtifacts: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(mine, "SKILL.md")); err != nil {
+		t.Errorf("user skill removed by disable: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(repo, ".claude", "skills", "pr-manager")); !os.IsNotExist(err) {
+		t.Errorf("materialized skill survived disable (err=%v)", err)
+	}
+	// agents/ had no user content, so it is pruned entirely.
+	if _, err := os.Stat(filepath.Join(repo, ".claude", "agents")); !os.IsNotExist(err) {
+		t.Errorf("empty created agents dir not pruned (err=%v)", err)
+	}
+}
+
+// Validation rule 3: a census entry that lands non-executable fails the
+// project-scope materialization (and rolls it back).
+func TestMaterializeRepo_ExecCensusViolationRollsBack(t *testing.T) {
+	t.Parallel()
+	store := writeRepoFixtureStore(t)
+	// Break the store: census names the helper, store copy lost its bit.
+	if err := os.Chmod(filepath.Join(store, "skills", "pr-manager", "bin", "helper.sh"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	repo := t.TempDir()
+
+	before := snapshotTree(t, repo)
+	_, err := MaterializeRepo(store, fixtureInventory(), RepoTarget{RepoDir: repo, Scope: ScopeProject})
+	if err == nil || !strings.Contains(err.Error(), execManifestName) {
+		t.Fatalf("err = %v, want exec-manifest verification failure", err)
+	}
+	if diff := diffSnapshots(before, snapshotTree(t, repo)); len(diff) > 0 {
+		t.Errorf("failed materialization left residue:\n  %s", strings.Join(diff, "\n  "))
+	}
+}
+
+func TestMaterializeRepo_HarnessDirIsAParameter(t *testing.T) {
+	t.Parallel()
+	store := writeRepoFixtureStore(t)
+	repo := t.TempDir()
+	target := RepoTarget{RepoDir: repo, HarnessDir: ".agents", Scope: ScopeLocal}
+
+	artifacts, err := MaterializeRepo(store, fixtureInventory(), target)
+	if err != nil {
+		t.Fatalf("MaterializeRepo: %v", err)
+	}
+	if _, err := os.Readlink(filepath.Join(repo, ".agents", "skills", "pr-manager")); err != nil {
+		t.Fatalf("binding not under parameterized harness dir: %v", err)
+	}
+	if _, err := RemoveRepoArtifacts(target, artifacts); err != nil {
+		t.Fatalf("RemoveRepoArtifacts: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(repo, ".agents")); !os.IsNotExist(err) {
+		t.Errorf("parameterized harness dir not pruned (err=%v)", err)
+	}
+}

--- a/internal/bindings/skill_dir.go
+++ b/internal/bindings/skill_dir.go
@@ -113,7 +113,7 @@ func (b *SkillDirBinding) syncSkillTree(src, dst string) error {
 			data = []byte(content)
 		}
 
-		if err := os.WriteFile(target, data, 0o644); err != nil {
+		if err := writeWithSourceMode(target, data, path); err != nil {
 			return fmt.Errorf("write %s: %w", target, err)
 		}
 		return nil

--- a/internal/bindings/write_mode.go
+++ b/internal/bindings/write_mode.go
@@ -1,0 +1,23 @@
+package bindings
+
+import (
+	"fmt"
+	"os"
+)
+
+// writeWithSourceMode writes data to target carrying the source file's
+// permission bits, so executables in a pack stay executable at the
+// destination (the store-side half of this fix is verifyExecManifest at
+// install time). os.WriteFile applies its mode only on create, so an
+// existing target from an earlier sync is chmodded into agreement.
+func writeWithSourceMode(target string, data []byte, srcPath string) error {
+	info, err := os.Stat(srcPath)
+	if err != nil {
+		return fmt.Errorf("stat source %s: %w", srcPath, err)
+	}
+	mode := info.Mode().Perm()
+	if err := os.WriteFile(target, data, mode); err != nil {
+		return err
+	}
+	return os.Chmod(target, mode)
+}


### PR DESCRIPTION
Plugin-shaped packs activate per repo, but the bindings layer could only write to `$HOME/.claude` — there was no way to put a pack's skills and agents into one repo, and nothing recording what was written so it could be removed exactly. This PR adds the repo-scoped materializer the enable/disable verbs will wrap. Additive: the user-scope sync path is unchanged except that copies now keep source permission bits (previously hardcoded 0o644, which stripped exec bits).

## What ships

- **`RepoTarget{RepoDir, HarnessDir, Scope}`** — the target directory is a parameter (default `.claude`). `HarnessDir` is a recorded seam for projecting the same bindings into other harness layouts later; nothing beyond the parameter is built.
- **`MaterializeRepo`** — hybrid strategy by scope: local scope symlinks into the repo (the store copy stays the only copy carrying exec bits; trial-backed on macOS), project scope materializes full mode-preserving copies verified against the pack's `exec-manifest.txt` census, because absolute symlinks don't cross machines and committed bindings must be self-contained bytes. All-or-nothing: a clobber preflight refuses before any write if a destination exists (sideshow never overwrites pre-existing repo content), and a mid-write failure rolls back everything created.
- **`RepoArtifact` + `RemoveRepoArtifacts`** — every created path (units plus created parent dirs) is recorded as the exact removal set; disable replays it in reverse under a repo-rooted containment predicate (removal only ever touches paths inside the binding root; a corrupt record fails closed). Parent dirs are pruned only when empty, so user content added after enable survives disable.
- **`writeWithSourceMode`** — replaces the four hardcoded 0o644 writes in the user-scope binding writers.

Proven by test: enable and disable are exact inverses on a repo with pre-existing user content at both scopes, and zero writes land outside the binding root.

Refs: aae-orc-d3nq.48, finding-091, finding-094