### PR TITLE
feat(enable): per-repo enable and disable verbs with the hooks platform bind

### DIFF
--- a/cmd/sideshow/enable.go
+++ b/cmd/sideshow/enable.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/ArcavenAE/sideshow/internal/bindings"
+	"github.com/ArcavenAE/sideshow/internal/enable"
+)
+
+// runEnable / runDisable are the per-repo activation verbs:
+//
+//	sideshow enable <pack>[@<version>] [--repo <path>] [--scope local|project] [--override-stale-lock]
+//	sideshow disable <pack> [--repo <path>] [--override-stale-lock]
+func runEnable(args []string) error {
+	opts, err := parseVerbArgs("enable", args)
+	if err != nil {
+		return err
+	}
+	return enable.Enable(*opts)
+}
+
+func runDisable(args []string) error {
+	opts, err := parseVerbArgs("disable", args)
+	if err != nil {
+		return err
+	}
+	return enable.Disable(*opts)
+}
+
+func parseVerbArgs(verb string, args []string) (*enable.Options, error) {
+	if len(args) < 1 || len(args[0]) == 0 || args[0][0] == '-' {
+		return nil, fmt.Errorf("usage: sideshow %s <pack>[@<version>] [--repo <path>] [--scope local|project] [--override-stale-lock]", verb)
+	}
+	packName, version, _ := strings.Cut(args[0], "@")
+	repoDir, err := os.Getwd()
+	if err != nil {
+		return nil, fmt.Errorf("resolve working directory: %w", err)
+	}
+	opts := &enable.Options{Pack: packName, Version: version, RepoDir: repoDir}
+	for i := 1; i < len(args); i++ {
+		switch args[i] {
+		case "--repo":
+			if i+1 >= len(args) {
+				return nil, fmt.Errorf("--repo requires a path")
+			}
+			i++
+			opts.RepoDir = args[i]
+		case "--scope":
+			if i+1 >= len(args) {
+				return nil, fmt.Errorf("--scope requires local or project")
+			}
+			i++
+			if args[i] == "user" {
+				return nil, fmt.Errorf("--scope user is refused: a per-repo-required pack never activates machine-wide (containment mandate); use local or project")
+			}
+			opts.Scope = bindings.RepoScope(args[i])
+		case "--override-stale-lock":
+			opts.OverrideStaleLock = true
+		default:
+			return nil, fmt.Errorf("unknown flag: %s", args[i])
+		}
+	}
+	return opts, nil
+}

--- a/cmd/sideshow/main.go
+++ b/cmd/sideshow/main.go
@@ -40,6 +40,8 @@ Usage:
                                           register it as a custom-skills source
   sideshow status                         Show installation status
   sideshow coexist <pack> [--repo <path>]  Read-only foreign-install census and coexistence findings
+  sideshow enable <pack>[@<ver>] [--repo <path>] [--scope local|project]  Activate a pack in one repo (repo-bindings)
+  sideshow disable <pack> [--repo <path>]  Reverse an enable exactly (ledger replay)
   sideshow coexist-check <pack> [--repo <path>]  Read-only enable/adopt preflight (ten checks)
   sideshow version                        Show version
 
@@ -123,6 +125,10 @@ func main() {
 		}
 	case "status":
 		err = runStatus()
+	case "enable":
+		err = runEnable(os.Args[2:])
+	case "disable":
+		err = runDisable(os.Args[2:])
 	case "coexist-check":
 		err = runCoexistCheck(os.Args[2:])
 	case "coexist":

