### PR TITLE
docs: native enablement runbook and divergence register

### DIFF
--- a/docs/divergence-register.md
+++ b/docs/divergence-register.md
@@ -1,0 +1,108 @@
+# Divergence register: vsdd-factory on the repo-bindings channel
+
+Status: initial register, 2026-08-01 (aae-orc-d3nq.55, finding-094
+round 3). The unshaping delivery accepts upstream-parity loss by
+design; this register prices every deliberate drop so consumer docs,
+the courtesy note, and the equivalence claim cite recorded facts
+instead of assuming parity. One entry per divergence: what changes,
+what it costs, what mitigates it.
+
+Scope note: "upstream" is the claude-mp plugin form of vsdd-factory;
+"this channel" is the sideshow repo-bindings delivery
+(docs/unshaping-spec.md). Any defect reproducible only on this
+channel is ours, not upstream's.
+
+## 1. `tests/` is excluded from the binding set (decision D3)
+
+Installs lose the in-repo self-test surface upstream ships since
+rc.23. Cost stated plainly: 175 of 247 `.bats` files reference
+`CLAUDE_PLUGIN_ROOT`, and 151 reconstruct the plugin root via a fixed
+four-level parent walk, so the suite as shipped cannot validate an
+unshaped install anyway. Mitigations: doctor may run the suite from
+the store copy; the locator-rewrite offer upstream is tracked
+(aae-orc-d3nq.31).
+
+## 2. Addressing changes to prefixed bare names
+
+Bound artifacts carry the `binding_prefix` (`vsdd-` for
+vsdd-factory): skills become `vsdd-<name>`, agent identifiers become
+`vsdd-<name>`, and namespace-qualified references
+(`/vsdd-factory:<name>`, `subagent_type="vsdd-factory:<name>"`) are
+rewritten at bind time. Cost: every upstream doc naming
+`/vsdd-factory:X` is wrong for this channel. Why it is not optional:
+a user-scope skill shadows a same-name repo skill (finding-091
+addendum 3, T16 corrected), and upstream ships generic names (`jira`,
+34 generic agent names) — unprefixed bound names would be silently
+hijacked on consumer machines.
+
+## 3. Upstream telemetry predicates match nothing here
+
+Repo-scope addressing has no namespace qualifier (trial T20), so the
+four upstream Grafana LogQL predicates on
+`attributes_subagent=vsdd-factory:pr-manager` return zero on this
+channel under any variant of the naming policy. The exact telemetry
+attribute value emitted on this channel is one pending OTEL
+observation (record here when telemetry is next live in an enabled
+repo).
+
+## 4. Upstream activate/deactivate skills do not drive this channel
+
+Both are excluded from the binding set (disposition `replace`,
+unshaping spec): activate renders `hooks.json` INTO the frozen shared
+store; deactivate `rm -f`s it there, which with a shared store would
+disarm every repo on the machine. Replacements: `sideshow enable` /
+`sideshow disable` (shipped) and the consented persona-flip skill
+(aae-orc-d3nq.60).
+
+## 5. Hooks live in the repo settings chain
+
+`claude plugin details` has no analogue here; there is no harness
+plugin state to inspect. Replacements: `sideshow coexist` (foreign
+census), `sideshow coexist-check` (preflight), and the ledger row.
+The hook chain is visible in plain text in the repo settings file,
+marked `_managed_by: sideshow:vsdd-factory`.
+
+## 6. Update semantics move to the ledger
+
+`claude plugin update` has no analogue; repo bindings pin absolute
+store version dirs (never a `current` symlink), so two repos on two
+versions is the representable normal case and a store flip can never
+retarget a bound repo. Version toggle is `disable(vA)` + `enable(vB)`
+per repo. Cost: no machine-wide one-command upgrade; that is the
+point.
+
+## 7. Installed-but-off state is lost (presence is activation)
+
+The harness activates whatever is present at repo scope (trial T21):
+there is no per-repo "installed but disabled" toggle on this channel;
+removal is the off switch. Mitigations: local-scope symlink
+materialization makes removal/re-add one repoint each way (D1);
+selective materialization (aae-orc-d3nq.56) is the finer-grained
+future instrument.
+
+## 8. Hook event set: 12 wired here vs 10 live upstream (decision D5)
+
+Upstream registers 12 events but its templates wire only 10;
+PreCompact/PostCompact are registered-but-dead as shipped (upstream
+defect, aae-orc-d3nq.63, filing held). This channel wires all 12 —
+fix over fidelity. Language discipline: "registered" means
+harness-accepted (T18); "verified firing" is observed only for
+SessionStart, PreToolUse, and PostToolUseFailure.
+
+## 9. Three dormant dispatcher capability grants become LIVE
+
+The engine-path compat symlink (D2) makes the three
+`hooks-registry.toml` read_file grants (:944, :1146, :1311 — the last
+`on_error=block`) resolve for the first time in any consumer repo.
+This is a behavior change, not a restoration: those grants have never
+executed for a claude-mp consumer. Their first observed outcome is a
+trial before it is a claim; record the outcome here, and verify the
+:1311 blocker does not break tool use.
+
+## 10. Standing per-release census-diff cost
+
+Every upstream release must be census-diffed against the unshape
+declaration (deny-by-default: a new top-level unit fails the build
+until dispositioned) before a pack is cut (aae-orc-d3nq.59). This is
+recurring maintainer work the plugin channel does not have, priced
+here so release planning counts it.

