### PR TITLE
feat(bindings): settings-hooks merge, unmerge, and verification

### DIFF
--- a/internal/bindings/settings_hooks.go
+++ b/internal/bindings/settings_hooks.go
@@ -1,0 +1,195 @@
+package bindings
+
+import "fmt"
+
+// Settings-hooks binding (aae-orc-d3nq.52): render a pack's hook
+// registrations into ONE repo settings file and remove exactly them
+// on disable. The settings path is a parameter — the verbs pass
+// settings.local.json at local scope (the finding-093 D3 default) and
+// settings.json at project scope (consent-gated).
+//
+// Schema facts from the trials and the upstream tree:
+//   - NO matcher key is emitted. Omitted matcher is equivalent to
+//     matcher:"" (T19), and all upstream hook groups carry only a
+//     hooks key.
+//   - Entries carry timeout (ms) and once where the pack declares
+//     them (accepted by the harness per T18).
+//   - Every rule group carries _managed_by: "sideshow:<pack>" — the
+//     ownership marker unmerge keys on. Foreign groups (the user's
+//     own hooks, other packs) are never touched.
+//   - The command string carries the inline env belt (InlineEnvBelt)
+//     upstream of this writer; nothing here depends on the settings
+//     env leg.
+
+// HookEntry is one synthesized hook registration.
+type HookEntry struct {
+	Event   string
+	Command string
+	Timeout int  // milliseconds; 0 omits the key
+	Once    bool // emitted only when true
+}
+
+// settingsHooksManagedBy mirrors the user-scope writer's marker
+// convention (internal/distribute).
+func settingsHooksManagedBy(packName string) string {
+	return "sideshow:" + packName
+}
+
+// MergeHookChain upserts the pack's rule groups into the settings
+// file at path: every existing group carrying this pack's marker is
+// replaced by the declared entries (so re-enable converges instead of
+// duplicating), and groups without the marker are preserved
+// byte-for-byte in their positions' order. Returns the number of
+// groups written.
+func MergeHookChain(path, packName string, entries []HookEntry) (int, error) {
+	settings, _, err := readSettings(path)
+	if err != nil {
+		return 0, err
+	}
+	hooks, err := hooksObject(settings, path)
+	if err != nil {
+		return 0, err
+	}
+
+	marker := settingsHooksManagedBy(packName)
+	stripManagedGroups(hooks, marker)
+
+	for _, e := range entries {
+		if e.Event == "" || e.Command == "" {
+			return 0, fmt.Errorf("hook entry missing event or command: %+v", e)
+		}
+		hook := map[string]any{"type": "command", "command": e.Command}
+		if e.Timeout > 0 {
+			hook["timeout"] = e.Timeout
+		}
+		if e.Once {
+			hook["once"] = true
+		}
+		group := map[string]any{
+			"hooks":       []any{hook},
+			"_managed_by": marker,
+		}
+		list, _ := hooks[e.Event].([]any)
+		hooks[e.Event] = append(list, group)
+	}
+	if len(hooks) > 0 {
+		settings["hooks"] = hooks
+	} else {
+		delete(settings, "hooks")
+	}
+	return len(entries), writeSettings(path, settings)
+}
+
+// RemoveHookChain removes every rule group carrying the pack's marker
+// from the settings file, pruning emptied event lists and an emptied
+// hooks object. A missing file removes nothing. Returns the number of
+// groups removed.
+func RemoveHookChain(path, packName string) (int, error) {
+	settings, existed, err := readSettings(path)
+	if err != nil {
+		return 0, err
+	}
+	if !existed {
+		return 0, nil
+	}
+	hooks, err := hooksObject(settings, path)
+	if err != nil {
+		return 0, err
+	}
+	removed := stripManagedGroups(hooks, settingsHooksManagedBy(packName))
+	if removed == 0 {
+		return 0, nil
+	}
+	if len(hooks) > 0 {
+		settings["hooks"] = hooks
+	} else {
+		delete(settings, "hooks")
+	}
+	return removed, writeSettings(path, settings)
+}
+
+// VerifyHookChain checks the post-write settings against the declared
+// entry set — enable refuses success if the hook-entry count is short
+// of the declared events (unshaping-spec validation rule 4), and
+// doctor re-runs the same check.
+func VerifyHookChain(path, packName string, entries []HookEntry) error {
+	settings, existed, err := readSettings(path)
+	if err != nil {
+		return err
+	}
+	if !existed {
+		return fmt.Errorf("hook chain missing: %s does not exist", path)
+	}
+	hooks, err := hooksObject(settings, path)
+	if err != nil {
+		return err
+	}
+
+	marker := settingsHooksManagedBy(packName)
+	got := map[string]int{} // event -> managed group count
+	for event, raw := range hooks {
+		list, _ := raw.([]any)
+		for _, g := range list {
+			group, _ := g.(map[string]any)
+			if group != nil && group["_managed_by"] == marker {
+				got[event]++
+			}
+		}
+	}
+
+	want := map[string]int{}
+	for _, e := range entries {
+		want[e.Event]++
+	}
+	var missing []string
+	for event, n := range want {
+		if got[event] < n {
+			missing = append(missing, fmt.Sprintf("%s (%d of %d)", event, got[event], n))
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("hook chain in %s is short of the declared event set: %v", path, missing)
+	}
+	return nil
+}
+
+// hooksObject returns the settings' hooks block as a mutable map,
+// failing closed when it exists with the wrong shape.
+func hooksObject(settings map[string]any, path string) (map[string]any, error) {
+	raw, ok := settings["hooks"]
+	if !ok {
+		return map[string]any{}, nil
+	}
+	hooks, ok := raw.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("settings %s: hooks is not an object; refusing to merge", path)
+	}
+	return hooks, nil
+}
+
+// stripManagedGroups deletes every rule group carrying the marker,
+// pruning emptied event lists. Returns the number removed.
+func stripManagedGroups(hooks map[string]any, marker string) int {
+	removed := 0
+	for event, raw := range hooks {
+		list, ok := raw.([]any)
+		if !ok {
+			continue
+		}
+		var kept []any
+		for _, g := range list {
+			group, _ := g.(map[string]any)
+			if group != nil && group["_managed_by"] == marker {
+				removed++
+				continue
+			}
+			kept = append(kept, g)
+		}
+		if len(kept) == 0 {
+			delete(hooks, event)
+		} else {
+			hooks[event] = kept
+		}
+	}
+	return removed
+}