--- a/internal/enable/enable.go
+++ b/internal/enable/enable.go
@@ -1,0 +1,458 @@
+// Package enable implements the per-repo activation verbs
+// (aae-orc-d3nq.7): Enable materializes a plugin-shaped pack's
+// binding set into one repo per the unshaping spec and records the
+// exact removal set in the repo-bindings ledger; Disable replays that
+// record in reverse. No harness plugin state of any kind is written
+// on this channel (finding-094): registration is the repo settings
+// chain, the identity lives only in sideshow's own ledger.
+package enable
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/ArcavenAE/sideshow/internal/bindings"
+	"github.com/ArcavenAE/sideshow/internal/coexistcheck"
+	"github.com/ArcavenAE/sideshow/internal/factoryguard"
+	"github.com/ArcavenAE/sideshow/internal/foreign"
+	"github.com/ArcavenAE/sideshow/internal/ledger"
+	"github.com/ArcavenAE/sideshow/internal/pack"
+)
+
+// Options configures Enable and Disable.
+type Options struct {
+	RepoDir    string
+	Pack       string
+	Version    string // "" resolves the registered version
+	Scope      bindings.RepoScope
+	LedgerPath string // "" means ledger.Path()
+	ConfigDir  string // "" means foreign.ConfigDir()
+	// OverrideStaleLock permits proceeding past an EXPIRED factory
+	// lock and the soft in-flight signals. Hard signals never pass.
+	OverrideStaleLock bool
+	// StoreRoot, Prefix, and BoundDir are resolved from the
+	// registry/activation and the sideshow data dir when empty; tests
+	// inject them.
+	StoreRoot string
+	Prefix    string
+	BoundDir  string
+	Now       time.Time
+}
+
+func (o *Options) normalize() error {
+	if o.Scope == "" {
+		o.Scope = bindings.ScopeLocal
+	}
+	if o.Scope != bindings.ScopeLocal && o.Scope != bindings.ScopeProject {
+		return fmt.Errorf("unknown scope %q (want local or project); user scope is not a thing on this channel — a per-repo-required pack never activates machine-wide", o.Scope)
+	}
+	if o.LedgerPath == "" {
+		o.LedgerPath = ledger.Path()
+	}
+	if o.ConfigDir == "" {
+		o.ConfigDir = foreign.ConfigDir()
+	}
+	if o.Now.IsZero() {
+		o.Now = time.Now().UTC()
+	}
+	abs, err := filepath.Abs(o.RepoDir)
+	if err != nil {
+		return fmt.Errorf("resolve repo dir: %w", err)
+	}
+	o.RepoDir = abs
+	return nil
+}
+
+// settingsFile returns the repo settings path for the scope: local
+// stays out of history (the ratified default), project is the
+// committed file.
+func settingsFile(repoDir string, scope bindings.RepoScope) string {
+	name := "settings.local.json"
+	if scope == bindings.ScopeProject {
+		name = "settings.json"
+	}
+	return filepath.Join(repoDir, ".claude", name)
+}
+
+// Enable activates a pack in one repo. The pipeline: activation gate,
+// coexist-check preflight, bound-variant render, materialization,
+// compat symlink, env shim, hook-chain merge, verification, ledger
+// row. Any failure rolls back everything already written.
+func Enable(opts Options) error {
+	if err := opts.normalize(); err != nil {
+		return err
+	}
+
+	storeRoot, prefix, perRepoRequired, err := resolveStore(&opts)
+	if err != nil {
+		return err
+	}
+	if !perRepoRequired {
+		fmt.Printf("note: %s does not declare per_repo_required; per-repo enable proceeds anyway\n", opts.Pack)
+	}
+
+	inv, err := bindings.DiscoverPluginLayout(pack.InstalledPack{Name: opts.Pack, Version: opts.Version, Path: storeRoot})
+	if err != nil {
+		return err
+	}
+
+	// Preflight: refuse on any ERROR; soft factory signals pass only
+	// under the explicit override.
+	report, err := coexistcheck.Run(coexistcheck.Options{
+		RepoDir:         opts.RepoDir,
+		Pack:            opts.Pack,
+		Prefix:          prefix,
+		StoreRoot:       storeRoot,
+		Inventory:       inv,
+		ConfigDir:       opts.ConfigDir,
+		LedgerPath:      opts.LedgerPath,
+		PerRepoRequired: perRepoRequired,
+		Now:             opts.Now,
+	})
+	if err != nil {
+		return err
+	}
+	guard := factoryguard.CheckRepo(opts.RepoDir, opts.Now)
+	if guard.HardRefusal() {
+		return fmt.Errorf("enable refused:\n%s", guard.Refusal())
+	}
+	if guard.InFlight() && !opts.OverrideStaleLock {
+		return fmt.Errorf("enable refused (pass --override-stale-lock to proceed past these):\n%s", guard.Refusal())
+	}
+	if report.Refuse() {
+		var lines []string
+		for _, r := range report.Results {
+			if r.Severity == foreign.Error && r.Check != 2 {
+				lines = append(lines, fmt.Sprintf("[%d %s] %s", r.Check, r.Name, r.Detail))
+			}
+		}
+		if len(lines) > 0 {
+			return fmt.Errorf("enable refused by coexist-check:\n%s", strings.Join(lines, "\n"))
+		}
+	}
+
+	platform, err := detectPlatform()
+	if err != nil {
+		return err
+	}
+	entries, err := hookEntries(storeRoot, platform)
+	if err != nil {
+		return err
+	}
+	if err := verifyDispatcher(storeRoot, platform); err != nil {
+		return err
+	}
+
+	// Render the bound variant (transforms, .51) and materialize from
+	// it (.48), then the compat symlink (.58).
+	boundDir := opts.BoundDir
+	if boundDir == "" {
+		boundDir = bindings.BoundVariantDir(opts.Pack, filepath.Base(storeRoot))
+	}
+	boundInv, err := bindings.RenderBoundVariant(storeRoot, inv, opts.Pack, prefix, boundDir)
+	if err != nil {
+		return err
+	}
+	materializeFrom := boundDir
+
+	target := bindings.RepoTarget{RepoDir: opts.RepoDir, Scope: opts.Scope}
+	var artifacts []bindings.RepoArtifact
+	rollback := func() {
+		if _, rmErr := bindings.RemoveRepoArtifacts(target, artifacts); rmErr != nil {
+			fmt.Fprintf(os.Stderr, "warning: rollback: %v\n", rmErr)
+		}
+	}
+
+	arts, err := bindings.MaterializeRepo(materializeFrom, boundInv, target)
+	artifacts = append(artifacts, arts...)
+	if err != nil {
+		rollback()
+		return err
+	}
+	compat, err := bindings.MaterializeCompatSymlink(storeRoot, target, opts.Pack)
+	artifacts = append(artifacts, compat...)
+	if err != nil {
+		rollback()
+		return err
+	}
+
+	settings := settingsFile(opts.RepoDir, opts.Scope)
+	created, err := bindings.MergeEnvShim(settings, "CLAUDE_PLUGIN_ROOT", storeRoot)
+	if err != nil {
+		rollback()
+		return err
+	}
+	unwindShim := func() {
+		if _, rmErr := bindings.RemoveEnvShim(settings, "CLAUDE_PLUGIN_ROOT", storeRoot); rmErr != nil {
+			fmt.Fprintf(os.Stderr, "warning: rollback env shim: %v\n", rmErr)
+		}
+		if created {
+			_ = os.Remove(settings)
+		}
+	}
+
+	if _, err := bindings.MergeHookChain(settings, opts.Pack, entries); err != nil {
+		unwindShim()
+		rollback()
+		return err
+	}
+	// Rule 4: refuse success if the post-write chain is short of the
+	// declared event set.
+	if err := bindings.VerifyHookChain(settings, opts.Pack, entries); err != nil {
+		if _, rmErr := bindings.RemoveHookChain(settings, opts.Pack); rmErr != nil {
+			fmt.Fprintf(os.Stderr, "warning: rollback hook chain: %v\n", rmErr)
+		}
+		unwindShim()
+		rollback()
+		return err
+	}
+
+	led, err := ledger.Load(opts.LedgerPath)
+	if err != nil {
+		return err
+	}
+	row := ledger.Row{
+		Version:       filepath.Base(storeRoot),
+		StorePath:     storeRoot,
+		Channel:       "sideshow-native",
+		Platform:      platform,
+		SettingsScope: string(opts.Scope),
+		EnabledAt:     opts.Now.Format(time.RFC3339),
+		Artifacts:     artifactStrings(artifacts, created),
+		Selection:     "full",
+	}
+	if err := led.SetRow(opts.RepoDir, opts.Pack, row); err != nil {
+		return err
+	}
+	if err := led.Save(opts.LedgerPath); err != nil {
+		return err
+	}
+
+	fmt.Printf("enabled %s %s in %s (scope %s, platform %s): %d artifacts, %d hook events\n",
+		opts.Pack, row.Version, opts.RepoDir, opts.Scope, platform, len(artifacts), len(entries))
+	return nil
+}
+
+// Disable reverses an enable exactly: hook chain unmerge, env shim
+// removal, artifact replay in reverse, ledger row deletion. The
+// running-factory guard applies the same way; class-1 state is never
+// touched.
+func Disable(opts Options) error {
+	if err := opts.normalize(); err != nil {
+		return err
+	}
+	led, err := ledger.Load(opts.LedgerPath)
+	if err != nil {
+		return err
+	}
+	row := led.RepoRow(opts.RepoDir, opts.Pack)
+	if row == nil {
+		return fmt.Errorf("%s is not enabled in %s (no ledger row)", opts.Pack, opts.RepoDir)
+	}
+
+	guard := factoryguard.CheckRepo(opts.RepoDir, opts.Now)
+	if guard.HardRefusal() {
+		return fmt.Errorf("disable refused:\n%s", guard.Refusal())
+	}
+	if guard.InFlight() && !opts.OverrideStaleLock {
+		return fmt.Errorf("disable refused (pass --override-stale-lock to proceed past these):\n%s", guard.Refusal())
+	}
+
+	settings := settingsFile(opts.RepoDir, bindings.RepoScope(row.SettingsScope))
+	if _, err := bindings.RemoveHookChain(settings, opts.Pack); err != nil {
+		return err
+	}
+	if _, err := bindings.RemoveEnvShim(settings, "CLAUDE_PLUGIN_ROOT", row.StorePath); err != nil {
+		return err
+	}
+
+	arts, removeSettingsFile := parseArtifactStrings(row.Artifacts)
+	target := bindings.RepoTarget{RepoDir: opts.RepoDir, Scope: bindings.RepoScope(row.SettingsScope)}
+	removed, err := bindings.RemoveRepoArtifacts(target, arts)
+	if err != nil {
+		return err
+	}
+	if removeSettingsFile {
+		if data, readErr := os.ReadFile(settings); readErr == nil && strings.TrimSpace(string(data)) == "{}" {
+			_ = os.Remove(settings)
+		}
+	}
+
+	led.DeleteRow(opts.RepoDir, opts.Pack)
+	if err := led.Save(opts.LedgerPath); err != nil {
+		return err
+	}
+	fmt.Printf("disabled %s in %s: %d artifacts removed\n", opts.Pack, opts.RepoDir, removed)
+	return nil
+}
+
+// resolveStore fills StoreRoot/Prefix from the pack registry and
+// activation contract when not injected.
+func resolveStore(opts *Options) (storeRoot, prefix string, perRepoRequired bool, err error) {
+	if opts.StoreRoot != "" {
+		prefix = opts.Prefix
+		if prefix == "" {
+			prefix = opts.Pack
+		}
+		return opts.StoreRoot, prefix, true, nil
+	}
+	packs, err := pack.List()
+	if err != nil {
+		return "", "", false, err
+	}
+	for _, p := range packs {
+		if p.Name != opts.Pack {
+			continue
+		}
+		if opts.Version != "" && p.Version != opts.Version {
+			continue
+		}
+		resolved, err := filepath.EvalSymlinks(p.Path)
+		if err != nil {
+			return "", "", false, fmt.Errorf("resolve store path: %w", err)
+		}
+		act, actErr := pack.LoadActivation(resolved)
+		if actErr != nil {
+			return "", "", false, fmt.Errorf("activation unreadable for %s: %w", opts.Pack, actErr)
+		}
+		opts.Version = p.Version
+		return resolved, act.Prefix(opts.Pack), act != nil && act.PerRepoRequired, nil
+	}
+	return "", "", false, fmt.Errorf("pack %s%s is not installed", opts.Pack, versionSuffix(opts.Version))
+}
+
+func versionSuffix(v string) string {
+	if v == "" {
+		return ""
+	}
+	return "@" + v
+}
+
+// detectPlatform mirrors upstream's detect-platform contract: five
+// canonical tuples.
+func detectPlatform() (string, error) {
+	key := runtime.GOOS + "/" + runtime.GOARCH
+	m := map[string]string{
+		"darwin/arm64":  "darwin-arm64",
+		"darwin/amd64":  "darwin-x64",
+		"linux/arm64":   "linux-arm64",
+		"linux/amd64":   "linux-x64",
+		"windows/amd64": "windows-x64",
+	}
+	p, ok := m[key]
+	if !ok {
+		return "", fmt.Errorf("no canonical platform tuple for %s (upstream supports darwin-arm64, darwin-x64, linux-arm64, linux-x64, windows-x64)", key)
+	}
+	return p, nil
+}
+
+// verifyDispatcher mirrors apply-platform.sh's binary check (exit
+// codes 2/3): present and executable at the platform path.
+func verifyDispatcher(storeRoot, platform string) error {
+	name := "factory-dispatcher"
+	if strings.HasPrefix(platform, "windows") {
+		name += ".exe"
+	}
+	path := filepath.Join(storeRoot, "hooks", "dispatcher", "bin", platform, name)
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("dispatcher binary missing at %s (zero-hooks trap: enable refuses rather than registering hooks that silently do nothing)", path)
+	}
+	if info.Mode().Perm()&0o100 == 0 {
+		return fmt.Errorf("dispatcher %s is present but not executable", path)
+	}
+	return nil
+}
+
+// hookEntries derives the settings hook chain from the pack's
+// platform template. Ratified D5: our channel wires all 12 events the
+// pack registers — the template's 10 plus PreCompact/PostCompact,
+// which upstream registers but never wired (the dead-hooks defect);
+// on this channel they point at the same dispatcher. Docs distinguish
+// "registered" from "verified firing".
+func hookEntries(storeRoot, platform string) ([]bindings.HookEntry, error) {
+	tmplPath := filepath.Join(storeRoot, "hooks", "hooks.json."+platform)
+	data, err := os.ReadFile(tmplPath)
+	if err != nil {
+		return nil, fmt.Errorf("platform hook template: %w", err)
+	}
+	var tmpl struct {
+		Hooks map[string][]struct {
+			Hooks []struct {
+				Command string `json:"command"`
+				Timeout int    `json:"timeout"`
+				Once    bool   `json:"once"`
+			} `json:"hooks"`
+		} `json:"hooks"`
+	}
+	if err := json.Unmarshal(data, &tmpl); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", tmplPath, err)
+	}
+
+	belt := bindings.InlineEnvBelt("CLAUDE_PLUGIN_ROOT", storeRoot)
+	var entries []bindings.HookEntry
+	var dispatcherCmd bindings.HookEntry
+	for event, groups := range tmpl.Hooks {
+		for _, g := range groups {
+			for _, h := range g.Hooks {
+				cmd := strings.ReplaceAll(h.Command, "${CLAUDE_PLUGIN_ROOT}", storeRoot)
+				e := bindings.HookEntry{Event: event, Command: belt + cmd, Timeout: h.Timeout, Once: h.Once}
+				entries = append(entries, e)
+				dispatcherCmd = e
+			}
+		}
+	}
+	if len(entries) == 0 {
+		return nil, fmt.Errorf("platform template %s declares no hooks", tmplPath)
+	}
+	seen := map[string]bool{}
+	for _, e := range entries {
+		seen[e.Event] = true
+	}
+	for _, extra := range []string{"PreCompact", "PostCompact"} {
+		if !seen[extra] {
+			entries = append(entries, bindings.HookEntry{
+				Event: extra, Command: dispatcherCmd.Command, Timeout: dispatcherCmd.Timeout,
+			})
+		}
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Event < entries[j].Event })
+	return entries, nil
+}
+
+// artifactStrings encodes the removal set for the ledger row:
+// kind-tagged strings plus the env-shim record (and whether the
+// settings file itself was created by enable).
+func artifactStrings(arts []bindings.RepoArtifact, settingsCreated bool) []string {
+	out := make([]string, 0, len(arts)+1)
+	for _, a := range arts {
+		out = append(out, a.Kind+":"+a.Path)
+	}
+	if settingsCreated {
+		out = append(out, "settings-file-created:")
+	}
+	return out
+}
+
+func parseArtifactStrings(rows []string) ([]bindings.RepoArtifact, bool) {
+	var arts []bindings.RepoArtifact
+	settingsCreated := false
+	for _, s := range rows {
+		kind, path, ok := strings.Cut(s, ":")
+		if !ok {
+			continue
+		}
+		if kind == "settings-file-created" {
+			settingsCreated = true
+			continue
+		}
+		arts = append(arts, bindings.RepoArtifact{Kind: kind, Path: path})
+	}
+	return arts, settingsCreated
+}

