### PR TITLE
feat(factoryguard): running-factory refusal predicate for mutating verbs

### DIFF
--- a/internal/factoryguard/factoryguard.go
+++ b/internal/factoryguard/factoryguard.go
@@ -1,0 +1,256 @@
+// Package factoryguard is the running-factory refusal predicate
+// (aae-orc-d3nq.40): every mutating sideshow verb (enable, disable,
+// adopt, uninstall) asks it before touching a repo, and doctor reads
+// it for reporting. It is strictly READ-ONLY — it inspects factory
+// state, it never writes any.
+//
+// The class-1 rule it enforces (findings 093/094): sideshow verbs
+// never touch running-factory state, and never yank the ground out
+// from under an in-flight run. Signals, from the pack's own
+// conventions:
+//
+//   - an unexpired factory_lock in .factory/STATE.md frontmatter
+//     (bin/factory-lock-write.sh shape, TTL 2700s) is a HARD refusal:
+//     the holder is named and there is no override;
+//   - an expired lock is overridable (--override-stale-lock in the
+//     verbs), reported with holder and age, so a crashed run cannot
+//     block removal forever;
+//   - between lock holds, recent wave-state.yaml or burst-log
+//     activity marks the factory in flight (overridable, but the
+//     verbs must say why they were stopped);
+//   - unreadable factory state fails closed as an overridable signal:
+//     the guard cannot prove the factory is NOT running.
+package factoryguard
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// LockTTL is the pack's non-configurable factory_lock TTL
+// (bin/factory-lock-write.sh Invariant 2). It doubles as the
+// "recent activity" window for the soft signals.
+const LockTTL = 2700 * time.Second
+
+// Signal kinds.
+const (
+	SignalFactoryLock = "factory-lock"       // unexpired lock: HARD
+	SignalStaleLock   = "stale-factory-lock" // expired lock: overridable
+	SignalWaveState   = "wave-state-activity"
+	SignalBurstLog    = "recent-burst-log"
+	SignalUnreadable  = "unreadable-factory-state"
+)
+
+// Signal is one observed in-flight indicator.
+type Signal struct {
+	Kind   string
+	Detail string
+	// Hard signals permit no override; everything else the verbs may
+	// pass with an explicit operator override flag.
+	Hard bool
+}
+
+// Verdict is the guard's answer for one repo.
+type Verdict struct {
+	RepoDir string
+	Signals []Signal
+}
+
+// InFlight reports whether any signal fired.
+func (v *Verdict) InFlight() bool { return len(v.Signals) > 0 }
+
+// HardRefusal reports whether an un-overridable signal fired.
+func (v *Verdict) HardRefusal() bool {
+	for _, s := range v.Signals {
+		if s.Hard {
+			return true
+		}
+	}
+	return false
+}
+
+// Refusal renders the verb-facing refusal text: every signal, one per
+// line, hard ones first.
+func (v *Verdict) Refusal() string {
+	var hard, soft []string
+	for _, s := range v.Signals {
+		line := fmt.Sprintf("[%s] %s", s.Kind, s.Detail)
+		if s.Hard {
+			hard = append(hard, line)
+		} else {
+			soft = append(soft, line)
+		}
+	}
+	return strings.Join(append(hard, soft...), "\n")
+}
+
+// LockInfo is the parsed factory_lock block.
+type LockInfo struct {
+	Holder    string
+	LockedAt  time.Time
+	ExpiresAt time.Time
+}
+
+// CheckRepo inspects one repo for an in-flight factory. now is
+// injected so verbs and tests share one clock read.
+func CheckRepo(repoDir string, now time.Time) *Verdict {
+	v := &Verdict{RepoDir: repoDir}
+	factory := filepath.Join(repoDir, ".factory")
+	if _, err := os.Stat(factory); err != nil {
+		return v // no factory state at all
+	}
+
+	statePath := filepath.Join(factory, "STATE.md")
+	lock, err := readFactoryLock(statePath)
+	switch {
+	case err != nil:
+		v.Signals = append(v.Signals, Signal{
+			Kind:   SignalUnreadable,
+			Detail: fmt.Sprintf("%s could not be read (%v); the guard cannot prove the factory is not running", statePath, err),
+		})
+	case lock != nil && now.Before(lock.ExpiresAt):
+		v.Signals = append(v.Signals, Signal{
+			Kind: SignalFactoryLock,
+			Detail: fmt.Sprintf("factory_lock held by %s (locked %s, expires %s); no override — wait for the run or its lock expiry",
+				lock.Holder, lock.LockedAt.Format(time.RFC3339), lock.ExpiresAt.Format(time.RFC3339)),
+			Hard: true,
+		})
+	case lock != nil:
+		v.Signals = append(v.Signals, Signal{
+			Kind: SignalStaleLock,
+			Detail: fmt.Sprintf("stale factory_lock held by %s, expired %s ago; pass the stale-lock override to proceed",
+				lock.Holder, now.Sub(lock.ExpiresAt).Round(time.Second)),
+		})
+	}
+
+	cutoff := now.Add(-LockTTL)
+	if mt, ok := mtime(filepath.Join(factory, "wave-state.yaml")); ok && mt.After(cutoff) {
+		v.Signals = append(v.Signals, Signal{
+			Kind:   SignalWaveState,
+			Detail: fmt.Sprintf("wave-state.yaml written %s ago; a wave appears in flight", now.Sub(mt).Round(time.Second)),
+		})
+	}
+	if path, mt, ok := newestEntry(filepath.Join(factory, "logs")); ok && mt.After(cutoff) {
+		v.Signals = append(v.Signals, Signal{
+			Kind:   SignalBurstLog,
+			Detail: fmt.Sprintf("burst log %s written %s ago; a burst appears in flight", filepath.Base(path), now.Sub(mt).Round(time.Second)),
+		})
+	}
+	return v
+}
+
+// CheckRepos sweeps a repo list (machine-scoped operations check
+// every ledger-known repo) and returns only in-flight verdicts.
+func CheckRepos(repoDirs []string, now time.Time) []*Verdict {
+	var out []*Verdict
+	for _, dir := range repoDirs {
+		if v := CheckRepo(dir, now); v.InFlight() {
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
+// readFactoryLock parses the factory_lock block out of STATE.md's
+// YAML frontmatter by line scan. The frontmatter in live factories
+// carries multi-kilobyte narrative fields, so a full YAML unmarshal
+// is deliberately avoided; the lock writer's shape is fixed (the key
+// followed by two-space-indented holder/locked_at/expires_at).
+// Missing file or absent key returns (nil, nil); a lock block whose
+// timestamps do not parse is an error (the guard fails closed).
+func readFactoryLock(statePath string) (*LockInfo, error) {
+	data, err := os.ReadFile(statePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	lines := strings.Split(string(data), "\n")
+	if len(lines) == 0 || strings.TrimRight(lines[0], "\r") != "---" {
+		return nil, nil // no frontmatter, no lock
+	}
+
+	var lock *LockInfo
+	inLock := false
+	for _, raw := range lines[1:] {
+		line := strings.TrimRight(raw, "\r")
+		if line == "---" {
+			break
+		}
+		if strings.HasPrefix(line, "factory_lock:") {
+			lock = &LockInfo{}
+			inLock = true
+			continue
+		}
+		if !inLock {
+			continue
+		}
+		if !strings.HasPrefix(line, "  ") {
+			inLock = false
+			continue
+		}
+		key, val, ok := strings.Cut(strings.TrimSpace(line), ":")
+		if !ok {
+			continue
+		}
+		val = strings.Trim(strings.TrimSpace(val), `"'`)
+		switch key {
+		case "holder":
+			lock.Holder = val
+		case "locked_at":
+			t, err := time.Parse(time.RFC3339, val)
+			if err != nil {
+				return nil, fmt.Errorf("factory_lock.locked_at %q: %w", val, err)
+			}
+			lock.LockedAt = t
+		case "expires_at":
+			t, err := time.Parse(time.RFC3339, val)
+			if err != nil {
+				return nil, fmt.Errorf("factory_lock.expires_at %q: %w", val, err)
+			}
+			lock.ExpiresAt = t
+		}
+	}
+	if lock != nil && lock.ExpiresAt.IsZero() {
+		return nil, fmt.Errorf("factory_lock block in %s has no parseable expires_at", statePath)
+	}
+	return lock, nil
+}
+
+func mtime(path string) (time.Time, bool) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return info.ModTime(), true
+}
+
+// newestEntry returns the most recently modified file directly under
+// dir.
+func newestEntry(dir string) (string, time.Time, bool) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return "", time.Time{}, false
+	}
+	var bestPath string
+	var bestTime time.Time
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		if info.ModTime().After(bestTime) {
+			bestTime = info.ModTime()
+			bestPath = filepath.Join(dir, e.Name())
+		}
+	}
+	return bestPath, bestTime, bestPath != ""
+}

