### PR TITLE
feat(bindings): engine-path compat symlink per decision D2

### DIFF
--- a/internal/bindings/compat_symlink.go
+++ b/internal/bindings/compat_symlink.go
@@ -1,0 +1,89 @@
+package bindings
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// The compat symlink is decision D2 (finding-094, aae-orc-d3nq.58):
+// <repo>/plugins/<pack> points at the pinned store version root, so
+// the 451 repo-relative plugins/<pack>/... references in the pack —
+// including three live dispatcher capability grants that only ever
+// resolved when the engine was vendored — resolve with zero content
+// rewriting and zero store mutation.
+//
+// Ratification riders: the symlink is recorded in the per-repo
+// ownership records (removal is exact) and belongs in the repo
+// gitignore (.53) so it never enters history. Grant-resolution is a
+// behavior change: those grants have never executed in any consumer
+// repo, so their first observed outcome is a trial before it is a
+// claim (recorded in the divergence register, .55).
+
+// ArtifactCompatSymlink is the compat symlink's artifact kind.
+// Removal only ever removes a SYMLINK at the recorded path — a real
+// directory there (the pack developing itself vendors the engine at
+// the same path) fails closed.
+const ArtifactCompatSymlink = "compat-symlink"
+
+// compatDir is the repo-relative directory compat symlinks live in.
+const compatDir = "plugins"
+
+// MaterializeCompatSymlink writes <repo>/plugins/<pack> ->
+// storeRoot. A pre-existing entry at the destination refuses with
+// ErrWouldClobber before anything is written — in particular the
+// pack's own development repo, where plugins/<pack> is the real
+// vendored engine. Returned artifacts follow the MaterializeRepo
+// contract (creation order; parent dir recorded only if created).
+func MaterializeCompatSymlink(storeRoot string, t RepoTarget, packName string) ([]RepoArtifact, error) {
+	repoDir, err := filepath.Abs(t.RepoDir)
+	if err != nil {
+		return nil, fmt.Errorf("resolve repo dir: %w", err)
+	}
+	if _, err := os.Stat(repoDir); err != nil {
+		return nil, fmt.Errorf("repo dir %s: %w", repoDir, err)
+	}
+	if packName == "" || strings.ContainsAny(packName, "/\\") {
+		return nil, fmt.Errorf("invalid pack name %q for compat symlink", packName)
+	}
+
+	dst := filepath.Join(repoDir, compatDir, packName)
+	if _, err := os.Lstat(dst); err == nil {
+		return nil, fmt.Errorf("%w:\n  %s", ErrWouldClobber, filepath.ToSlash(filepath.Join(compatDir, packName)))
+	}
+
+	var created []RepoArtifact
+	parent := filepath.Join(repoDir, compatDir)
+	if _, err := os.Stat(parent); err != nil {
+		if err := os.Mkdir(parent, 0o755); err != nil {
+			return nil, fmt.Errorf("create %s: %w", compatDir, err)
+		}
+		created = append(created, RepoArtifact{Kind: ArtifactParentDir, Path: compatDir})
+	}
+	if err := os.Symlink(storeRoot, dst); err != nil {
+		if _, rmErr := RemoveRepoArtifacts(t, created); rmErr != nil {
+			fmt.Fprintf(os.Stderr, "warning: rollback after failed compat symlink: %v\n", rmErr)
+		}
+		return nil, fmt.Errorf("create compat symlink: %w", err)
+	}
+	created = append(created, RepoArtifact{
+		Kind: ArtifactCompatSymlink,
+		Path: filepath.ToSlash(filepath.Join(compatDir, packName)),
+	})
+	return created, nil
+}
+
+// compatRemovalAllowed reports whether a recorded compat artifact
+// path is one this package could have written: the symlink is exactly
+// plugins/<name>, and the only parent dir is plugins itself.
+func compatRemovalAllowed(a RepoArtifact) bool {
+	parts := strings.Split(filepath.ToSlash(a.Path), "/")
+	switch a.Kind {
+	case ArtifactCompatSymlink:
+		return len(parts) == 2 && parts[0] == compatDir && parts[1] != "" && parts[1] != ".." && parts[1] != "."
+	case ArtifactParentDir:
+		return a.Path == compatDir
+	}
+	return false
+}