--- a/docs/repo-bindings-enablement.md
+++ b/docs/repo-bindings-enablement.md
@@ -1,0 +1,155 @@
+# Enabling vsdd-factory via repo bindings
+
+This is the native enablement runbook for plugin-shaped packs on the
+sideshow channel (aae-orc-d3nq.54). It is the document the pack.yaml
+`runbook:` pointer resolves to. A reader who has never seen a claude
+plugin can enable, verify, toggle versions, and remove with this page
+alone; converting an existing claude-mp install is a different
+document (docs/claude-plugin-conversion-reference.md).
+
+## Why this channel
+
+What a consumer gets here that the plugin form cannot give:
+
+- **Multi-version install.** The store holds every installed version
+  side by side; each repo pins the exact version dir it was enabled
+  with. Two repos on two versions is the representable normal case.
+- **Supply-chain verification.** The pack tarball is cosign-signed
+  with a Rekor transparency-log entry and a source-provenance
+  attestation; verification happens at install, before any repo sees
+  a byte.
+- **Per-repo pinning with no machine-wide activation.** Enabling in
+  one repo changes nothing anywhere else. There is no user-scope
+  enable on this channel at all; a factory pack never activates in
+  repos you did not name.
+- **Exact removal.** Everything enable writes is recorded; disable
+  replays the record in reverse and is byte-exact, proven by test.
+
+Deliberate differences from the plugin form are priced in
+[docs/divergence-register.md](divergence-register.md) — read it once
+before your first enable.
+
+## 1. Obtain and verify
+
+Install the pack into the store from a signed release (unchanged from
+the standard sideshow flow):
+
+```sh
+sideshow install vsdd-factory --from <path-or-release>
+```
+
+Install verifies the file manifest and the executable census
+(`exec-manifest.txt`); a store copy that fails verification is not
+usable. Nothing is active anywhere after install — the store copy is
+producer-validated content only.
+
+## 2. Enable in one repo
+
+```sh
+cd /path/to/your/repo
+sideshow enable vsdd-factory                  # current registered version
+sideshow enable vsdd-factory@1.0.0-rc.23      # or pin explicitly
+```
+
+Flags: `--repo <path>` (instead of cwd), `--scope local|project`
+(default `local`), `--override-stale-lock` (see below).
+
+What the scopes mean:
+
+- **local** (default): bindings are symlinks into the machine store
+  and registration goes to `.claude/settings.local.json`. Nothing
+  enters your repo's git history. This is the testing-the-waters
+  posture.
+- **project**: bindings are full self-contained copies (absolute
+  symlinks do not cross machines) and registration goes to the
+  committed `.claude/settings.json`. Choose this only when the whole
+  team is meant to get the pack on checkout, and expect the diff.
+
+What materializes where (the store-vs-repo split):
+
+| Location | Content |
+|---|---|
+| `.claude/skills/vsdd-*` | The pack's skills, prefixed |
+| `.claude/agents/vsdd-*` | The pack's agents, prefixed, nesting preserved |
+| `.claude/settings.local.json` (or `settings.json`) | `env.CLAUDE_PLUGIN_ROOT` shim + the hook chain (all 12 events), every entry marked `_managed_by: sideshow:vsdd-factory` |
+| `plugins/vsdd-factory` | Compat symlink to the pinned store version (resolves the pack's repo-relative engine paths) |
+| the store (never your repo) | The engine: dispatcher binaries, wasm hook plugins, `bin/`, templates, workflows, rules |
+
+Enable runs a preflight first and refuses rather than proceeding into
+a hazard: another vsdd-factory channel effectively enabled in the
+same repo (two hook chains against one `.factory` state), an
+in-flight factory run, pre-existing content it would overwrite, or a
+missing/non-executable dispatcher (the zero-hooks trap). An unexpired
+factory lock is never overridable; a stale lock or recent-activity
+signal passes only with `--override-stale-lock`.
+
+## 3. Verify
+
+```sh
+sideshow coexist-check vsdd-factory
+```
+
+Clean output ends with `preflight clean`. For a bound repo it also
+verifies the env shim resolves to the pinned store path and the
+dispatcher is executable. Quick manual checks:
+
+```sh
+grep -c 'sideshow:vsdd-factory' .claude/settings.local.json   # hook groups
+ls .claude/skills | grep -c '^vsdd-'                          # skill census
+readlink plugins/vsdd-factory                                 # pinned store path
+```
+
+Enable itself refuses to report success if the post-write hook chain
+is short of the declared event set, so a successful enable already
+implies the full chain.
+
+## 4. Disable and re-enable
+
+```sh
+sideshow disable vsdd-factory
+```
+
+Disable replays the enable record exactly: hook chain unmerged, env
+shim removed, bindings and the compat symlink removed, ledger row
+deleted. Your own settings entries, hooks, and skills are untouched
+(removal never guesses; it only removes what enable recorded).
+Re-enable is a fresh `sideshow enable`.
+
+## 5. Per-repo version toggle
+
+```sh
+sideshow disable vsdd-factory
+sideshow enable vsdd-factory@<other-version>
+```
+
+Only this repo changes. Other repos keep their pins; the store keeps
+every version. There is no machine-wide upgrade lever on this channel
+by design.
+
+## 6. Testing-the-waters trial recipe
+
+To trial the pack beside an existing claude-mp install on the same
+machine (machine-level coexistence is supported; same-REPO dual
+enable is refused):
+
+1. Pick a trial repo the plugin is NOT enabled in. If the repo's
+   origin carries a `factory-artifacts` ref shared with a production
+   checkout, do not trial there — the preflight refuses this
+   (remote-safety).
+2. Snapshot the foreign footprint if you want drift proof:
+   `sideshow coexist vsdd-factory` before and after; the claude-mp
+   footprint is fully disjoint from everything sideshow writes.
+3. `sideshow enable vsdd-factory` (local scope), work the trial.
+4. Exit paths: `sideshow disable vsdd-factory` restores the repo
+   exactly (the preflight records a retreat anchor — the
+   `factory-artifacts` tip and `.factory` status — so you can prove
+   the trial changed nothing it should not have).
+
+## Divergence notice
+
+This channel deliberately diverges from the plugin form in named,
+priced ways — prefixed artifact names, settings-chain registration,
+ledger-based updates, twelve wired hook events, excluded `tests/`.
+The register is [docs/divergence-register.md](divergence-register.md);
+defects reproducible only on this channel belong to sideshow, not
+upstream.


### PR DESCRIPTION
The enable/disable verbs shipped (#76), but the runbook URL the frozen pack.yaml points to had nothing native to resolve to, and every parity claim about the repo-bindings channel rested on scattered working notes. This PR gives both a durable home. Docs only; no behavior changes.

- **`docs/repo-bindings-enablement.md`** — the native enablement runbook: obtain/verify, enable with the local/project scope split and a store-vs-repo table, verification, disable and re-enable, per-repo version toggle, and the testing-the-waters trial recipe with its retreat contract. Leads with what this channel gives that the plugin form cannot: multi-version install, supply-chain verification, per-repo pinning, exact removal.
- **`docs/divergence-register.md`** — ten entries pricing every deliberate parity drop: `tests/` exclusion, prefixed addressing, dead upstream telemetry predicates, replaced activate/deactivate, settings-chain registration, ledger-based updates, presence-is-activation, the 12-vs-10 hook event set, the three dormant capability grants going live (trial pending), and the standing per-release census-diff cost. Consumer docs and the equivalence claim cite this register rather than assuming parity.

Refs: aae-orc-d3nq.54, aae-orc-d3nq.55, finding-094