### PR TITLE
feat(bindings): runtime env shim primitives and rewritePaths parameterization

### DIFF
--- a/internal/bindings/env_shim.go
+++ b/internal/bindings/env_shim.go
@@ -1,0 +1,168 @@
+package bindings
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// The runtime env shim is route (a) of the CLAUDE_PLUGIN_ROOT
+// resolution decision (aae-orc-d3nq.50): keep the variable NAME, set
+// its VALUE in the repo settings file at enable time. Trial-verified
+// (finding-091 addendum 2, T15): a settings env entry reaches hook
+// execution, main-loop Bash, and Bash inside subagents, resolving
+// every store-relative reference in the pack's content with zero
+// rewriting — byte identity preserved for the equivalence proof.
+//
+// These are read-merge-write primitives on one settings JSON file;
+// the enable/disable verbs (.7) choose which file (settings.local.json
+// at local scope, settings.json at project scope) and record the
+// artifact in the ledger.
+
+// MergeEnvShim sets env[name] = value in the settings file at path,
+// creating the file when absent and preserving every other key. It
+// reports whether the file itself was created (the caller records
+// that for exact removal). A pre-existing env[name] with a different
+// value refuses with ErrWouldClobber — sideshow never overwrites
+// repo content it does not own; same-value entries are idempotent.
+func MergeEnvShim(path, name, value string) (created bool, err error) {
+	settings, existed, err := readSettings(path)
+	if err != nil {
+		return false, err
+	}
+
+	env, err := envObject(settings, path)
+	if err != nil {
+		return false, err
+	}
+	if prev, ok := env[name]; ok {
+		if s, isStr := prev.(string); isStr && s == value {
+			return !existed, writeSettings(path, settings)
+		}
+		return false, fmt.Errorf("%w: %s already sets env.%s=%v", ErrWouldClobber, path, name, prev)
+	}
+	env[name] = value
+	settings["env"] = env
+
+	return !existed, writeSettings(path, settings)
+}
+
+// RemoveEnvShim removes env[name] from the settings file only when it
+// still holds value — removal never guesses; a drifted or foreign
+// entry is left in place and reported via removed=false. An empty env
+// object is pruned. Whether to delete a file MergeEnvShim created is
+// the caller's call, made from its artifact record.
+func RemoveEnvShim(path, name, value string) (removed bool, err error) {
+	settings, existed, err := readSettings(path)
+	if err != nil {
+		return false, err
+	}
+	if !existed {
+		return false, nil
+	}
+	env, err := envObject(settings, path)
+	if err != nil {
+		return false, err
+	}
+	s, isStr := env[name].(string)
+	if !isStr || s != value {
+		return false, nil
+	}
+	delete(env, name)
+	if len(env) == 0 {
+		delete(settings, "env")
+	} else {
+		settings["env"] = env
+	}
+	return true, writeSettings(path, settings)
+}
+
+// VerifyEnvShim checks that the settings file resolves name to
+// wantValue — the bind-time check behind "zero unresolved references
+// in materialized output", re-run by doctor. The error text names the
+// drift so callers can print it verbatim.
+func VerifyEnvShim(path, name, wantValue string) error {
+	settings, existed, err := readSettings(path)
+	if err != nil {
+		return err
+	}
+	if !existed {
+		return fmt.Errorf("env shim missing: %s does not exist, so %s is unresolved in this repo", path, name)
+	}
+	env, err := envObject(settings, path)
+	if err != nil {
+		return err
+	}
+	got, ok := env[name].(string)
+	switch {
+	case !ok:
+		return fmt.Errorf("env shim missing: %s has no env.%s entry", path, name)
+	case got != wantValue:
+		return fmt.Errorf("env shim drifted: %s sets env.%s=%q, want %q", path, name, got, wantValue)
+	}
+	return nil
+}
+
+// InlineEnvBelt returns the NAME='value' prefix every synthesized
+// hook command carries (the belt to the settings-env suspender): the
+// hook surface keeps working even where the settings env leg is
+// absent or drifted. The value is single-quoted with POSIX-safe
+// escaping.
+func InlineEnvBelt(name, value string) string {
+	quoted := "'" + strings.ReplaceAll(value, "'", `'\''`) + "'"
+	return name + "=" + quoted + " "
+}
+
+// readSettings loads a settings JSON object. A missing file returns
+// an empty object with existed=false; malformed JSON is an error
+// (fail closed — merging into a file we cannot parse risks destroying
+// user configuration).
+func readSettings(path string) (map[string]any, bool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return map[string]any{}, false, nil
+		}
+		return nil, false, fmt.Errorf("read settings %s: %w", path, err)
+	}
+	var settings map[string]any
+	if err := json.Unmarshal(data, &settings); err != nil {
+		return nil, false, fmt.Errorf("parse settings %s (refusing to merge into a file that cannot round-trip): %w", path, err)
+	}
+	if settings == nil {
+		settings = map[string]any{}
+	}
+	return settings, true, nil
+}
+
+// envObject returns the settings' env block as a mutable map, failing
+// closed when env exists but is not an object.
+func envObject(settings map[string]any, path string) (map[string]any, error) {
+	raw, ok := settings["env"]
+	if !ok {
+		return map[string]any{}, nil
+	}
+	env, ok := raw.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("settings %s: env is not an object; refusing to merge", path)
+	}
+	return env, nil
+}
+
+// writeSettings persists a settings object with stable two-space
+// indentation and a trailing newline.
+func writeSettings(path string, settings map[string]any) error {
+	data, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal settings: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create settings dir: %w", err)
+	}
+	if err := os.WriteFile(path, append(data, '\n'), 0o644); err != nil {
+		return fmt.Errorf("write settings %s: %w", path, err)
+	}
+	return nil
+}