--- a/internal/bindings/compat_symlink_test.go
+++ b/internal/bindings/compat_symlink_test.go
@@ -1,0 +1,149 @@
+package bindings
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestMaterializeCompatSymlink_ExactInverse(t *testing.T) {
+	t.Parallel()
+	store := t.TempDir()
+	repo := writeRepoWithUserContent(t)
+	target := RepoTarget{RepoDir: repo, Scope: ScopeLocal}
+
+	before := snapshotTree(t, repo)
+	artifacts, err := MaterializeCompatSymlink(store, target, "vsdd-factory")
+	if err != nil {
+		t.Fatalf("MaterializeCompatSymlink: %v", err)
+	}
+
+	link := filepath.Join(repo, "plugins", "vsdd-factory")
+	got, err := os.Readlink(link)
+	if err != nil {
+		t.Fatalf("compat symlink missing: %v", err)
+	}
+	if got != store {
+		t.Errorf("symlink target = %s, want the pinned store root %s", got, store)
+	}
+
+	if _, err := RemoveRepoArtifacts(target, artifacts); err != nil {
+		t.Fatalf("RemoveRepoArtifacts: %v", err)
+	}
+	if diff := diffSnapshots(before, snapshotTree(t, repo)); len(diff) > 0 {
+		t.Errorf("compat symlink not exactly inverted:\n  %s", strings.Join(diff, "\n  "))
+	}
+}
+
+// The pack's own development repo vendors the real engine at
+// plugins/<pack>; enable there must refuse, not clobber.
+func TestMaterializeCompatSymlink_RefusesVendoredEngine(t *testing.T) {
+	t.Parallel()
+	store := t.TempDir()
+	repo := t.TempDir()
+	engine := filepath.Join(repo, "plugins", "vsdd-factory")
+	if err := os.MkdirAll(engine, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(engine, "plugin.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	before := snapshotTree(t, repo)
+	_, err := MaterializeCompatSymlink(store, RepoTarget{RepoDir: repo, Scope: ScopeLocal}, "vsdd-factory")
+	if !errors.Is(err, ErrWouldClobber) {
+		t.Fatalf("err = %v, want ErrWouldClobber", err)
+	}
+	if diff := diffSnapshots(before, snapshotTree(t, repo)); len(diff) > 0 {
+		t.Errorf("refused symlink still wrote:\n  %s", strings.Join(diff, "\n  "))
+	}
+}
+
+// A pre-existing plugins/ dir with other content: the symlink goes in
+// beside it, and disable removes only the symlink.
+func TestMaterializeCompatSymlink_SharesExistingPluginsDir(t *testing.T) {
+	t.Parallel()
+	store := t.TempDir()
+	repo := t.TempDir()
+	other := filepath.Join(repo, "plugins", "other-tool")
+	if err := os.MkdirAll(other, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	artifacts, err := MaterializeCompatSymlink(store, RepoTarget{RepoDir: repo, Scope: ScopeLocal}, "vsdd-factory")
+	if err != nil {
+		t.Fatalf("MaterializeCompatSymlink: %v", err)
+	}
+	for _, a := range artifacts {
+		if a.Kind == ArtifactParentDir {
+			t.Errorf("pre-existing plugins dir recorded as created: %+v", a)
+		}
+	}
+
+	if _, err := RemoveRepoArtifacts(RepoTarget{RepoDir: repo, Scope: ScopeLocal}, artifacts); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(other); err != nil {
+		t.Errorf("sibling plugins content disturbed: %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(repo, "plugins", "vsdd-factory")); !os.IsNotExist(err) {
+		t.Errorf("compat symlink survived disable (err=%v)", err)
+	}
+}
+
+// Fail-closed removal: a ledger row claiming compat-symlink at a path
+// holding a real directory refuses rather than deleting the engine.
+func TestRemoveRepoArtifacts_CompatSymlinkNeverRemovesRealDir(t *testing.T) {
+	t.Parallel()
+	repo := t.TempDir()
+	engine := filepath.Join(repo, "plugins", "vsdd-factory")
+	if err := os.MkdirAll(engine, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := RemoveRepoArtifacts(RepoTarget{RepoDir: repo, Scope: ScopeLocal}, []RepoArtifact{
+		{Kind: ArtifactCompatSymlink, Path: "plugins/vsdd-factory"},
+	})
+	if err == nil {
+		t.Fatal("removal accepted a real directory recorded as a compat symlink")
+	}
+	if _, statErr := os.Stat(engine); statErr != nil {
+		t.Fatalf("real directory removed: %v", statErr)
+	}
+}
+
+// Containment: compat kinds only allow the exact shapes this package
+// writes; anything else outside the harness root still fails closed.
+func TestRemoveRepoArtifacts_CompatContainmentShapes(t *testing.T) {
+	t.Parallel()
+	repo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repo, ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	target := RepoTarget{RepoDir: repo, Scope: ScopeLocal}
+
+	for _, bad := range []RepoArtifact{
+		{Kind: ArtifactCompatSymlink, Path: "plugins/a/b"},
+		{Kind: ArtifactCompatSymlink, Path: "src/thing"},
+		{Kind: ArtifactCompatSymlink, Path: "plugins/.."},
+		{Kind: ArtifactParentDir, Path: "src"},
+		{Kind: ArtifactSkillDir, Path: "plugins/vsdd-factory"},
+	} {
+		if _, err := RemoveRepoArtifacts(target, []RepoArtifact{bad}); err == nil {
+			t.Errorf("artifact %+v accepted, want containment refusal", bad)
+		}
+	}
+
+	// The legal compat shapes pass containment (nothing on disk, so
+	// removal is a no-op rather than an error).
+	for _, ok := range []RepoArtifact{
+		{Kind: ArtifactCompatSymlink, Path: "plugins/vsdd-factory"},
+		{Kind: ArtifactParentDir, Path: "plugins"},
+	} {
+		if _, err := RemoveRepoArtifacts(target, []RepoArtifact{ok}); err != nil {
+			t.Errorf("artifact %+v refused: %v", ok, err)
+		}
+	}
+}

--- a/internal/bindings/repo_materialize.go
+++ b/internal/bindings/repo_materialize.go
@@ -334,17 +334,19 @@ func RemoveRepoArtifacts(t RepoTarget, artifacts []RepoArtifact) (int, error) {
 	root := t.harnessRoot()
 
 	// Containment preflight over the whole set before touching anything.
-	// The binding root itself is a legal artifact only as a parent-dir
-	// (Remove-if-empty is safe there); every other kind must sit
-	// strictly inside it.
+	// Two allowed roots: the harness dir (the binding root itself is a
+	// legal artifact only as a parent-dir, where Remove-if-empty is
+	// safe) and the compat-symlink shapes under plugins/ (D2). Anything
+	// else fails closed.
 	abs := make([]string, len(artifacts))
 	for i, a := range artifacts {
 		p := filepath.Join(repoDir, filepath.FromSlash(a.Path))
 		rel, relErr := filepath.Rel(root, p)
 		rootAsParentDir := rel == "." && a.Kind == ArtifactParentDir
-		if relErr != nil || strings.HasPrefix(rel, "..") || filepath.IsAbs(a.Path) ||
-			(rel == "." && !rootAsParentDir) {
-			return 0, fmt.Errorf("refusing removal: artifact %q resolves outside binding root %s", a.Path, root)
+		underHarness := relErr == nil && !strings.HasPrefix(rel, "..") && !filepath.IsAbs(a.Path) &&
+			(rel != "." || rootAsParentDir)
+		if !underHarness && !compatRemovalAllowed(a) {
+			return 0, fmt.Errorf("refusing removal: artifact %q (kind %s) resolves outside the allowed binding roots of %s", a.Path, a.Kind, repoDir)
 		}
 		abs[i] = p
 	}
@@ -364,6 +366,20 @@ func RemoveRepoArtifacts(t RepoTarget, artifacts []RepoArtifact) (int, error) {
 			}
 		case ArtifactSkillDir:
 			if rmErr := os.RemoveAll(p); rmErr != nil {
+				return removed, fmt.Errorf("remove %s: %w", a.Path, rmErr)
+			}
+		case ArtifactCompatSymlink:
+			// Only ever remove a symlink here: a real directory at the
+			// recorded path is the vendored engine (the pack developing
+			// itself), and a corrupt ledger row must not delete it.
+			info, statErr := os.Lstat(p)
+			if statErr != nil {
+				continue
+			}
+			if info.Mode()&os.ModeSymlink == 0 {
+				return removed, fmt.Errorf("refusing removal: %s is recorded as a compat symlink but is not a symlink on disk", a.Path)
+			}
+			if rmErr := os.Remove(p); rmErr != nil {
 				return removed, fmt.Errorf("remove %s: %w", a.Path, rmErr)
 			}
 		default: // ArtifactAgentFile and future file-shaped kinds


### PR DESCRIPTION
The pack carries 451 repo-relative `plugins/<pack>/...` references across 244 files that assume the engine is vendored into the consumer repo — true only when the pack develops itself. Three of them are live dispatcher capability grants (one `on_error=block`) that have never resolved for any consumer. The ratified fix is a compat symlink, `<repo>/plugins/<pack>` pointing at the pinned store version root: every repo-relative read lands in the store tree with zero content rewriting and zero store mutation. Additive; nothing else in the bindings surface changes.

## What ships

- **`MaterializeCompatSymlink`** — follows the existing artifact contract: a clobber preflight refuses any pre-existing destination, which specifically protects the pack's own development repo where `plugins/<pack>` is the real vendored engine; the `plugins/` parent dir is recorded only when created, so disable leaves a shared dir alone.
- **Removal containment gains a second allowed root** — compat kinds accept exactly the shapes this package writes (`plugins/<name>` symlink, `plugins` parent); everything else outside the harness root still fails closed. The removal path only ever deletes a symlink at the recorded path: a ledger row pointing at a real directory refuses rather than deleting an engine.
- Tests for exact inverse, vendored-engine refusal, shared-plugins-dir siblings, fail-closed real-dir removal, and containment shapes.

Grant resolution is a behavior change (three grants switch on for the first time in a consumer repo); its first observed outcome is a trial before it is a claim, tracked in the divergence register.

Refs: aae-orc-d3nq.58, finding-094