--- a/internal/bindings/settings_hooks_test.go
+++ b/internal/bindings/settings_hooks_test.go
@@ -1,0 +1,142 @@
+package bindings
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+var vsddEntries = []HookEntry{
+	{Event: "SessionStart", Command: "CLAUDE_PLUGIN_ROOT='/store/v1' /store/v1/hooks/dispatcher/d session-start", Timeout: 10000, Once: true},
+	{Event: "PreToolUse", Command: "CLAUDE_PLUGIN_ROOT='/store/v1' /store/v1/hooks/dispatcher/d pre-tool-use", Timeout: 10000},
+	{Event: "SessionEnd", Command: "CLAUDE_PLUGIN_ROOT='/store/v1' /store/v1/hooks/dispatcher/d session-end", Timeout: 10000, Once: true},
+}
+
+// The .52 done criterion: merge then unmerge is a settings-file byte
+// diff of zero, with a second pack's hooks and the user's own hooks
+// present and undisturbed throughout.
+func TestHookChain_MergeUnmergeByteExact(t *testing.T) {
+	t.Parallel()
+	path := settingsFixture(t, `{
+	  "env": {"USER_KEY": "kept"},
+	  "hooks": {
+	    "SessionStart": [
+	      {"matcher": "", "hooks": [{"type": "command", "command": "bmad-session"}], "_managed_by": "sideshow:bmad"},
+	      {"hooks": [{"type": "command", "command": "user-own-hook"}]}
+	    ],
+	    "PostToolUse": [
+	      {"hooks": [{"type": "command", "command": "beads-export"}], "_managed_by": "sideshow:beads-config"}
+	    ]
+	  }
+	}`)
+
+	// Normalize once through the writer so the byte comparison is
+	// against a stable rendering, then snapshot.
+	if _, err := MergeHookChain(path, "vsdd-factory", nil); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	added, err := MergeHookChain(path, "vsdd-factory", vsddEntries)
+	if err != nil || added != 3 {
+		t.Fatalf("MergeHookChain = (%d, %v), want (3, nil)", added, err)
+	}
+	if err := VerifyHookChain(path, "vsdd-factory", vsddEntries); err != nil {
+		t.Fatalf("VerifyHookChain after merge: %v", err)
+	}
+
+	removed, err := RemoveHookChain(path, "vsdd-factory")
+	if err != nil || removed != 3 {
+		t.Fatalf("RemoveHookChain = (%d, %v), want (3, nil)", removed, err)
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(before) != string(after) {
+		t.Errorf("settings not byte-identical after unmerge:\nbefore:\n%s\nafter:\n%s", before, after)
+	}
+	if !strings.Contains(string(after), "sideshow:bmad") || !strings.Contains(string(after), "beads-config") || !strings.Contains(string(after), "user-own-hook") {
+		t.Error("second pack or user hooks disturbed")
+	}
+}
+
+func TestMergeHookChain_SchemaShape(t *testing.T) {
+	t.Parallel()
+	path := settingsFixture(t, "")
+	if _, err := MergeHookChain(path, "vsdd-factory", vsddEntries); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(data)
+	if strings.Contains(s, `"matcher"`) {
+		t.Error("matcher key emitted; upstream groups carry only a hooks key (T19: omitted ≡ \"\")")
+	}
+	if !strings.Contains(s, `"timeout": 10000`) {
+		t.Error("timeout not emitted")
+	}
+	if !strings.Contains(s, `"once": true`) {
+		t.Error("once not emitted")
+	}
+	if !strings.Contains(s, `"_managed_by": "sideshow:vsdd-factory"`) {
+		t.Error("ownership marker missing")
+	}
+}
+
+// Re-merge converges: enabling twice (or after a version flip) does
+// not duplicate groups.
+func TestMergeHookChain_UpsertConverges(t *testing.T) {
+	t.Parallel()
+	path := settingsFixture(t, "")
+	if _, err := MergeHookChain(path, "vsdd-factory", vsddEntries); err != nil {
+		t.Fatal(err)
+	}
+	first, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := MergeHookChain(path, "vsdd-factory", vsddEntries); err != nil {
+		t.Fatal(err)
+	}
+	second, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(first) != string(second) {
+		t.Errorf("re-merge not convergent:\n%s\nvs\n%s", first, second)
+	}
+}
+
+func TestVerifyHookChain_ReportsShortfall(t *testing.T) {
+	t.Parallel()
+	path := settingsFixture(t, "")
+	if _, err := MergeHookChain(path, "vsdd-factory", vsddEntries[:1]); err != nil {
+		t.Fatal(err)
+	}
+	err := VerifyHookChain(path, "vsdd-factory", vsddEntries)
+	if err == nil || !strings.Contains(err.Error(), "PreToolUse") {
+		t.Errorf("VerifyHookChain = %v, want shortfall naming PreToolUse", err)
+	}
+}
+
+func TestRemoveHookChain_MissingFileAndForeignOnly(t *testing.T) {
+	t.Parallel()
+	if n, err := RemoveHookChain(settingsFixture(t, ""), "vsdd-factory"); err != nil || n != 0 {
+		t.Errorf("missing file: RemoveHookChain = (%d, %v), want (0, nil)", n, err)
+	}
+	path := settingsFixture(t, `{"hooks": {"SessionStart": [{"hooks": [{"type": "command", "command": "user"}]}]}}`)
+	before, _ := os.ReadFile(path)
+	if n, err := RemoveHookChain(path, "vsdd-factory"); err != nil || n != 0 {
+		t.Errorf("foreign-only: RemoveHookChain = (%d, %v), want (0, nil)", n, err)
+	}
+	after, _ := os.ReadFile(path)
+	if string(before) != string(after) {
+		t.Error("no-op removal rewrote the file")
+	}
+}


### PR DESCRIPTION
Sideshow could write hook registrations but never take them back: the existing writer emits `_managed_by` markers that nothing reads, so every disable path was net-new code. This PR ships the pair — merge AND exact unmerge — for the repo settings hook chain, plus the post-write verification the enable verb will refuse on. Additive: the settings path is a parameter (local scope's `settings.local.json` by default), and foreign groups — the user's own hooks, other packs — are never touched, proven by a byte-diff test.

## What ships

- **`MergeHookChain`** — upserts the pack's rule groups keyed on the `_managed_by: sideshow:<pack>` marker (the same convention the user-scope writer already emits), so re-enable and version flips converge instead of duplicating. Schema per the trials and the upstream tree: no `matcher` key (omitted is equivalent to `matcher:""`), `timeout` and `once` emitted where declared.
- **`RemoveHookChain`** — the unmerge that did not exist: removes every group carrying the pack's marker, prunes emptied event lists and an emptied hooks object, and leaves everything else alone.
- **`VerifyHookChain`** — the post-write check behind "enable refuses success if the hook-entry count is short of the declared event set"; doctor re-runs the same check.

The done criterion is proven as specified: merge then unmerge yields a byte-identical settings file with a second pack's managed groups and a user's own hooks present and undisturbed throughout.

Refs: aae-orc-d3nq.52, finding-091, finding-094