### PR TITLE
feat(coexist-check): per-repo enable/adopt preflight and repo-bindings ledger reader

### DIFF
--- a/cmd/sideshow/coexist_check.go
+++ b/cmd/sideshow/coexist_check.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/ArcavenAE/sideshow/internal/bindings"
+	"github.com/ArcavenAE/sideshow/internal/coexistcheck"
+	"github.com/ArcavenAE/sideshow/internal/foreign"
+	"github.com/ArcavenAE/sideshow/internal/pack"
+)
+
+// runCoexistCheck is the read-only per-repo preflight:
+//
+//	sideshow coexist-check <pack> [--repo <path>]
+//
+// The same Run the enable/adopt verbs call as a precondition, exposed
+// standalone so an operator (or doctor) can ask "would enable refuse
+// here, and why" without touching anything.
+func runCoexistCheck(args []string) error {
+	if len(args) < 1 || len(args[0]) == 0 || args[0][0] == '-' {
+		return fmt.Errorf("usage: sideshow coexist-check <pack> [--repo <path>]")
+	}
+	packName := args[0]
+	repoDir, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("resolve working directory: %w", err)
+	}
+	for i := 1; i < len(args); i++ {
+		switch args[i] {
+		case "--repo":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--repo requires a path")
+			}
+			i++
+			repoDir = args[i]
+		default:
+			return fmt.Errorf("unknown flag: %s", args[i])
+		}
+	}
+
+	opts := coexistcheck.Options{
+		RepoDir:         repoDir,
+		Pack:            packName,
+		Prefix:          packName,
+		ConfigDir:       foreign.ConfigDir(),
+		PerRepoRequired: true,
+		Now:             time.Now().UTC(),
+	}
+	if p := findInstalledPack(packName); p != nil {
+		act, actErr := pack.LoadActivation(p.Path)
+		if actErr == nil {
+			opts.Prefix = act.Prefix(packName)
+			if act != nil {
+				opts.PerRepoRequired = act.PerRepoRequired
+			}
+		}
+		opts.StoreRoot = p.Path
+		if inv, invErr := bindings.DiscoverPluginLayout(*p); invErr == nil {
+			opts.Inventory = inv
+		}
+	}
+
+	rep, err := coexistcheck.Run(opts)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("coexist-check: %s in %s\n", packName, repoDir)
+	if len(rep.Results) == 0 {
+		fmt.Println("  all checks clean")
+	}
+	for _, r := range rep.Results {
+		fmt.Printf("  %s [%d %s]: %s\n", r.Severity, r.Check, r.Name, r.Detail)
+	}
+	if a := rep.RetreatAnchor; a != nil && a.FactoryArtifactsSHA != "" {
+		fmt.Printf("retreat anchor: factory-artifacts %s, .factory dirty=%v, captured %s\n",
+			a.FactoryArtifactsSHA, a.FactoryDirty, a.CapturedAt.Format(time.RFC3339))
+	}
+	if rep.Refuse() {
+		return fmt.Errorf("preflight refused: enable/adopt would not proceed in this repo")
+	}
+	fmt.Println("preflight clean: enable/adopt may proceed")
+	return nil
+}

--- a/cmd/sideshow/main.go
+++ b/cmd/sideshow/main.go
@@ -40,6 +40,7 @@ Usage:
                                           register it as a custom-skills source
   sideshow status                         Show installation status
   sideshow coexist <pack> [--repo <path>]  Read-only foreign-install census and coexistence findings
+  sideshow coexist-check <pack> [--repo <path>]  Read-only enable/adopt preflight (ten checks)
   sideshow version                        Show version
 
 Install options:
@@ -122,6 +123,8 @@ func main() {
 		}
 	case "status":
 		err = runStatus()
+	case "coexist-check":
+		err = runCoexistCheck(os.Args[2:])
 	case "coexist":
 		err = runCoexist(os.Args[2:])
 	case "version", "--version", "-V":