--- a/internal/enable/enable_test.go
+++ b/internal/enable/enable_test.go
@@ -1,0 +1,331 @@
+package enable
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ArcavenAE/sideshow/internal/ledger"
+)
+
+// writeStore builds a plugin-shaped store version root with skills,
+// nested agents, an executable dispatcher for the current platform,
+// and the platform hook template (10 upstream events, once on the
+// Session pair).
+func writeStore(t *testing.T) string {
+	t.Helper()
+	store := filepath.Join(t.TempDir(), "1.0.0-rc.23")
+	platform, err := detectPlatform()
+	if err != nil {
+		t.Skipf("no canonical platform tuple here: %v", err)
+	}
+
+	mustWrite := func(rel, content string, mode os.FileMode) {
+		t.Helper()
+		p := filepath.Join(store, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(content), mode); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	mustWrite(".claude-plugin/plugin.json", `{"name": "vsdd-factory", "version": "1.0.0-rc.23"}`, 0o644)
+	mustWrite("skills/jira/SKILL.md", "---\nname: jira\n---\n\nRun /vsdd-factory:github-ops.\n", 0o644)
+	mustWrite("agents/github-ops.md", "---\nname: github-ops\n---\n\nbody\n", 0o644)
+	mustWrite("hooks/dispatcher/bin/"+platform+"/factory-dispatcher", "#!/bin/sh\nexit 0\n", 0o755)
+
+	tmpl := map[string]any{"hooks": map[string]any{}}
+	hooks := tmpl["hooks"].(map[string]any)
+	for _, ev := range []string{"PreToolUse", "PostToolUse", "SessionStart", "SessionEnd", "Stop"} {
+		h := map[string]any{
+			"type":    "command",
+			"command": "${CLAUDE_PLUGIN_ROOT}/hooks/dispatcher/bin/" + platform + "/factory-dispatcher",
+			"timeout": 10000,
+		}
+		if ev == "SessionStart" || ev == "SessionEnd" {
+			h["once"] = true
+		}
+		hooks[ev] = []any{map[string]any{"hooks": []any{h}}}
+	}
+	data, err := json.MarshalIndent(tmpl, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	mustWrite("hooks/hooks.json."+platform, string(data), 0o644)
+	return store
+}
+
+// writeRepo builds a consumer repo with pre-existing user content
+// including a second pack's managed hook groups.
+func writeRepo(t *testing.T) string {
+	t.Helper()
+	repo := t.TempDir()
+	settings := `{
+  "env": {"USER_KEY": "kept"},
+  "hooks": {
+    "SessionStart": [
+      {"hooks": [{"type": "command", "command": "bmad-session"}], "_managed_by": "sideshow:bmad"},
+      {"hooks": [{"type": "command", "command": "user-own-hook"}]}
+    ]
+  }
+}`
+	// Normalize the settings fixture through the same rendering the
+	// merge/unmerge writer uses, so the byte diff tests semantic
+	// restoration rather than JSON formatting.
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(settings), &parsed); err != nil {
+		t.Fatal(err)
+	}
+	normalized, err := json.MarshalIndent(parsed, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	settings = string(normalized) + "\n"
+
+	for rel, content := range map[string]string{
+		".claude/settings.local.json":  settings,
+		".claude/skills/mine/SKILL.md": "# mine\n",
+		"README.md":                    "user repo\n",
+	} {
+		p := filepath.Join(repo, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return repo
+}
+
+func snapshot(t *testing.T, dir string) map[string]string {
+	t.Helper()
+	snap := map[string]string{}
+	err := filepath.WalkDir(dir, func(path string, d os.DirEntry, werr error) error {
+		if werr != nil {
+			return werr
+		}
+		rel, err := filepath.Rel(dir, path)
+		if err != nil || rel == "." {
+			return err
+		}
+		info, err := os.Lstat(path)
+		if err != nil {
+			return err
+		}
+		switch {
+		case info.Mode()&os.ModeSymlink != 0:
+			target, _ := os.Readlink(path)
+			snap[rel] = "link -> " + target
+		case info.IsDir():
+			snap[rel] = "dir"
+		default:
+			data, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			snap[rel] = fmt.Sprintf("file %x", sha256.Sum256(data))
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return snap
+}
+
+func baseOpts(t *testing.T, repo, store string) Options {
+	t.Helper()
+	return Options{
+		RepoDir:    repo,
+		Pack:       "vsdd-factory",
+		Version:    "1.0.0-rc.23",
+		StoreRoot:  store,
+		Prefix:     "vsdd",
+		BoundDir:   filepath.Join(t.TempDir(), "bound"),
+		LedgerPath: filepath.Join(t.TempDir(), "repo-bindings.yaml"),
+		ConfigDir:  t.TempDir(),
+		Now:        time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC),
+	}
+}
+
+// The .7 done criterion: enable and disable are exact inverses,
+// settings byte diff included, with a second pack present throughout.
+func TestEnableDisable_ExactInverse(t *testing.T) {
+	t.Parallel()
+	store := writeStore(t)
+	repo := writeRepo(t)
+	opts := baseOpts(t, repo, store)
+
+	before := snapshot(t, repo)
+	if err := Enable(opts); err != nil {
+		t.Fatalf("Enable: %v", err)
+	}
+
+	// Enabled state sanity: prefixed skill bound, shim + hooks merged,
+	// ledger row present.
+	if _, err := os.Lstat(filepath.Join(repo, ".claude", "skills", "vsdd-jira")); err != nil {
+		t.Errorf("bound skill missing: %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(repo, "plugins", "vsdd-factory")); err != nil {
+		t.Errorf("compat symlink missing: %v", err)
+	}
+	settings, err := os.ReadFile(filepath.Join(repo, ".claude", "settings.local.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(settings)
+	for _, want := range []string{"CLAUDE_PLUGIN_ROOT", "PreCompact", "PostCompact", `"once": true`, "sideshow:vsdd-factory", "sideshow:bmad", "user-own-hook"} {
+		if !strings.Contains(s, want) {
+			t.Errorf("enabled settings missing %q", want)
+		}
+	}
+	led, err := ledger.Load(opts.LedgerPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	row := led.RepoRow(repo, "vsdd-factory")
+	if row == nil || row.Version != "1.0.0-rc.23" || row.Channel != "sideshow-native" {
+		t.Fatalf("ledger row = %+v", row)
+	}
+	if row.StorePath != store {
+		t.Errorf("ledger store_path = %s, want the pinned version dir", row.StorePath)
+	}
+
+	if err := Disable(opts); err != nil {
+		t.Fatalf("Disable: %v", err)
+	}
+	after := snapshot(t, repo)
+	var diffs []string
+	for k, v := range after {
+		if bv, ok := before[k]; !ok || bv != v {
+			diffs = append(diffs, "added/changed "+k)
+		}
+	}
+	for k := range before {
+		if _, ok := after[k]; !ok {
+			diffs = append(diffs, "removed "+k)
+		}
+	}
+	if len(diffs) > 0 {
+		t.Errorf("repo not restored exactly:\n  %s", strings.Join(diffs, "\n  "))
+	}
+	led, err = ledger.Load(opts.LedgerPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if led.RepoRow(repo, "vsdd-factory") != nil {
+		t.Error("ledger row survived disable")
+	}
+}
+
+func TestEnable_RefusesForeignDualEnable(t *testing.T) {
+	t.Parallel()
+	store := writeStore(t)
+	repo := writeRepo(t)
+	opts := baseOpts(t, repo, store)
+	for rel, content := range map[string]string{
+		"plugins/config.json": `{"version": 2, "repositories": {"claude-mp": {"plugins": {"vsdd-factory": [{"scope": "user", "installPath": "/nonexistent", "version": "1.0.0-rc.23"}]}}}}`,
+		"settings.json":       `{"enabledPlugins": {"vsdd-factory@claude-mp": true}}`,
+	} {
+		p := filepath.Join(opts.ConfigDir, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	before := snapshot(t, repo)
+	err := Enable(opts)
+	if err == nil || !strings.Contains(err.Error(), "coexist-check") {
+		t.Fatalf("Enable = %v, want coexist-check refusal", err)
+	}
+	after := snapshot(t, repo)
+	if len(before) != len(after) {
+		t.Error("refused enable still wrote into the repo")
+	}
+}
+
+func TestEnable_RefusesUnexpiredFactoryLock(t *testing.T) {
+	t.Parallel()
+	store := writeStore(t)
+	repo := writeRepo(t)
+	opts := baseOpts(t, repo, store)
+	lock := "---\nfactory_lock:\n  holder: dev@example.com\n  locked_at: " +
+		opts.Now.Add(-time.Minute).Format(time.RFC3339) + "\n  expires_at: " +
+		opts.Now.Add(40*time.Minute).Format(time.RFC3339) + "\n---\n"
+	p := filepath.Join(repo, ".factory", "STATE.md")
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(lock), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := Enable(opts)
+	if err == nil || !strings.Contains(err.Error(), "dev@example.com") {
+		t.Fatalf("Enable = %v, want hard lock refusal naming the holder", err)
+	}
+	// The override must NOT pass a hard signal.
+	opts.OverrideStaleLock = true
+	if err := Enable(opts); err == nil {
+		t.Fatal("override passed an unexpired lock; hard signals never pass")
+	}
+}
+
+func TestEnable_MissingDispatcherRefuses(t *testing.T) {
+	t.Parallel()
+	store := writeStore(t)
+	platform, _ := detectPlatform()
+	if err := os.RemoveAll(filepath.Join(store, "hooks", "dispatcher")); err != nil {
+		t.Fatal(err)
+	}
+	_ = platform
+	opts := baseOpts(t, t.TempDir(), store)
+
+	err := Enable(opts)
+	if err == nil || !strings.Contains(err.Error(), "zero-hooks trap") {
+		t.Fatalf("Enable = %v, want dispatcher refusal", err)
+	}
+}
+
+func TestHookEntries_WiresAllTwelveEvents(t *testing.T) {
+	t.Parallel()
+	store := writeStore(t)
+	platform, err := detectPlatform()
+	if err != nil {
+		t.Skip(err)
+	}
+	entries, err := hookEntries(store, platform)
+	if err != nil {
+		t.Fatal(err)
+	}
+	events := map[string]bool{}
+	for _, e := range entries {
+		events[e.Event] = true
+		if e.Timeout != 10000 {
+			t.Errorf("%s timeout = %d, want 10000", e.Event, e.Timeout)
+		}
+		if !strings.HasPrefix(e.Command, "CLAUDE_PLUGIN_ROOT='") {
+			t.Errorf("%s command missing inline env belt: %s", e.Event, e.Command)
+		}
+		if strings.Contains(e.Command, "${CLAUDE_PLUGIN_ROOT}") {
+			t.Errorf("%s command not resolved: %s", e.Event, e.Command)
+		}
+	}
+	// D5: the template's events plus the registered-but-dead pair.
+	for _, ev := range []string{"PreToolUse", "SessionStart", "SessionEnd", "PreCompact", "PostCompact"} {
+		if !events[ev] {
+			t.Errorf("event %s not wired", ev)
+		}
+	}
+}

--- a/internal/ledger/ledger.go
+++ b/internal/ledger/ledger.go
@@ -84,3 +84,59 @@ func (l *Ledger) RepoDirs() []string {
 	}
 	return out
 }
+
+// SetRow records a (repo, pack) binding. The enable verb is the
+// caller; repoDir is normalized to an absolute path.
+func (l *Ledger) SetRow(repoDir, packName string, row Row) error {
+	abs, err := filepath.Abs(repoDir)
+	if err != nil {
+		return fmt.Errorf("resolve repo dir: %w", err)
+	}
+	if l.Repos == nil {
+		l.Repos = map[string]map[string]Row{}
+	}
+	if l.Repos[abs] == nil {
+		l.Repos[abs] = map[string]Row{}
+	}
+	l.Repos[abs][packName] = row
+	return nil
+}
+
+// DeleteRow removes a (repo, pack) binding, pruning an emptied repo
+// entry. Reports whether a row was present.
+func (l *Ledger) DeleteRow(repoDir, packName string) bool {
+	abs, err := filepath.Abs(repoDir)
+	if err != nil {
+		return false
+	}
+	packs, ok := l.Repos[abs]
+	if !ok {
+		return false
+	}
+	if _, ok := packs[packName]; !ok {
+		return false
+	}
+	delete(packs, packName)
+	if len(packs) == 0 {
+		delete(l.Repos, abs)
+	}
+	return true
+}
+
+// Save persists the ledger with a stable schema version.
+func (l *Ledger) Save(path string) error {
+	if l.SchemaVersion == "" {
+		l.SchemaVersion = "0.1.0"
+	}
+	data, err := yaml.Marshal(l)
+	if err != nil {
+		return fmt.Errorf("marshal repo-bindings ledger: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create sideshow data dir: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("write repo-bindings ledger: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
The step after install — activating a plugin-shaped pack in ONE repo — had no supported path, and the zero-hooks trap meant an enabled-but-never-activated install loads 126 skills and 34 agents with the guard surface silently absent. This PR ships the verb pair that closes both: `sideshow enable` refuses to report success unless the full declared hook chain is in place and the dispatcher is executable, and `sideshow disable` reverses an enable exactly. No harness plugin state of any kind is written on this channel; registration is the repo settings chain, and the identity lives only in sideshow's own ledger.

## Enable pipeline

`sideshow enable <pack>[@<ver>] [--repo <path>] [--scope local|project] [--override-stale-lock]`

- Activation gate: `--scope user` is refused outright for per-repo packs (containment mandate).
- Preflight: the ten-check coexist-check plus the running-factory guard. Hard lock signals never pass; soft in-flight signals pass only under an explicit `--override-stale-lock`.
- Platform: five canonical tuples mirroring upstream's detect-platform contract; dispatcher present and executable per apply-platform's checks.
- Materialization: bound-variant render (prefix + namespace rewrite) → repo materialization per the hybrid scope strategy → engine-path compat symlink → env shim → settings-hooks merge. Hook entries derive from the pack's platform template with the inline env belt and resolved store paths; all 12 registered events are wired (the template's 10 plus the registered-but-dead PreCompact/PostCompact pair).
- Post-write verification: a hook chain short of the declared event set refuses success, and every failure path rolls back what was written.
- The ledger row records the exact removal set; version pins are absolute store version dirs, never the `current` symlink, so a store-level flip can never retarget a bound repo.

## Disable

Ledger replay in reverse: hook-chain unmerge, env-shim removal (exact value only), artifact removal under the repo-rooted containment predicate, row deletion. The agent key and class-1 factory state are never touched.

Done criterion proven by test: enable and disable are exact inverses by settings byte diff, with a second pack's managed hooks and the user's own hooks present and undisturbed throughout.

Refs: aae-orc-d3nq.7, finding-093, finding-094