### PR TITLE
feat(bindings): binding-prefix policy via rendered bound variant, namespace rewrite

### DIFF
--- a/internal/bindings/bound_variant.go
+++ b/internal/bindings/bound_variant.go
@@ -1,0 +1,248 @@
+package bindings
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/ArcavenAE/sideshow/internal/pack"
+)
+
+// The bound variant is the transformed derivative of a plugin pack's
+// materialize-disposition units (aae-orc-d3nq.51): store content is
+// signed reference and stays byte-frozen, so the binding-prefix and
+// namespace-rewrite transforms render ONCE per pack version into a
+// machine-scoped derived tree under the sideshow data dir. Repos then
+// materialize FROM the variant: local scope symlinks into it (still
+// one copy per machine, exec bits in one place, version flip is one
+// repoint), project scope copies from it. The transforms applied here
+// are the declared derivative the rewrite manifest records
+// (aae-orc-d3nq.61) and the equivalence proof subtracts.
+//
+// Why the transforms exist (finding-091):
+//   - T16 corrected: a USER-scope skill shadows a same-name repo
+//     skill, so unprefixed generic names (upstream ships `jira`, 34
+//     generic agent names) would be silently hijacked on consumer
+//     machines. Prefixing is correctness, not hygiene.
+//   - T20: repo-scope addressing is the bare frontmatter name; the
+//     namespace-qualified `<pack>:<name>` form cannot occur on this
+//     channel, so every internal reference is rewritten to the
+//     prefixed bare name.
+
+// BoundVariantDir returns the canonical location of a pack version's
+// bound variant inside the sideshow data dir (sibling of packs/).
+func BoundVariantDir(packName, version string) string {
+	return filepath.Join(filepath.Dir(pack.PacksDir()), "bound", packName, version)
+}
+
+// RenderBoundVariant renders the transformed derivative of the
+// inventory's materialize units from storeRoot into destDir, and
+// returns the inventory of the variant (prefixed names, same shape)
+// for MaterializeRepo to consume. An existing destDir is rebuilt from
+// scratch — it is a derived cache; rebuilding the same version is
+// deterministic and repos symlinked into it see identical content.
+func RenderBoundVariant(storeRoot string, inv *PluginInventory, packName, prefix, destDir string) (*PluginInventory, error) {
+	if prefix == "" {
+		return nil, fmt.Errorf("empty binding prefix for pack %s", packName)
+	}
+	if err := os.RemoveAll(destDir); err != nil {
+		return nil, fmt.Errorf("clear bound variant dir: %w", err)
+	}
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		return nil, fmt.Errorf("create bound variant dir: %w", err)
+	}
+
+	nsRewrite, err := namespaceRewriter(packName, prefix)
+	if err != nil {
+		return nil, err
+	}
+
+	out := &PluginInventory{}
+
+	for _, s := range inv.SkillDirs {
+		name := filepath.Base(s)
+		dstRel := filepath.Join("skills", prefix+"-"+name)
+		// The skill's own SKILL.md carries the harness identifier that
+		// must agree with the prefixed directory name; deeper files
+		// (including any the skill nests) only get the namespace
+		// rewrite.
+		skillTransform := func(rel string, data []byte) []byte {
+			if !shouldRewrite(rel) {
+				return data
+			}
+			content := nsRewrite(string(data))
+			if rel == "SKILL.md" {
+				content = rewriteFrontmatterName(content, prefix)
+			}
+			return []byte(content)
+		}
+		if err := copyTransformed(
+			filepath.Join(storeRoot, filepath.FromSlash(s)),
+			filepath.Join(destDir, dstRel),
+			skillTransform,
+		); err != nil {
+			return nil, fmt.Errorf("render skill %s: %w", name, err)
+		}
+		out.SkillDirs = append(out.SkillDirs, filepath.ToSlash(dstRel))
+	}
+
+	for _, a := range inv.AgentFiles {
+		dstRel, err := prefixTopLevel(a, "agents", prefix)
+		if err != nil {
+			return nil, err
+		}
+		src := filepath.Join(storeRoot, filepath.FromSlash(a))
+		dst := filepath.Join(destDir, filepath.FromSlash(dstRel))
+		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+			return nil, fmt.Errorf("create agent dir: %w", err)
+		}
+		data, err := os.ReadFile(src)
+		if err != nil {
+			return nil, fmt.Errorf("read agent %s: %w", a, err)
+		}
+		if shouldRewrite(src) {
+			content := nsRewrite(string(data))
+			content = rewriteFrontmatterName(content, prefix)
+			data = []byte(content)
+		}
+		if err := writeWithSourceMode(dst, data, src); err != nil {
+			return nil, fmt.Errorf("render agent %s: %w", a, err)
+		}
+		out.AgentFiles = append(out.AgentFiles, dstRel)
+	}
+
+	if err := translateExecManifest(storeRoot, destDir, inv, prefix); err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}
+
+// namespaceRewriter builds the `<pack>:<name>` → `<prefix>-<name>`
+// content rewrite. The qualifier must be immediately followed by an
+// artifact-name character, so prose like "the pack: a plugin" is
+// untouched. One rule covers slash-form skill references and
+// subagent_type call sites alike.
+func namespaceRewriter(packName, prefix string) (func(string) string, error) {
+	re, err := regexp.Compile(regexp.QuoteMeta(packName) + `:([A-Za-z0-9][A-Za-z0-9_-]*)`)
+	if err != nil {
+		return nil, fmt.Errorf("compile namespace rewrite for %s: %w", packName, err)
+	}
+	repl := prefix + "-$1"
+	return func(content string) string {
+		return re.ReplaceAllString(content, repl)
+	}, nil
+}
+
+// frontmatterNameLine matches the name: field of a YAML frontmatter
+// block's first line occurrence.
+var frontmatterNameLine = regexp.MustCompile(`(?m)^name:[ \t]*(\S+)[ \t]*$`)
+
+// rewriteFrontmatterName prefixes the frontmatter name: field so the
+// harness identifier agrees with the prefixed bound location. Only
+// the leading frontmatter block is touched; body content is left to
+// the namespace rewrite.
+func rewriteFrontmatterName(content, prefix string) string {
+	if !strings.HasPrefix(content, "---\n") {
+		return content
+	}
+	end := strings.Index(content[4:], "\n---")
+	if end < 0 {
+		return content
+	}
+	head := content[:4+end]
+	rest := content[4+end:]
+	head = frontmatterNameLine.ReplaceAllStringFunc(head, func(line string) string {
+		m := frontmatterNameLine.FindStringSubmatch(line)
+		if m == nil || strings.HasPrefix(m[1], prefix+"-") {
+			return line
+		}
+		return "name: " + prefix + "-" + m[1]
+	})
+	return head + rest
+}
+
+// prefixTopLevel prefixes the first path segment under root: flat
+// files rename (agents/reviewer.md → agents/<p>-reviewer.md), nested
+// layouts rename their top directory (agents/orchestrator/planner.md
+// → agents/<p>-orchestrator/planner.md) so one gitignore glob per
+// pack covers everything and nesting is preserved (bare-name
+// addressing per trial T20).
+func prefixTopLevel(rel, root, prefix string) (string, error) {
+	parts := strings.Split(filepath.ToSlash(rel), "/")
+	if len(parts) < 2 || parts[0] != root {
+		return "", fmt.Errorf("unexpected %s path %q", root, rel)
+	}
+	parts[1] = prefix + "-" + parts[1]
+	return strings.Join(parts, "/"), nil
+}
+
+// copyTransformed copies a directory tree applying the transform
+// (keyed by unit-relative path) to each file's content while
+// preserving source permission bits.
+func copyTransformed(src, dst string, transform func(string, []byte) []byte) error {
+	return filepath.WalkDir(src, func(path string, d fs.DirEntry, werr error) error {
+		if werr != nil {
+			return werr
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+		if d.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		return writeWithSourceMode(target, transform(filepath.ToSlash(rel), data), path)
+	})
+}
+
+// translateExecManifest writes the variant's exec-manifest.txt:
+// census entries under materialized units, re-rooted to the variant's
+// prefixed paths, so project-scope copies keep validation rule 3 of
+// the unshaping spec end-to-end. A store without the census emits
+// none.
+func translateExecManifest(storeRoot, destDir string, inv *PluginInventory, prefix string) error {
+	data, err := os.ReadFile(filepath.Join(storeRoot, execManifestName))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read %s: %w", execManifestName, err)
+	}
+
+	var out []string
+	for _, line := range strings.Split(string(data), "\n") {
+		rel := strings.TrimSpace(line)
+		if rel == "" || strings.HasPrefix(rel, "#") {
+			continue
+		}
+		for _, s := range inv.SkillDirs {
+			if rel == s || strings.HasPrefix(rel, s+"/") {
+				name := filepath.Base(s)
+				out = append(out, "skills/"+prefix+"-"+name+strings.TrimPrefix(rel, s))
+				break
+			}
+		}
+		for _, a := range inv.AgentFiles {
+			if rel == a {
+				prefixed, err := prefixTopLevel(a, "agents", prefix)
+				if err == nil {
+					out = append(out, prefixed)
+				}
+				break
+			}
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return os.WriteFile(filepath.Join(destDir, execManifestName), []byte(strings.Join(out, "\n")+"\n"), 0o644)
+}

--- a/internal/bindings/bound_variant_test.go
+++ b/internal/bindings/bound_variant_test.go
@@ -1,0 +1,276 @@
+package bindings
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ArcavenAE/sideshow/internal/pack"
+)
+
+// writeBoundFixtureStore mirrors the upstream vsdd-factory shapes the
+// transforms exist for: a generic-named skill (T16: user-scope
+// shadowing makes prefixing correctness-critical), namespace-qualified
+// slash and subagent_type references, prose with a bare "pack: " that
+// must survive, an executable helper, and nested agents.
+func writeBoundFixtureStore(t *testing.T) string {
+	t.Helper()
+	store := t.TempDir()
+	mustWrite := func(rel, content string, mode os.FileMode) {
+		t.Helper()
+		p := filepath.Join(store, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(content), mode); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	mustWrite("skills/jira/SKILL.md",
+		"---\nname: jira\ndescription: generic name upstream\n---\n\n"+
+			"Run /vsdd-factory:github-ops first. Note that vsdd-factory: a plugin, ships this.\n"+
+			"name: jira appears in the body too.\n", 0o644)
+	mustWrite("skills/jira/bin/helper.sh", "#!/bin/sh\necho vsdd-factory:github-ops\n", 0o755)
+	mustWrite("skills/jira/ref.csv", "a,b\n", 0o644)
+	mustWrite("agents/github-ops.md",
+		"---\nname: github-ops\n---\n\nI am spawned as subagent_type=\"vsdd-factory:github-ops\".\n", 0o644)
+	mustWrite("agents/orchestrator/planner.md",
+		"---\nname: planner\n---\n\nDelegate via Agent(subagent_type=\"vsdd-factory:pr-manager\").\n", 0o644)
+	mustWrite("exec-manifest.txt", "skills/jira/bin/helper.sh\nbin/never-materialized.sh\n", 0o644)
+
+	return store
+}
+
+func boundFixtureInventory() *PluginInventory {
+	return &PluginInventory{
+		SkillDirs:  []string{"skills/jira"},
+		AgentFiles: []string{"agents/github-ops.md", "agents/orchestrator/planner.md"},
+	}
+}
+
+func renderFixtureVariant(t *testing.T) (string, *PluginInventory) {
+	t.Helper()
+	store := writeBoundFixtureStore(t)
+	dest := filepath.Join(t.TempDir(), "bound", "vsdd-factory", "1.0.0-rc.23")
+	out, err := RenderBoundVariant(store, boundFixtureInventory(), "vsdd-factory", "vsdd", dest)
+	if err != nil {
+		t.Fatalf("RenderBoundVariant: %v", err)
+	}
+	return dest, out
+}
+
+func TestRenderBoundVariant_PrefixesNamesAndInventory(t *testing.T) {
+	t.Parallel()
+	dest, out := renderFixtureVariant(t)
+
+	if got, want := out.SkillDirs, []string{"skills/vsdd-jira"}; len(got) != 1 || got[0] != want[0] {
+		t.Errorf("SkillDirs = %v, want %v", got, want)
+	}
+	wantAgents := map[string]bool{
+		"agents/vsdd-github-ops.md":           true,
+		"agents/vsdd-orchestrator/planner.md": true,
+	}
+	for _, a := range out.AgentFiles {
+		if !wantAgents[a] {
+			t.Errorf("unexpected agent path %s", a)
+		}
+	}
+	if len(out.AgentFiles) != 2 {
+		t.Errorf("AgentFiles = %v, want 2 entries", out.AgentFiles)
+	}
+	if _, err := os.Stat(filepath.Join(dest, "skills", "vsdd-jira", "SKILL.md")); err != nil {
+		t.Errorf("prefixed skill dir missing: %v", err)
+	}
+}
+
+func TestRenderBoundVariant_RewritesFrontmatterAndReferences(t *testing.T) {
+	t.Parallel()
+	dest, _ := renderFixtureVariant(t)
+
+	skill, err := os.ReadFile(filepath.Join(dest, "skills", "vsdd-jira", "SKILL.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(skill)
+	if !strings.Contains(s, "name: vsdd-jira\n") {
+		t.Error("skill frontmatter name not prefixed")
+	}
+	if !strings.Contains(s, "/vsdd-github-ops first") {
+		t.Error("slash-form namespace reference not rewritten")
+	}
+	if !strings.Contains(s, "vsdd-factory: a plugin") {
+		t.Error("prose 'pack: ' false positive: bare mention was rewritten")
+	}
+	if !strings.Contains(s, "name: jira appears in the body") {
+		t.Error("body name: line rewritten; only frontmatter should change")
+	}
+
+	agent, err := os.ReadFile(filepath.Join(dest, "agents", "vsdd-github-ops.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	a := string(agent)
+	if !strings.Contains(a, "name: vsdd-github-ops\n") {
+		t.Error("agent frontmatter name not prefixed")
+	}
+	if !strings.Contains(a, `subagent_type="vsdd-github-ops"`) {
+		t.Errorf("subagent_type reference not rewritten:\n%s", a)
+	}
+
+	nested, err := os.ReadFile(filepath.Join(dest, "agents", "vsdd-orchestrator", "planner.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(nested), `subagent_type="vsdd-pr-manager"`) {
+		t.Error("nested agent namespace reference not rewritten")
+	}
+	if !strings.Contains(string(nested), "name: vsdd-planner\n") {
+		t.Error("nested agent frontmatter name not prefixed")
+	}
+}
+
+func TestRenderBoundVariant_PreservesExecBitsAndTranslatesCensus(t *testing.T) {
+	t.Parallel()
+	dest, _ := renderFixtureVariant(t)
+
+	helper := filepath.Join(dest, "skills", "vsdd-jira", "bin", "helper.sh")
+	info, err := os.Stat(helper)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm()&0o100 == 0 {
+		t.Errorf("variant helper lost exec bit: %o", info.Mode().Perm())
+	}
+	// Executable content still gets the namespace rewrite (.sh is not
+	// a rewrite extension, so it stays byte-identical to the store).
+	data, err := os.ReadFile(helper)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "vsdd-factory:github-ops") {
+		t.Error("non-rewrite-extension file was transformed; shell content must stay byte-identical")
+	}
+
+	census, err := os.ReadFile(filepath.Join(dest, execManifestName))
+	if err != nil {
+		t.Fatalf("translated census missing: %v", err)
+	}
+	got := strings.TrimSpace(string(census))
+	if got != "skills/vsdd-jira/bin/helper.sh" {
+		t.Errorf("translated census = %q, want the prefixed materialized entry only", got)
+	}
+}
+
+func TestRenderBoundVariant_RebuildIsIdempotent(t *testing.T) {
+	t.Parallel()
+	store := writeBoundFixtureStore(t)
+	dest := filepath.Join(t.TempDir(), "bound-variant")
+
+	if _, err := RenderBoundVariant(store, boundFixtureInventory(), "vsdd-factory", "vsdd", dest); err != nil {
+		t.Fatal(err)
+	}
+	first := snapshotTree(t, dest)
+	if _, err := RenderBoundVariant(store, boundFixtureInventory(), "vsdd-factory", "vsdd", dest); err != nil {
+		t.Fatal(err)
+	}
+	second := snapshotTree(t, dest)
+	if diff := diffSnapshots(first, second); len(diff) > 0 {
+		t.Errorf("re-render not deterministic:\n  %s", strings.Join(diff, "\n  "))
+	}
+}
+
+// The .51 → .48 composition: the variant feeds MaterializeRepo
+// unchanged, local scope symlinks resolve into the variant, and the
+// exact-inverse property holds end to end.
+func TestBoundVariant_ComposesWithMaterializeRepo(t *testing.T) {
+	t.Parallel()
+	dest, out := renderFixtureVariant(t)
+	repo := writeRepoWithUserContent(t)
+	target := RepoTarget{RepoDir: repo, Scope: ScopeLocal}
+
+	before := snapshotTree(t, repo)
+	artifacts, err := MaterializeRepo(dest, out, target)
+	if err != nil {
+		t.Fatalf("MaterializeRepo from variant: %v", err)
+	}
+
+	link := filepath.Join(repo, ".claude", "skills", "vsdd-jira")
+	targetPath, err := os.Readlink(link)
+	if err != nil {
+		t.Fatalf("prefixed skill not symlinked: %v", err)
+	}
+	if want := filepath.Join(dest, "skills", "vsdd-jira"); targetPath != want {
+		t.Errorf("symlink target = %s, want the bound variant %s", targetPath, want)
+	}
+
+	if _, err := RemoveRepoArtifacts(target, artifacts); err != nil {
+		t.Fatal(err)
+	}
+	if diff := diffSnapshots(before, snapshotTree(t, repo)); len(diff) > 0 {
+		t.Errorf("variant materialization not exactly inverted:\n  %s", strings.Join(diff, "\n  "))
+	}
+}
+
+// Real-tree check (env-gated like TestDiscoverPluginLayout_RealTree):
+// after rendering the variant from an actual vsdd-factory tree, zero
+// namespace-qualified references survive in rewrite-extension files —
+// the full slash-form + subagent_type surface is covered.
+func TestRenderBoundVariant_RealTreeLeavesNoQualifiedReferences(t *testing.T) {
+	tree := os.Getenv("VSDD_TREE")
+	if tree == "" {
+		t.Skip("VSDD_TREE not set; real-tree rewrite check skipped")
+	}
+	inv, err := DiscoverPluginLayout(pack.InstalledPack{Name: "vsdd-factory", Version: "real-tree", Path: tree})
+	if err != nil {
+		t.Fatalf("DiscoverPluginLayout: %v", err)
+	}
+	dest := filepath.Join(t.TempDir(), "bound")
+	if _, err := RenderBoundVariant(tree, inv, "vsdd-factory", "vsdd", dest); err != nil {
+		t.Fatalf("RenderBoundVariant: %v", err)
+	}
+
+	var leftovers []string
+	err = filepath.WalkDir(dest, func(path string, d os.DirEntry, werr error) error {
+		if werr != nil || d.IsDir() || !shouldRewrite(path) {
+			return werr
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		for _, line := range strings.Split(string(data), "\n") {
+			if idx := strings.Index(line, "vsdd-factory:"); idx >= 0 &&
+				idx+len("vsdd-factory:") < len(line) && isNameChar(line[idx+len("vsdd-factory:")]) {
+				rel, _ := filepath.Rel(dest, path)
+				leftovers = append(leftovers, rel+": "+strings.TrimSpace(line))
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(leftovers) > 0 {
+		t.Errorf("%d namespace-qualified references survived the rewrite:\n  %s",
+			len(leftovers), strings.Join(leftovers, "\n  "))
+	}
+}
+
+func isNameChar(c byte) bool {
+	return c == '-' || c == '_' ||
+		(c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
+}
+
+func TestRewriteFrontmatterName_Idempotent(t *testing.T) {
+	t.Parallel()
+	in := "---\nname: vsdd-jira\n---\nbody\n"
+	if got := rewriteFrontmatterName(in, "vsdd"); got != in {
+		t.Errorf("already-prefixed name double-prefixed: %q", got)
+	}
+	noFM := "no frontmatter here\nname: jira\n"
+	if got := rewriteFrontmatterName(noFM, "vsdd"); got != noFM {
+		t.Errorf("content without frontmatter modified: %q", got)
+	}
+}

--- a/internal/pack/activation.go
+++ b/internal/pack/activation.go
@@ -17,6 +17,14 @@ type Activation struct {
 	Mechanism             string `yaml:"mechanism"`
 	Runbook               string `yaml:"runbook"`
 	ValidatedHarnessFloor string `yaml:"validated_harness_floor"`
+	// BindingPrefix names the prefix bound artifacts carry in a repo
+	// (aae-orc-d3nq.51): skill dirs, agent entries, and every internal
+	// reference are renamed <prefix>-<name> at bind time. Empty means
+	// the pack name. The prefix is correctness-load-bearing, not
+	// hygiene: a user-scope skill shadows a same-name repo skill
+	// (finding-091 addendum 3, T16 corrected), so unprefixed generic
+	// names would be silently hijacked on consumer machines.
+	BindingPrefix string `yaml:"binding_prefix"`
 }
 
 // knownMechanisms are the activation mechanisms this sideshow version
@@ -24,6 +32,19 @@ type Activation struct {
 // the calmer install notice over the unrecognized-mechanism warning.
 var knownMechanisms = map[string]bool{
 	"claude-plugin": true,
+	// repo-bindings is the unshaping delivery mechanism (decision D4,
+	// finding-094): per-repo materialization from the store with no
+	// harness plugin state.
+	"repo-bindings": true,
+}
+
+// Prefix returns the binding prefix bound artifacts carry, defaulting
+// to the pack name when the pack declares none.
+func (a *Activation) Prefix(packName string) string {
+	if a != nil && a.BindingPrefix != "" {
+		return a.BindingPrefix
+	}
+	return packName
 }
 
 // PluginClass reports whether the pack activates through a mechanism

--- a/internal/pack/activation_test.go
+++ b/internal/pack/activation_test.go
@@ -175,3 +175,17 @@ func TestInstallFromLocal_UnknownMechanismWarns(t *testing.T) {
 		t.Errorf("unknown mechanism must warn by name:\n%s", out)
 	}
 }
+
+func TestActivationPrefix(t *testing.T) {
+	t.Parallel()
+	if got := (&Activation{BindingPrefix: "vsdd"}).Prefix("vsdd-factory"); got != "vsdd" {
+		t.Errorf("declared prefix = %q, want vsdd", got)
+	}
+	if got := (&Activation{}).Prefix("mypack"); got != "mypack" {
+		t.Errorf("default prefix = %q, want pack name", got)
+	}
+	var nilAct *Activation
+	if got := nilAct.Prefix("mypack"); got != "mypack" {
+		t.Errorf("nil activation prefix = %q, want pack name", got)
+	}
+}


### PR DESCRIPTION
Upstream vsdd-factory ships a skill literally named `jira` and 34 generic agent names, and trials proved a user-scope skill silently shadows a same-name repo skill — so unprefixed bound names would be hijacked on any consumer machine that happens to carry a collision. This PR makes bound-artifact names prefixed by policy, and reconciles that with the frozen store: transforms render once per pack version into a machine-scoped **bound variant**, and repos materialize from the variant, keeping every symlink property of the local-scope strategy (one copy per machine, exec bits in one place, version flip is one repoint). Additive: bmad's sync path and existing pack.yaml files are untouched; the prefix field defaults to the pack name.

## What ships

- **`activation.binding_prefix`** in pack.yaml (default: pack name) with `Activation.Prefix`; `knownMechanisms` gains `repo-bindings` (decision D4).
- **`RenderBoundVariant`** — skill dirs and agent top-level entries renamed `<prefix>-<name>` (nesting preserved; bare-name addressing per trial T20). SKILL.md and agent frontmatter `name:` are prefixed to agree with the bound location. The namespace rewrite `<pack>:<name>` → `<prefix>-<name>` covers slash-form skill references and `subagent_type` call sites with one rule, and is immune to prose `pack: ...` false positives. Rewrite extensions only — shell and binaries stay byte-identical to the store. Exec bits are preserved and the exec-manifest census is translated to variant paths, so copy-mode verification holds end to end.
- The variant inventory feeds the existing repo materializer unchanged, and the exact-inverse enable/disable property is re-proven through the composition.
- **Real-tree gate** (env-gated on `VSDD_TREE`): rendering the actual upstream tree (124 skills, 44 agent files) leaves zero namespace-qualified references in rewrite-extension files — the full 176 slash-form + 23 subagent_type surface, verified rather than counted.

Refs: aae-orc-d3nq.51, finding-091, finding-094