--- a/internal/bindings/env_shim_test.go
+++ b/internal/bindings/env_shim_test.go
@@ -1,0 +1,221 @@
+package bindings
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func settingsFixture(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "settings.local.json")
+	if content != "" {
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return path
+}
+
+func readJSON(t *testing.T, path string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("settings not valid JSON after write: %v\n%s", err, data)
+	}
+	return out
+}
+
+func TestMergeEnvShim_CreatesFile(t *testing.T) {
+	t.Parallel()
+	path := settingsFixture(t, "")
+
+	created, err := MergeEnvShim(path, "CLAUDE_PLUGIN_ROOT", "/store/packs/vsdd-factory/1.0.0-rc.23")
+	if err != nil {
+		t.Fatalf("MergeEnvShim: %v", err)
+	}
+	if !created {
+		t.Error("created = false for a file that did not exist")
+	}
+	env := readJSON(t, path)["env"].(map[string]any)
+	if got := env["CLAUDE_PLUGIN_ROOT"]; got != "/store/packs/vsdd-factory/1.0.0-rc.23" {
+		t.Errorf("env.CLAUDE_PLUGIN_ROOT = %v", got)
+	}
+}
+
+func TestMergeEnvShim_PreservesOtherKeys(t *testing.T) {
+	t.Parallel()
+	path := settingsFixture(t, `{"permissions": {"allow": ["Bash(ls:*)"]}, "env": {"OTHER": "kept"}}`)
+
+	created, err := MergeEnvShim(path, "CLAUDE_PLUGIN_ROOT", "/store/v1")
+	if err != nil {
+		t.Fatalf("MergeEnvShim: %v", err)
+	}
+	if created {
+		t.Error("created = true for a pre-existing file")
+	}
+	got := readJSON(t, path)
+	if _, ok := got["permissions"]; !ok {
+		t.Error("permissions key lost in merge")
+	}
+	env := got["env"].(map[string]any)
+	if env["OTHER"] != "kept" {
+		t.Errorf("sibling env entry lost: %v", env)
+	}
+	if env["CLAUDE_PLUGIN_ROOT"] != "/store/v1" {
+		t.Errorf("shim not merged: %v", env)
+	}
+}
+
+func TestMergeEnvShim_IdempotentAndClobberRefusal(t *testing.T) {
+	t.Parallel()
+	path := settingsFixture(t, `{"env": {"CLAUDE_PLUGIN_ROOT": "/store/v1"}}`)
+
+	if _, err := MergeEnvShim(path, "CLAUDE_PLUGIN_ROOT", "/store/v1"); err != nil {
+		t.Fatalf("same-value merge should be idempotent: %v", err)
+	}
+	_, err := MergeEnvShim(path, "CLAUDE_PLUGIN_ROOT", "/store/v2")
+	if !errors.Is(err, ErrWouldClobber) {
+		t.Fatalf("err = %v, want ErrWouldClobber", err)
+	}
+	// The refused merge changed nothing.
+	env := readJSON(t, path)["env"].(map[string]any)
+	if env["CLAUDE_PLUGIN_ROOT"] != "/store/v1" {
+		t.Errorf("refused merge mutated the file: %v", env)
+	}
+}
+
+func TestMergeEnvShim_FailsClosedOnMalformedSettings(t *testing.T) {
+	t.Parallel()
+	for name, content := range map[string]string{
+		"invalid json":   `{not json`,
+		"env not object": `{"env": ["list"]}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			path := settingsFixture(t, content)
+			if _, err := MergeEnvShim(path, "CLAUDE_PLUGIN_ROOT", "/store/v1"); err == nil {
+				t.Error("merge accepted a settings file it cannot round-trip")
+			}
+		})
+	}
+}
+
+func TestRemoveEnvShim_RemovesOnlyOurValue(t *testing.T) {
+	t.Parallel()
+	path := settingsFixture(t, `{"env": {"CLAUDE_PLUGIN_ROOT": "/store/v1", "OTHER": "kept"}, "model": "opus"}`)
+
+	removed, err := RemoveEnvShim(path, "CLAUDE_PLUGIN_ROOT", "/store/v1")
+	if err != nil || !removed {
+		t.Fatalf("RemoveEnvShim = (%v, %v), want (true, nil)", removed, err)
+	}
+	got := readJSON(t, path)
+	env := got["env"].(map[string]any)
+	if _, ok := env["CLAUDE_PLUGIN_ROOT"]; ok {
+		t.Error("shim entry survived removal")
+	}
+	if env["OTHER"] != "kept" || got["model"] != "opus" {
+		t.Errorf("removal disturbed sibling keys: %v", got)
+	}
+}
+
+func TestRemoveEnvShim_NeverGuesses(t *testing.T) {
+	t.Parallel()
+	path := settingsFixture(t, `{"env": {"CLAUDE_PLUGIN_ROOT": "/user/own/value"}}`)
+
+	removed, err := RemoveEnvShim(path, "CLAUDE_PLUGIN_ROOT", "/store/v1")
+	if err != nil {
+		t.Fatalf("RemoveEnvShim: %v", err)
+	}
+	if removed {
+		t.Error("removed a value sideshow did not write")
+	}
+	env := readJSON(t, path)["env"].(map[string]any)
+	if env["CLAUDE_PLUGIN_ROOT"] != "/user/own/value" {
+		t.Errorf("foreign value disturbed: %v", env)
+	}
+
+	if removed, err := RemoveEnvShim(filepath.Join(t.TempDir(), "absent.json"), "X", "y"); err != nil || removed {
+		t.Errorf("missing file: RemoveEnvShim = (%v, %v), want (false, nil)", removed, err)
+	}
+}
+
+func TestRemoveEnvShim_PrunesEmptyEnv(t *testing.T) {
+	t.Parallel()
+	path := settingsFixture(t, `{"env": {"CLAUDE_PLUGIN_ROOT": "/store/v1"}, "model": "opus"}`)
+
+	if _, err := RemoveEnvShim(path, "CLAUDE_PLUGIN_ROOT", "/store/v1"); err != nil {
+		t.Fatal(err)
+	}
+	got := readJSON(t, path)
+	if _, ok := got["env"]; ok {
+		t.Errorf("empty env object not pruned: %v", got)
+	}
+}
+
+func TestVerifyEnvShim(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		content string
+		wantErr string
+	}{
+		{"resolves", `{"env": {"CLAUDE_PLUGIN_ROOT": "/store/v1"}}`, ""},
+		{"missing file", "", "does not exist"},
+		{"missing entry", `{"env": {}}`, "no env.CLAUDE_PLUGIN_ROOT"},
+		{"drifted", `{"env": {"CLAUDE_PLUGIN_ROOT": "/elsewhere"}}`, "drifted"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			path := settingsFixture(t, tt.content)
+			err := VerifyEnvShim(path, "CLAUDE_PLUGIN_ROOT", "/store/v1")
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Errorf("VerifyEnvShim = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("VerifyEnvShim = %v, want error containing %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestInlineEnvBelt_QuotesSafely(t *testing.T) {
+	t.Parallel()
+	got := InlineEnvBelt("CLAUDE_PLUGIN_ROOT", "/store/o'brien")
+	want := `CLAUDE_PLUGIN_ROOT='/store/o'\''brien' `
+	if got != want {
+		t.Errorf("InlineEnvBelt = %q, want %q", got, want)
+	}
+}
+
+// Regression coverage for the rewritePaths parameterization: the bmad
+// default is unchanged and a second prefix routes correctly.
+func TestRewritePathsForPrefix(t *testing.T) {
+	t.Parallel()
+	in := "read {project-root}/_vsdd/templates/a.md, write {project-root}/_vsdd-custom/x " +
+		"and {project-root}/_vsdd-output/y, leave {project-root}/README.md"
+	got := rewritePathsForPrefix(in, "/store/vsdd/1.0.0", "_vsdd")
+	want := "read /store/vsdd/1.0.0/templates/a.md, write {project-root}/_vsdd-custom/x " +
+		"and {project-root}/_vsdd-output/y, leave {project-root}/README.md"
+	if got != want {
+		t.Errorf("rewritePathsForPrefix:\n got %q\nwant %q", got, want)
+	}
+
+	// The bmad wrapper still behaves exactly as before.
+	bmadIn := "{project-root}/_bmad/core/a.md {project-root}/_bmad-custom/b"
+	bmadWant := "/packs/bmad/6.3.0/core/a.md {project-root}/_bmad-custom/b"
+	if got := rewritePaths(bmadIn, "/packs/bmad/6.3.0"); got != bmadWant {
+		t.Errorf("rewritePaths (bmad default):\n got %q\nwant %q", got, bmadWant)
+	}
+}

--- a/internal/bindings/rewrite.go
+++ b/internal/bindings/rewrite.go
@@ -21,20 +21,29 @@ import (
 // The implementation uses nul-byte sentinels to protect the per-repo
 // prefixes from being caught by the pack-content rewrite.
 //
-// Currently the pack prefix is hardcoded as "_bmad" because bmad is the
-// only pack sideshow manages. When a second pack with a different prefix
-// lands, this will need parameterizing.
+// rewritePaths keeps the historical bmad default; every binding that
+// syncs a differently prefixed pack calls rewritePathsForPrefix with
+// that pack's prefix (aae-orc-d3nq.50).
 func rewritePaths(content, packPath string) string {
-	const customSentinel = "\x00BMAD_CUSTOM\x00"
-	const outputSentinel = "\x00BMAD_OUTPUT\x00"
+	return rewritePathsForPrefix(content, packPath, "_bmad")
+}
 
-	content = strings.ReplaceAll(content, "{project-root}/_bmad-custom/", customSentinel)
-	content = strings.ReplaceAll(content, "{project-root}/_bmad-output/", outputSentinel)
+// rewritePathsForPrefix is rewritePaths parameterized on the pack's
+// project-root prefix (e.g. "_bmad", "_gds"): {project-root}/<prefix>/
+// references become absolute store paths while the sibling per-repo
+// dirs (<prefix>-custom/, <prefix>-output/) stay project-relative.
+func rewritePathsForPrefix(content, packPath, prefix string) string {
+	const customSentinel = "\x00PACK_CUSTOM\x00"
+	const outputSentinel = "\x00PACK_OUTPUT\x00"
 
-	content = strings.ReplaceAll(content, "{project-root}/_bmad/", packPath+"/")
+	root := "{project-root}/" + prefix
+	content = strings.ReplaceAll(content, root+"-custom/", customSentinel)
+	content = strings.ReplaceAll(content, root+"-output/", outputSentinel)
 
-	content = strings.ReplaceAll(content, customSentinel, "{project-root}/_bmad-custom/")
-	content = strings.ReplaceAll(content, outputSentinel, "{project-root}/_bmad-output/")
+	content = strings.ReplaceAll(content, root+"/", packPath+"/")
+
+	content = strings.ReplaceAll(content, customSentinel, root+"-custom/")
+	content = strings.ReplaceAll(content, outputSentinel, root+"-output/")
 
 	return content
 }


### PR DESCRIPTION
Plugin-shaped packs carry hundreds of `${CLAUDE_PLUGIN_ROOT}` references — in shell, wasm registries, and prose. Rewriting them all at bind time would corrupt the parameter-expansion forms and break the byte-identity equivalence proof against upstream. The trial-selected answer is a runtime shim: keep the variable name, set its value in the repo settings file at enable time, and every reference resolves with zero rewriting. This PR ships the settings primitives that shim needs, plus the belt for hook commands and the rewritePaths parameterization the second pack prefix requires. Additive: bmad call sites are unchanged, with regression coverage asserting the default byte-for-byte.

## What ships

- **`MergeEnvShim` / `RemoveEnvShim`** — read-merge-write on one settings JSON, preserving sibling keys. Merge refuses a pre-existing different value (sideshow never overwrites repo content it doesn't own) and is idempotent on its own; removal never guesses — it removes only the exact value written, prunes an emptied `env` object, and leaves drifted or foreign entries alone. Malformed settings fail closed.
- **`VerifyEnvShim`** — the bind-time check behind "zero unresolved references in materialized output", re-run by doctor.
- **`InlineEnvBelt`** — the `NAME='value'` prefix synthesized hook commands carry, so the hook surface never depends on the settings leg alone.
- **`rewritePathsForPrefix`** — parameterizes the hardcoded `_bmad` prefix; `rewritePaths` keeps the bmad default.

Trial grounding: a settings env entry reaches hook execution, main-loop Bash, and Bash inside subagents (finding-091 addendum 2, T15 — three legs, verified live).

Refs: aae-orc-d3nq.50, finding-091, finding-094