--- a/internal/factoryguard/factoryguard_test.go
+++ b/internal/factoryguard/factoryguard_test.go
@@ -1,0 +1,198 @@
+package factoryguard
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+var testNow = time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
+
+// writeFactory builds a .factory fixture. stateFrontmatter is placed
+// inside the --- fences; empty means no STATE.md at all.
+func writeFactory(t *testing.T, stateFrontmatter string) string {
+	t.Helper()
+	repo := t.TempDir()
+	factory := filepath.Join(repo, ".factory")
+	if err := os.MkdirAll(factory, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if stateFrontmatter != "" {
+		content := "---\n" + stateFrontmatter + "---\n\n# Factory State\n"
+		if err := os.WriteFile(filepath.Join(factory, "STATE.md"), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return repo
+}
+
+func lockBlock(holder string, lockedAt, expiresAt time.Time) string {
+	return "document_type: pipeline-state\n" +
+		"timestamp: 2026-07-21T21:38:00Z\n" +
+		"factory_lock:\n" +
+		"  holder: " + holder + "\n" +
+		"  locked_at: " + lockedAt.Format(time.RFC3339) + "\n" +
+		"  expires_at: " + expiresAt.Format(time.RFC3339) + "\n" +
+		"phase: E-21\n"
+}
+
+func TestCheckRepo_NoFactoryState(t *testing.T) {
+	t.Parallel()
+	v := CheckRepo(t.TempDir(), testNow)
+	if v.InFlight() {
+		t.Errorf("clean repo reported in flight: %+v", v.Signals)
+	}
+}
+
+func TestCheckRepo_UnexpiredLockIsHard(t *testing.T) {
+	t.Parallel()
+	repo := writeFactory(t, lockBlock("dev@example.com", testNow.Add(-10*time.Minute), testNow.Add(35*time.Minute)))
+
+	v := CheckRepo(repo, testNow)
+	if !v.HardRefusal() {
+		t.Fatalf("unexpired lock not a hard refusal: %+v", v.Signals)
+	}
+	msg := v.Refusal()
+	if !strings.Contains(msg, "dev@example.com") {
+		t.Errorf("refusal does not name the holder:\n%s", msg)
+	}
+	if !strings.Contains(msg, "no override") {
+		t.Errorf("refusal does not state no-override:\n%s", msg)
+	}
+}
+
+func TestCheckRepo_ExpiredLockIsOverridable(t *testing.T) {
+	t.Parallel()
+	repo := writeFactory(t, lockBlock("dev@example.com", testNow.Add(-3*time.Hour), testNow.Add(-2*time.Hour)))
+
+	v := CheckRepo(repo, testNow)
+	if !v.InFlight() || v.HardRefusal() {
+		t.Fatalf("expired lock should be overridable in-flight: %+v", v.Signals)
+	}
+	msg := v.Refusal()
+	if !strings.Contains(msg, "dev@example.com") || !strings.Contains(msg, "expired 2h0m0s ago") {
+		t.Errorf("stale-lock signal missing holder or age:\n%s", msg)
+	}
+	if !strings.Contains(msg, "override") {
+		t.Errorf("stale-lock signal does not mention the override:\n%s", msg)
+	}
+}
+
+func TestCheckRepo_ClearedLockNoSignals(t *testing.T) {
+	t.Parallel()
+	// A paused factory: frontmatter with no factory_lock key, no
+	// recent activity.
+	repo := writeFactory(t, "document_type: pipeline-state\npipeline: PAUSED\n")
+
+	v := CheckRepo(repo, testNow)
+	if v.InFlight() {
+		t.Errorf("paused factory reported in flight: %+v", v.Signals)
+	}
+}
+
+func TestCheckRepo_RecentActivityIsSoftSignal(t *testing.T) {
+	t.Parallel()
+	repo := writeFactory(t, "pipeline: RUNNING\n")
+	factory := filepath.Join(repo, ".factory")
+	if err := os.WriteFile(filepath.Join(factory, "wave-state.yaml"), []byte("wave: W1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	logs := filepath.Join(factory, "logs")
+	if err := os.MkdirAll(logs, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(logs, "dispatcher-internal-2026-07-31.jsonl"), []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Files just written: both activity signals fire against a "now"
+	// close to wall clock.
+	v := CheckRepo(repo, time.Now())
+	kinds := map[string]bool{}
+	for _, s := range v.Signals {
+		kinds[s.Kind] = true
+		if s.Hard {
+			t.Errorf("activity signal %s marked hard; only the unexpired lock is", s.Kind)
+		}
+	}
+	if !kinds[SignalWaveState] || !kinds[SignalBurstLog] {
+		t.Errorf("expected wave-state and burst-log signals, got %+v", v.Signals)
+	}
+
+	// The same tree long after: signals age out.
+	v = CheckRepo(repo, time.Now().Add(2*LockTTL))
+	if v.InFlight() {
+		t.Errorf("aged-out activity still in flight: %+v", v.Signals)
+	}
+}
+
+func TestCheckRepo_MalformedLockFailsClosed(t *testing.T) {
+	t.Parallel()
+	repo := writeFactory(t, "factory_lock:\n  holder: dev@example.com\n  expires_at: not-a-time\n")
+
+	v := CheckRepo(repo, testNow)
+	if !v.InFlight() {
+		t.Fatal("unreadable lock produced no signal; the guard must fail closed")
+	}
+	if v.HardRefusal() {
+		t.Errorf("unreadable state should be overridable, not hard: %+v", v.Signals)
+	}
+	if v.Signals[0].Kind != SignalUnreadable {
+		t.Errorf("signal kind = %s, want %s", v.Signals[0].Kind, SignalUnreadable)
+	}
+}
+
+func TestCheckRepo_NoFrontmatterNoLock(t *testing.T) {
+	t.Parallel()
+	repo := t.TempDir()
+	factory := filepath.Join(repo, ".factory")
+	if err := os.MkdirAll(factory, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(factory, "STATE.md"), []byte("# Just a heading\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if v := CheckRepo(repo, testNow); v.InFlight() {
+		t.Errorf("frontmatter-less STATE.md reported in flight: %+v", v.Signals)
+	}
+}
+
+func TestCheckRepos_SweepReturnsOnlyInFlight(t *testing.T) {
+	t.Parallel()
+	locked := writeFactory(t, lockBlock("a@example.com", testNow.Add(-time.Minute), testNow.Add(44*time.Minute)))
+	clean := t.TempDir()
+	paused := writeFactory(t, "pipeline: PAUSED\n")
+
+	verdicts := CheckRepos([]string{locked, clean, paused}, testNow)
+	if len(verdicts) != 1 || verdicts[0].RepoDir != locked {
+		t.Errorf("sweep = %+v, want only the locked repo", verdicts)
+	}
+}
+
+// The parser survives the shape of a REAL factory frontmatter: huge
+// narrative fields with colons, quotes, and nested brackets around
+// the lock block.
+func TestReadFactoryLock_ToleratesNarrativeFrontmatter(t *testing.T) {
+	t.Parallel()
+	fm := "document_type: pipeline-state\n" +
+		"last_amended: \"2026-07-21 (v6.17) — huge narrative: with [nested: things] and \\\"quotes\\\"; more text\"\n" +
+		"factory_lock:\n" +
+		"  holder: dev@example.com\n" +
+		"  locked_at: 2026-07-31T11:00:00Z\n" +
+		"  expires_at: 2026-07-31T11:45:00Z\n" +
+		"current_step: \"D-chain cite D-874 (POLICY 16: grep -n \\\"^## D-\\\" | tail -3)\"\n"
+	repo := writeFactory(t, fm)
+
+	lock, err := readFactoryLock(filepath.Join(repo, ".factory", "STATE.md"))
+	if err != nil {
+		t.Fatalf("readFactoryLock: %v", err)
+	}
+	if lock == nil || lock.Holder != "dev@example.com" {
+		t.Fatalf("lock = %+v", lock)
+	}
+	if !lock.ExpiresAt.Equal(time.Date(2026, 7, 31, 11, 45, 0, 0, time.UTC)) {
+		t.Errorf("expires_at = %v", lock.ExpiresAt)
+	}
+}

--- a/internal/factoryguard/realtree_test.go
+++ b/internal/factoryguard/realtree_test.go
@@ -1,0 +1,19 @@
+package factoryguard
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+// Env-gated real-tree observation (same pattern as the bindings
+// package's VSDD_TREE tests): run the guard read-only against an
+// actual factory checkout and print what it sees.
+func TestCheckRepo_RealTree(t *testing.T) {
+	repo := os.Getenv("VSDD_FACTORY_REPO")
+	if repo == "" {
+		t.Skip("VSDD_FACTORY_REPO not set; real-tree guard observation skipped")
+	}
+	v := CheckRepo(repo, time.Now())
+	t.Logf("in-flight=%v hard=%v\n%s", v.InFlight(), v.HardRefusal(), v.Refusal())
+}


### PR DESCRIPTION
vsdd-factory runs are long-lived and stateful; a sideshow enable, disable, or uninstall landing mid-run could yank bindings out from under an in-flight burst. This PR ships the shared read-only predicate every mutating verb will ask first, enforcing the ratified "without damaging their running factories" rule. It inspects factory state and never writes any.

## Signals (from the pack's own conventions)

- An unexpired `factory_lock` in `.factory/STATE.md` frontmatter (the pack's lock-writer shape, TTL 2700s) is a **hard refusal**: the holder is named and there is no override.
- An expired lock is overridable, reported with holder and age, so a crashed run cannot block removal forever.
- Between lock holds, recent `wave-state.yaml` or burst-log activity (within the lock TTL) marks the factory in flight — overridable, but the verbs say why they stopped.
- Unreadable factory state fails closed as an overridable signal: the guard cannot prove the factory is *not* running.

`CheckRepo` takes an injected clock; `CheckRepos` sweeps a repo list for machine-scoped operations. The frontmatter parse is a line scan by design: live factory frontmatter carries multi-kilobyte narrative fields a full YAML unmarshal would choke on, and the lock block's shape is fixed. A test locks the parser against real-shaped narrative frontmatter, and an env-gated observation runs the guard against an actual factory checkout (the paused fork correctly reads as not in flight).

Refs: aae-orc-d3nq.40, finding-093, finding-094