--- a/internal/coexistcheck/coexistcheck.go
+++ b/internal/coexistcheck/coexistcheck.go
@@ -1,0 +1,399 @@
+// Package coexistcheck is the per-repo preflight for enable and adopt
+// (aae-orc-d3nq.41): ten read-only checks composing the foreign
+// census (paqn), the running-factory guard (.40), the binding
+// planners (.48/.51), and the repo-bindings ledger (.5). The verbs
+// (.7 enable, .22 adopt) call Run as a precondition; doctor consumes
+// the same predicates read-only. Nothing here mutates repo, store, or
+// harness state.
+package coexistcheck
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/ArcavenAE/sideshow/internal/bindings"
+	"github.com/ArcavenAE/sideshow/internal/factoryguard"
+	"github.com/ArcavenAE/sideshow/internal/foreign"
+	"github.com/ArcavenAE/sideshow/internal/ledger"
+)
+
+// Result grades one check.
+type Result struct {
+	Check    int // 1..10 per the bead's numbering
+	Name     string
+	Severity foreign.Severity // reuse INFO/WARN/ERROR
+	Detail   string
+}
+
+// Report is the full preflight outcome.
+type Report struct {
+	RepoDir string
+	Pack    string
+	Results []Result
+	// RetreatAnchor is check (7): the pre-trial factory-artifacts tip
+	// SHA and .factory worktree status, recorded so adopt/retreat can
+	// prove the trial changed nothing it should not have.
+	RetreatAnchor *Anchor
+}
+
+// Anchor is the retreat reference point.
+type Anchor struct {
+	FactoryArtifactsSHA string
+	FactoryDirty        bool
+	CapturedAt          time.Time
+}
+
+// Refuse reports whether any ERROR-grade result fired.
+func (r *Report) Refuse() bool {
+	for _, res := range r.Results {
+		if res.Severity == foreign.Error {
+			return true
+		}
+	}
+	return false
+}
+
+// Options configures a run.
+type Options struct {
+	RepoDir         string
+	Pack            string
+	Prefix          string // binding prefix (activation.Prefix)
+	StoreRoot       string // resolved version dir being enabled; "" when unknown
+	Inventory       *bindings.PluginInventory
+	ConfigDir       string // harness config dir (foreign.ConfigDir())
+	LedgerPath      string // "" means ledger.Path()
+	PerRepoRequired bool
+	Now             time.Time
+}
+
+// Run executes the preflight.
+func Run(opts Options) (*Report, error) {
+	rep := &Report{RepoDir: opts.RepoDir, Pack: opts.Pack}
+	if opts.LedgerPath == "" {
+		opts.LedgerPath = ledger.Path()
+	}
+
+	led, err := ledger.Load(opts.LedgerPath)
+	if err != nil {
+		return nil, err
+	}
+	row := led.RepoRow(opts.RepoDir, opts.Pack)
+
+	// (1) + (10): foreign effective-enable resolution; same-repo
+	// double-dispatch is a HARD refusal (T11: both chains fired at one
+	// SessionStart). Orphaned enables surface as WARN (T14).
+	census, err := foreign.TakeCensus(opts.ConfigDir, opts.Pack)
+	if err != nil {
+		return nil, err
+	}
+	view, err := census.ResolveRepo(opts.RepoDir)
+	if err != nil {
+		return nil, err
+	}
+	sideshowActive := row != nil
+	for _, f := range foreign.Diagnose(census, view, sideshowActive, opts.PerRepoRequired) {
+		rep.add(1, "foreign-enable-resolution", f.Severity, f.Message)
+	}
+	// Enabling OUR channel where a foreign identity is already
+	// effectively enabled is the same class-1 double-dispatch even
+	// before any sideshow binding exists.
+	if !sideshowActive {
+		for _, id := range view.EffectivelyEnabled {
+			rep.add(10, "same-repo-dual-enable", foreign.Error,
+				fmt.Sprintf("%s is effectively enabled in this repo; enabling the sideshow channel would run two hook chains against one .factory state. %s",
+					id, foreign.RefusalOptions(id, opts.RepoDir)))
+		}
+	}
+
+	// (2) running-factory census: guard signals plus the git-level
+	// in-flight indicators the guard's fs view cannot see.
+	guard := factoryguard.CheckRepo(opts.RepoDir, opts.Now)
+	for _, s := range guard.Signals {
+		sev := foreign.Warn
+		if s.Hard {
+			sev = foreign.Error
+		}
+		rep.add(2, "running-factory", sev, fmt.Sprintf("[%s] %s", s.Kind, s.Detail))
+	}
+	dirty, dirtyKnown := factoryWorktreeDirty(opts.RepoDir)
+	if dirtyKnown && dirty {
+		rep.add(2, "running-factory", foreign.Warn, ".factory worktree has uncommitted changes")
+	}
+	if stories := storyWorktrees(opts.RepoDir); len(stories) > 0 {
+		rep.add(2, "running-factory", foreign.Warn,
+			fmt.Sprintf("story worktrees present: %s", strings.Join(stories, ", ")))
+	}
+
+	// (3) remote-safety: a factory-artifacts ref on origin means this
+	// checkout shares CAS state with another (bin/factory-cas-push.sh
+	// uses force-with-lease; a trial repo pushing that ref can clobber
+	// a production checkout).
+	if ref := originFactoryArtifactsRef(opts.RepoDir); ref != "" {
+		rep.add(3, "remote-safety", foreign.Error,
+			fmt.Sprintf("origin carries %s; this checkout shares factory-artifacts state with another checkout — do not run trials here", ref))
+	}
+
+	// (4) platform bind: only meaningful once the ledger says this
+	// repo is bound; verifies the env shim resolves and the dispatcher
+	// is executable at its store path.
+	if row != nil {
+		checkPlatformBind(rep, opts, row)
+	}
+
+	// (5) agent-key audit: which channel's agent copies live in the
+	// repo. Prefixed names are ours; a foreign enable means the
+	// harness ALSO loads namespace-qualified agents from the plugin.
+	checkAgentKeys(rep, opts, view)
+
+	// (6) version skew: ledger row vs the store version being enabled.
+	if row != nil && opts.StoreRoot != "" {
+		want := filepath.Base(opts.StoreRoot)
+		if row.Version != want {
+			rep.add(6, "version-skew", foreign.Warn,
+				fmt.Sprintf("repo is bound to %s %s but %s is being enabled; use the version-toggle path (disable+enable) rather than re-enable", opts.Pack, row.Version, want))
+		}
+	}
+
+	// (7) retreat anchor.
+	rep.RetreatAnchor = captureAnchor(opts.RepoDir, opts.Now)
+
+	// (9) pre-existing content collision: everything materialization
+	// would write that already exists. Refuse rather than clobber.
+	if opts.Inventory != nil {
+		for _, rel := range plannedPaths(opts) {
+			if _, err := os.Lstat(filepath.Join(opts.RepoDir, filepath.FromSlash(rel))); err == nil {
+				rep.add(9, "content-collision", foreign.Error,
+					fmt.Sprintf("%s already exists; sideshow never overwrites pre-existing repo content", rel))
+			}
+		}
+	}
+
+	sort.SliceStable(rep.Results, func(i, j int) bool { return rep.Results[i].Check < rep.Results[j].Check })
+	return rep, nil
+}
+
+func (r *Report) add(check int, name string, sev foreign.Severity, detail string) {
+	r.Results = append(r.Results, Result{Check: check, Name: name, Severity: sev, Detail: detail})
+}
+
+// plannedPaths mirrors the materialization plan (.48/.51/.58): the
+// prefixed skill dirs, prefixed agent top-level entries, and the
+// compat symlink.
+func plannedPaths(opts Options) []string {
+	var out []string
+	for _, s := range opts.Inventory.SkillDirs {
+		out = append(out, ".claude/skills/"+opts.Prefix+"-"+filepath.Base(s))
+	}
+	seenTop := map[string]bool{}
+	for _, a := range opts.Inventory.AgentFiles {
+		parts := strings.Split(filepath.ToSlash(a), "/")
+		if len(parts) < 2 {
+			continue
+		}
+		top := ".claude/agents/" + opts.Prefix + "-" + parts[1]
+		if !seenTop[top] {
+			seenTop[top] = true
+			out = append(out, top)
+		}
+	}
+	out = append(out, "plugins/"+opts.Pack)
+	return out
+}
+
+func checkPlatformBind(rep *Report, opts Options, row *ledger.Row) {
+	scopeFile := ".claude/settings.local.json"
+	if row.SettingsScope == "project" {
+		scopeFile = ".claude/settings.json"
+	}
+	settingsPath := filepath.Join(opts.RepoDir, filepath.FromSlash(scopeFile))
+	if err := bindings.VerifyEnvShim(settingsPath, "CLAUDE_PLUGIN_ROOT", row.StorePath); err != nil {
+		rep.add(4, "platform-bind", foreign.Error, err.Error())
+	}
+	dispatcher := findDispatcher(row.StorePath)
+	if dispatcher == "" {
+		rep.add(4, "platform-bind", foreign.Warn,
+			"no dispatcher binary found under the bound store path; hook commands referencing it will fail")
+		return
+	}
+	if info, err := os.Stat(dispatcher); err != nil || info.Mode().Perm()&0o100 == 0 {
+		rep.add(4, "platform-bind", foreign.Error,
+			fmt.Sprintf("dispatcher %s is not executable (zero-hooks trap: registrations that silently do nothing)", dispatcher))
+	}
+}
+
+// findDispatcher locates the platform dispatcher under the store
+// tree (hooks/dispatcher/<binary> per the upstream layout).
+func findDispatcher(storeRoot string) string {
+	dir := filepath.Join(storeRoot, "hooks", "dispatcher")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return ""
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			return filepath.Join(dir, e.Name())
+		}
+	}
+	return ""
+}
+
+func checkAgentKeys(rep *Report, opts Options, view *foreign.RepoView) {
+	agentsDir := filepath.Join(opts.RepoDir, ".claude", "agents")
+	entries, err := os.ReadDir(agentsDir)
+	if err != nil {
+		return
+	}
+	var ours, bare []string
+	for _, e := range entries {
+		name := strings.TrimSuffix(e.Name(), ".md")
+		if strings.HasPrefix(name, opts.Prefix+"-") {
+			ours = append(ours, name)
+		} else {
+			bare = append(bare, name)
+		}
+	}
+	if len(ours) > 0 {
+		rep.add(5, "agent-key-audit", foreign.Info,
+			fmt.Sprintf("%d prefixed agent entries in .claude/agents (sideshow channel)", len(ours)))
+	}
+	if len(bare) > 0 && len(view.EffectivelyEnabled) > 0 {
+		rep.add(5, "agent-key-audit", foreign.Warn,
+			fmt.Sprintf("unprefixed .claude/agents entries (%s) beside an enabled foreign identity; bare-name agent calls may resolve to either channel", strings.Join(bare, ", ")))
+	}
+}
+
+func captureAnchor(repoDir string, now time.Time) *Anchor {
+	a := &Anchor{CapturedAt: now}
+	if sha, err := gitOutput(repoDir, "rev-parse", "--verify", "--quiet", "refs/heads/factory-artifacts"); err == nil {
+		a.FactoryArtifactsSHA = sha
+	} else if sha, err := gitOutput(repoDir, "rev-parse", "--verify", "--quiet", "refs/remotes/origin/factory-artifacts"); err == nil {
+		a.FactoryArtifactsSHA = sha
+	}
+	if dirty, known := factoryWorktreeDirty(repoDir); known {
+		a.FactoryDirty = dirty
+	}
+	return a
+}
+
+// factoryWorktreeDirty reports uncommitted changes under .factory.
+// known=false when the repo is not a git checkout or .factory is
+// absent.
+func factoryWorktreeDirty(repoDir string) (dirty, known bool) {
+	if _, err := os.Stat(filepath.Join(repoDir, ".factory")); err != nil {
+		return false, false
+	}
+	out, err := gitOutput(repoDir, "status", "--porcelain", "--", ".factory")
+	if err != nil {
+		return false, false
+	}
+	return out != "", true
+}
+
+// storyWorktrees lists .worktrees/STORY-* entries — the factory's own
+// worktree pattern.
+func storyWorktrees(repoDir string) []string {
+	matches, _ := filepath.Glob(filepath.Join(repoDir, ".worktrees", "STORY-*"))
+	out := make([]string, 0, len(matches))
+	for _, m := range matches {
+		out = append(out, filepath.Base(m))
+	}
+	return out
+}
+
+// originFactoryArtifactsRef returns the local record of an origin
+// factory-artifacts ref, empty when absent. Deliberately reads local
+// remote-tracking state only — a preflight must not hit the network.
+func originFactoryArtifactsRef(repoDir string) string {
+	if _, err := gitOutput(repoDir, "rev-parse", "--verify", "--quiet", "refs/remotes/origin/factory-artifacts"); err == nil {
+		return "refs/remotes/origin/factory-artifacts"
+	}
+	return ""
+}
+
+func gitOutput(repoDir string, args ...string) (string, error) {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = repoDir
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = nil
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(buf.String()), nil
+}
+
+// SnapshotForeignFootprint is check (8)'s instrument: a content hash
+// of the foreign claude-mp footprint (registry, settings, marketplace
+// and plugin cache trees) under configDir. The footprint is fully
+// disjoint from everything sideshow writes, so identical before and
+// after a trial is clean proof the trial left the foreign channel
+// untouched.
+func SnapshotForeignFootprint(configDir string) (map[string]string, error) {
+	roots := []string{
+		filepath.Join(configDir, "plugins"),
+		filepath.Join(configDir, "settings.json"),
+	}
+	snap := map[string]string{}
+	for _, root := range roots {
+		info, err := os.Stat(root)
+		if err != nil {
+			continue
+		}
+		if !info.IsDir() {
+			if err := hashInto(snap, configDir, root); err != nil {
+				return nil, err
+			}
+			continue
+		}
+		err = filepath.WalkDir(root, func(path string, d fs.DirEntry, werr error) error {
+			if werr != nil || d.IsDir() {
+				return werr
+			}
+			return hashInto(snap, configDir, path)
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+	return snap, nil
+}
+
+func hashInto(snap map[string]string, base, path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	rel, err := filepath.Rel(base, path)
+	if err != nil {
+		return err
+	}
+	snap[filepath.ToSlash(rel)] = fmt.Sprintf("%x", sha256.Sum256(data))
+	return nil
+}
+
+// DiffFootprints reports drift between two snapshots.
+func DiffFootprints(before, after map[string]string) []string {
+	var out []string
+	for k, v := range after {
+		if bv, ok := before[k]; !ok {
+			out = append(out, "added "+k)
+		} else if bv != v {
+			out = append(out, "changed "+k)
+		}
+	}
+	for k := range before {
+		if _, ok := after[k]; !ok {
+			out = append(out, "removed "+k)
+		}
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/coexistcheck/coexistcheck_test.go
+++ b/internal/coexistcheck/coexistcheck_test.go
@@ -1,0 +1,230 @@
+package coexistcheck
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ArcavenAE/sideshow/internal/bindings"
+	"github.com/ArcavenAE/sideshow/internal/foreign"
+)
+
+var testNow = time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
+
+func write(t *testing.T, base, rel, content string) {
+	t.Helper()
+	p := filepath.Join(base, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// baseOptions builds a run against empty foreign config, empty
+// ledger, and a minimal inventory.
+func baseOptions(t *testing.T) Options {
+	t.Helper()
+	return Options{
+		RepoDir:         t.TempDir(),
+		Pack:            "vsdd-factory",
+		Prefix:          "vsdd",
+		ConfigDir:       t.TempDir(),
+		LedgerPath:      filepath.Join(t.TempDir(), "repo-bindings.yaml"),
+		PerRepoRequired: true,
+		Now:             testNow,
+		Inventory: &bindings.PluginInventory{
+			SkillDirs:  []string{"skills/pr-manager"},
+			AgentFiles: []string{"agents/github-ops.md"},
+		},
+	}
+}
+
+func severities(rep *Report, check int) []foreign.Severity {
+	var out []foreign.Severity
+	for _, r := range rep.Results {
+		if r.Check == check {
+			out = append(out, r.Severity)
+		}
+	}
+	return out
+}
+
+func TestRun_CleanRepoPasses(t *testing.T) {
+	t.Parallel()
+	rep, err := Run(baseOptions(t))
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if rep.Refuse() {
+		t.Errorf("clean repo refused: %+v", rep.Results)
+	}
+	if rep.RetreatAnchor == nil {
+		t.Error("retreat anchor not captured")
+	}
+}
+
+func TestRun_ForeignEnableIsHardRefusal(t *testing.T) {
+	t.Parallel()
+	opts := baseOptions(t)
+	write(t, opts.ConfigDir, "plugins/config.json", `{
+	  "version": 2,
+	  "repositories": {
+	    "claude-mp": {"plugins": {"vsdd-factory": [{"scope": "user", "installPath": "/nonexistent", "version": "1.0.0-rc.23"}]}}
+	  }
+	}`)
+	write(t, opts.ConfigDir, "settings.json", `{"enabledPlugins": {"vsdd-factory@claude-mp": true}}`)
+
+	rep, err := Run(opts)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !rep.Refuse() {
+		t.Fatalf("foreign enable did not refuse: %+v", rep.Results)
+	}
+	found := false
+	for _, r := range rep.Results {
+		if r.Check == 10 && r.Severity == foreign.Error && strings.Contains(r.Detail, "never auto-") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("check 10 hard refusal with consent menu missing: %+v", rep.Results)
+	}
+}
+
+func TestRun_SuppressedForeignEnablePasses(t *testing.T) {
+	t.Parallel()
+	opts := baseOptions(t)
+	write(t, opts.ConfigDir, "plugins/config.json", `{
+	  "version": 2,
+	  "repositories": {
+	    "claude-mp": {"plugins": {"vsdd-factory": [{"scope": "user", "installPath": "/nonexistent", "version": "1.0.0-rc.23"}]}}
+	  }
+	}`)
+	write(t, opts.ConfigDir, "settings.json", `{"enabledPlugins": {"vsdd-factory@claude-mp": true}}`)
+	// T10: repo-side suppression beats the user-scope enable, but the
+	// per-repo-required containment error on the user-scope enable
+	// itself still fires.
+	write(t, opts.RepoDir, ".claude/settings.local.json", `{"enabledPlugins": {"vsdd-factory@claude-mp": false}}`)
+
+	rep, err := Run(opts)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	for _, r := range rep.Results {
+		if r.Check == 10 {
+			t.Errorf("suppressed identity still graded dual-enable: %+v", r)
+		}
+	}
+}
+
+func TestRun_ContentCollisionRefuses(t *testing.T) {
+	t.Parallel()
+	opts := baseOptions(t)
+	write(t, opts.RepoDir, ".claude/skills/vsdd-pr-manager/SKILL.md", "# theirs\n")
+
+	rep, err := Run(opts)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	sevs := severities(rep, 9)
+	if len(sevs) != 1 || sevs[0] != foreign.Error {
+		t.Errorf("check 9 = %v, want one ERROR", sevs)
+	}
+}
+
+func TestRun_RunningFactorySignals(t *testing.T) {
+	t.Parallel()
+	opts := baseOptions(t)
+	write(t, opts.RepoDir, ".factory/STATE.md",
+		"---\nfactory_lock:\n  holder: dev@example.com\n  locked_at: 2026-07-31T11:50:00Z\n  expires_at: 2026-07-31T12:30:00Z\n---\n")
+	if err := os.MkdirAll(filepath.Join(opts.RepoDir, ".worktrees", "STORY-042"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	rep, err := Run(opts)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !rep.Refuse() {
+		t.Fatalf("unexpired lock did not refuse: %+v", rep.Results)
+	}
+	var sawLock, sawWorktrees bool
+	for _, r := range rep.Results {
+		if r.Check != 2 {
+			continue
+		}
+		if r.Severity == foreign.Error && strings.Contains(r.Detail, "dev@example.com") {
+			sawLock = true
+		}
+		if strings.Contains(r.Detail, "STORY-042") {
+			sawWorktrees = true
+		}
+	}
+	if !sawLock || !sawWorktrees {
+		t.Errorf("lock=%v worktrees=%v: %+v", sawLock, sawWorktrees, rep.Results)
+	}
+}
+
+func TestRun_VersionSkewAndPlatformBind(t *testing.T) {
+	t.Parallel()
+	opts := baseOptions(t)
+	store := t.TempDir()
+	opts.StoreRoot = filepath.Join(store, "1.0.0-rc.24")
+	write(t, opts.StoreRoot, "hooks/dispatcher/placeholder", "not executable\n")
+	write(t, "", opts.LedgerPath, "schema_version: \"0.1.0\"\nrepos:\n  "+opts.RepoDir+":\n    vsdd-factory:\n      version: 1.0.0-rc.23\n      store_path: /store/1.0.0-rc.23\n      settings_scope: local\n")
+
+	rep, err := Run(opts)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if sevs := severities(rep, 6); len(sevs) != 1 || sevs[0] != foreign.Warn {
+		t.Errorf("check 6 = %v, want one WARN", sevs)
+	}
+	// Bound repo with no env shim written: check 4 flags it.
+	var envShimError bool
+	for _, r := range rep.Results {
+		if r.Check == 4 && r.Severity == foreign.Error && strings.Contains(r.Detail, "env shim") {
+			envShimError = true
+		}
+	}
+	if !envShimError {
+		t.Errorf("check 4 missing env-shim error: %+v", rep.Results)
+	}
+}
+
+func TestSnapshotAndDiffFootprints(t *testing.T) {
+	t.Parallel()
+	cfg := t.TempDir()
+	write(t, cfg, "plugins/config.json", `{"version": 2}`)
+	write(t, cfg, "settings.json", `{"enabledPlugins": {}}`)
+
+	before, err := SnapshotForeignFootprint(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(before) != 2 {
+		t.Fatalf("snapshot = %v, want 2 entries", before)
+	}
+	after, err := SnapshotForeignFootprint(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := DiffFootprints(before, after); len(diff) > 0 {
+		t.Errorf("identical footprints diffed: %v", diff)
+	}
+
+	write(t, cfg, "plugins/config.json", `{"version": 2, "changed": true}`)
+	after, err = SnapshotForeignFootprint(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	diff := DiffFootprints(before, after)
+	if len(diff) != 1 || !strings.Contains(diff[0], "changed plugins/config.json") {
+		t.Errorf("diff = %v, want the changed registry", diff)
+	}
+}

--- a/internal/ledger/ledger.go
+++ b/internal/ledger/ledger.go
@@ -1,0 +1,86 @@
+// Package ledger reads the per-repo activation record at
+// <sideshow-data>/repo-bindings.yaml (decision aae-orc-d3nq.5,
+// docs/repo-bindings-ledger.md). The enable/disable verbs (.7) are
+// the writers; everything else — coexist-check, doctor, version-skew
+// reporting — reads through here.
+package ledger
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/ArcavenAE/sideshow/internal/pack"
+	"gopkg.in/yaml.v3"
+)
+
+// Row is one (repo, pack) binding record.
+type Row struct {
+	Version       string   `yaml:"version"`
+	StorePath     string   `yaml:"store_path"` // absolute version dir, never `current`
+	Channel       string   `yaml:"channel"`    // sideshow-native | claude-mp
+	Platform      string   `yaml:"platform"`
+	SettingsScope string   `yaml:"settings_scope"` // local | project
+	EnabledAt     string   `yaml:"enabled_at"`
+	Artifacts     []string `yaml:"artifacts"`
+	Selection     string   `yaml:"selection"`
+}
+
+// Ledger is the whole repo-bindings file.
+type Ledger struct {
+	SchemaVersion string                    `yaml:"schema_version"`
+	Repos         map[string]map[string]Row `yaml:"repos"` // abs repo path -> pack -> row
+}
+
+// Path returns the ledger location inside the sideshow data dir.
+func Path() string {
+	return filepath.Join(filepath.Dir(pack.PacksDir()), "repo-bindings.yaml")
+}
+
+// Load reads the ledger. A missing file is an empty ledger, not an
+// error; a malformed one is an error (readers fail closed rather
+// than reporting a repo as unbound).
+func Load(path string) (*Ledger, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &Ledger{Repos: map[string]map[string]Row{}}, nil
+		}
+		return nil, fmt.Errorf("read repo-bindings ledger: %w", err)
+	}
+	var l Ledger
+	if err := yaml.Unmarshal(data, &l); err != nil {
+		return nil, fmt.Errorf("parse repo-bindings ledger %s: %w", path, err)
+	}
+	if l.Repos == nil {
+		l.Repos = map[string]map[string]Row{}
+	}
+	return &l, nil
+}
+
+// RepoRow returns the row for (repoDir, packName), or nil.
+func (l *Ledger) RepoRow(repoDir, packName string) *Row {
+	abs, err := filepath.Abs(repoDir)
+	if err != nil {
+		return nil
+	}
+	packs, ok := l.Repos[abs]
+	if !ok {
+		return nil
+	}
+	row, ok := packs[packName]
+	if !ok {
+		return nil
+	}
+	return &row
+}
+
+// RepoDirs returns every repo path the ledger knows — the sweep list
+// for machine-scoped operations.
+func (l *Ledger) RepoDirs() []string {
+	out := make([]string, 0, len(l.Repos))
+	for dir := range l.Repos {
+		out = append(out, dir)
+	}
+	return out
+}


### PR DESCRIPTION
Enable and adopt are about to become real verbs, and each can do damage if it lands in the wrong repo: two hook chains against one `.factory` state, a clobbered pre-existing skill, a mutation under a running factory lock. This PR ships the read-only preflight both verbs will call as a precondition, exposed standalone as `sideshow coexist-check <pack> [--repo <path>]` so an operator (or doctor) can ask "would enable refuse here, and why" without touching anything. Additive; nothing mutates repo, store, or harness state.

## The ten checks

1. Foreign effective-enable resolution (current + legacy identity, orphaned enables)
2. Running-factory census: lock/wave/burst signals plus git-level indicators (dirty `.factory` worktree, `.worktrees/STORY-*`)
3. Remote-safety: an origin `factory-artifacts` ref refuses (the force-with-lease CAS leak path); local remote-tracking state only, no network
4. Platform bind, when ledger-bound: env shim resolves to the bound store path, dispatcher executable (the zero-hooks trap)
5. Agent-key audit: prefixed vs bare `.claude/agents` entries identify the channel
6. Version skew: ledger row vs the store version being enabled
7. Retreat anchor: `factory-artifacts` tip SHA and `.factory` status, recorded pre-trial
8. Foreign-footprint snapshot/diff: before/after hashing of the claude-mp footprint (disjoint from everything sideshow writes, so identical hashes are clean proof a trial left it untouched)
9. Pre-existing content collision on every planned materialization path; refuse rather than clobber
10. Same-repo dual-enable hard refusal (trial-verified: both chains fired at one SessionStart), carrying the consent menu

Also ships `internal/ledger`, the reader for the repo-bindings ledger (`<sideshow-data>/repo-bindings.yaml`); the enable/disable verbs are the writers. A missing ledger is empty; a malformed one fails closed.

Refs: aae-orc-d3nq.41, aae-orc-d3nq.5, finding-091, finding-093, finding-094