### PR TITLE
feat(activate): consented persona flip verbs and replacement skills

### DIFF
--- a/cmd/sideshow/activate.go
+++ b/cmd/sideshow/activate.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/ArcavenAE/sideshow/internal/enable"
+	"github.com/ArcavenAE/sideshow/internal/pack"
+)
+
+// runActivate / runDeactivate are the consented persona flip:
+//
+//	sideshow activate <pack> [--repo <path>] [--agent <name>]
+//	sideshow deactivate <pack> [--repo <path>]
+func runActivate(args []string) error {
+	opts, agent, err := parseActivateArgs("activate", args, true)
+	if err != nil {
+		return err
+	}
+	return enable.Activate(*opts, agent)
+}
+
+func runDeactivate(args []string) error {
+	opts, _, err := parseActivateArgs("deactivate", args, false)
+	if err != nil {
+		return err
+	}
+	return enable.Deactivate(*opts)
+}
+
+func parseActivateArgs(verb string, args []string, allowAgent bool) (*enable.Options, string, error) {
+	if len(args) < 1 || len(args[0]) == 0 || args[0][0] == '-' {
+		return nil, "", fmt.Errorf("usage: sideshow %s <pack> [--repo <path>]", verb)
+	}
+	packName, version, _ := strings.Cut(args[0], "@")
+	repoDir, err := os.Getwd()
+	if err != nil {
+		return nil, "", fmt.Errorf("resolve working directory: %w", err)
+	}
+	opts := &enable.Options{Pack: packName, Version: version, RepoDir: repoDir}
+	agent := ""
+	for i := 1; i < len(args); i++ {
+		switch args[i] {
+		case "--repo":
+			if i+1 >= len(args) {
+				return nil, "", fmt.Errorf("--repo requires a path")
+			}
+			i++
+			opts.RepoDir = args[i]
+		case "--agent":
+			if !allowAgent {
+				return nil, "", fmt.Errorf("--agent applies to activate only")
+			}
+			if i+1 >= len(args) {
+				return nil, "", fmt.Errorf("--agent requires a name")
+			}
+			i++
+			agent = args[i]
+		default:
+			return nil, "", fmt.Errorf("unknown flag: %s", args[i])
+		}
+	}
+	// The prefix guards both verbs; resolve it from the installed
+	// pack's activation contract when present.
+	if p := findInstalledPack(opts.Pack); p != nil {
+		if act, actErr := pack.LoadActivation(p.Path); actErr == nil {
+			opts.Prefix = act.Prefix(opts.Pack)
+		}
+	}
+	return opts, agent, nil
+}

--- a/cmd/sideshow/main.go
+++ b/cmd/sideshow/main.go
@@ -43,6 +43,8 @@ Usage:
   sideshow coexist <pack> [--repo <path>]  Read-only foreign-install census and coexistence findings
   sideshow enable <pack>[@<ver>] [--repo <path>] [--scope local|project]  Activate a pack in one repo (repo-bindings)
   sideshow disable <pack> [--repo <path>]  Reverse an enable exactly (ledger replay)
+  sideshow activate <pack> [--repo <path>] [--agent <name>]  Consented persona flip (repo default agent)
+  sideshow deactivate <pack> [--repo <path>]  Remove the persona flip only (prefix-guarded)
   sideshow coexist-check <pack> [--repo <path>]  Read-only enable/adopt preflight (ten checks)
   sideshow version                        Show version
 
@@ -126,6 +128,10 @@ func main() {
 		}
 	case "status":
 		err = runStatus()
+	case "activate":
+		err = runActivate(os.Args[2:])
+	case "deactivate":
+		err = runDeactivate(os.Args[2:])
 	case "enable":
 		err = runEnable(os.Args[2:])
 	case "disable":

--- a/internal/bindings/bound_variant.go
+++ b/internal/bindings/bound_variant.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/ArcavenAE/sideshow/internal/pack"
@@ -114,11 +115,80 @@ func RenderBoundVariant(storeRoot string, inv *PluginInventory, packName, prefix
 		out.AgentFiles = append(out.AgentFiles, dstRel)
 	}
 
+	// Replace-disposition skills: the upstream activate/deactivate
+	// pair writes into the frozen store (render hooks.json in, rm -f
+	// it out) and is excluded from materialization; sideshow-authored
+	// replacements ship in their place so an in-session /<prefix>-
+	// activate resolves to something correct (aae-orc-d3nq.60).
+	for _, ex := range inv.ExcludedSkills {
+		name := filepath.Base(ex)
+		content, ok := replacementSkill(packName, prefix, name)
+		if !ok {
+			continue
+		}
+		dstRel := filepath.Join("skills", prefix+"-"+name)
+		dst := filepath.Join(destDir, dstRel, "SKILL.md")
+		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+			return nil, fmt.Errorf("create replacement skill dir: %w", err)
+		}
+		if err := os.WriteFile(dst, []byte(content), 0o644); err != nil {
+			return nil, fmt.Errorf("write replacement skill %s: %w", name, err)
+		}
+		out.SkillDirs = append(out.SkillDirs, filepath.ToSlash(dstRel))
+	}
+	sort.Strings(out.SkillDirs)
+
 	if err := translateExecManifest(storeRoot, destDir, inv, prefix); err != nil {
 		return nil, err
 	}
 
 	return out, nil
+}
+
+// replacementSkill returns the sideshow-authored SKILL.md for a
+// replace-disposition upstream skill. Nothing in these skills may
+// write into the store; every operation routes through sideshow
+// verbs, which are consent-gated and ledger-recorded.
+func replacementSkill(packName, prefix, name string) (string, bool) {
+	switch name {
+	case "activate":
+		return `---
+name: ` + prefix + `-activate
+description: Opt in to the ` + packName + ` persona for this repo. On the sideshow channel this flips the default agent to the bound orchestrator; hooks and platform binding were already handled by sideshow enable. Reversible via /` + prefix + `-deactivate.
+---
+
+# Activate (sideshow channel)
+
+This repo receives ` + packName + ` through sideshow repo bindings, so
+this skill replaces the upstream activate flow. Enabling the pack made
+its agents, skills, and hooks available and wired the hook chain; what
+remains is the explicit, consented persona flip.
+
+1. Confirm the pack is enabled here: run ` + "`sideshow coexist-check " + packName + "`" + ` via Bash and check the report.
+2. Ask the operator to confirm they want the default agent flipped to ` + "`" + prefix + `-orchestrator` + "`" + ` for THIS repo only.
+3. On consent, run ` + "`sideshow activate " + packName + "`" + ` via Bash. It refuses to overwrite a persona it does not own and warns on platform drift.
+4. Report the outcome: the new default agent, that the change is repo-local, and that ` + "`sideshow deactivate " + packName + "`" + ` reverses it.
+
+Never edit settings files or the pack store directly; the sideshow
+verbs are the recorded, reversible path.
+`, true
+	case "deactivate":
+		return `---
+name: ` + prefix + `-deactivate
+description: Reverse /` + prefix + `-activate. Removes the default-agent persona flip only; bindings and hooks stay enabled (sideshow disable removes those). Refuses to touch a persona this pack did not set.
+---
+
+# Deactivate (sideshow channel)
+
+This repo receives ` + packName + ` through sideshow repo bindings, so
+this skill replaces the upstream deactivate flow. Nothing here touches
+the shared store or other repos.
+
+1. Run ` + "`sideshow deactivate " + packName + "`" + ` via Bash. It removes the default-agent key only when it points at a ` + "`" + prefix + `-` + "`" + ` agent; anything else is refused, not cleaned.
+2. Report the outcome. If the operator wants the pack's bindings and hooks gone too, that is ` + "`sideshow disable " + packName + "`" + ` (exact, ledger-recorded removal).
+`, true
+	}
+	return "", false
 }
 
 // namespaceRewriter builds the `<pack>:<name>` → `<prefix>-<name>`

--- a/internal/bindings/bound_variant_test.go
+++ b/internal/bindings/bound_variant_test.go
@@ -274,3 +274,42 @@ func TestRewriteFrontmatterName_Idempotent(t *testing.T) {
 		t.Errorf("content without frontmatter modified: %q", got)
 	}
 }
+
+// .60: excluded activate/deactivate get sideshow-authored
+// replacements that route through verbs and never write into the
+// store.
+func TestRenderBoundVariant_ReplacementSkills(t *testing.T) {
+	t.Parallel()
+	store := writeBoundFixtureStore(t)
+	dest := filepath.Join(t.TempDir(), "bound")
+	inv := boundFixtureInventory()
+	inv.ExcludedSkills = []string{"skills/activate", "skills/deactivate"}
+
+	out, err := RenderBoundVariant(store, inv, "vsdd-factory", "vsdd", dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := map[string]bool{}
+	for _, s := range out.SkillDirs {
+		found[s] = true
+	}
+	if !found["skills/vsdd-activate"] || !found["skills/vsdd-deactivate"] {
+		t.Fatalf("replacement skills missing from inventory: %v", out.SkillDirs)
+	}
+	data, err := os.ReadFile(filepath.Join(dest, "skills", "vsdd-activate", "SKILL.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(data)
+	if !strings.Contains(s, "name: vsdd-activate") {
+		t.Error("replacement frontmatter name missing or unprefixed")
+	}
+	if !strings.Contains(s, "sideshow activate vsdd-factory") {
+		t.Error("replacement does not route through the sideshow verb")
+	}
+	for _, forbidden := range []string{"rm -f", "cp ", "hooks.json"} {
+		if strings.Contains(s, forbidden) {
+			t.Errorf("replacement skill carries store-write instruction %q", forbidden)
+		}
+	}
+}

--- a/internal/enable/activate.go
+++ b/internal/enable/activate.go
@@ -1,0 +1,191 @@
+package enable
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/ArcavenAE/sideshow/internal/bindings"
+	"github.com/ArcavenAE/sideshow/internal/ledger"
+)
+
+// Activate and Deactivate are the consented persona flip
+// (aae-orc-d3nq.60), porting the logic of the upstream
+// activate/deactivate skills without their store writes. Enable
+// deliberately does not touch the agent key (the upstream
+// no-hijack-on-enable property, kept); running activate is the
+// explicit opt-in that makes a plain session the pipeline driver.
+//
+// Reframes from the upstream pair:
+//   - activated_platform / activated_plugin_version are NOT written
+//     into settings. The ledger row is the single record of both;
+//     the platform drift warning reads it from there.
+//   - The agent value is the bound (prefixed) bare name per trial
+//     T20 — no namespace-qualified form exists on this channel.
+//   - Nothing here can write into the store: the upstream pair's
+//     hooks.json copy/remove steps are the enable/disable verbs'
+//     settings-chain work.
+
+// defaultAgentSuffix is the upstream persona the flip selects.
+const defaultAgentSuffix = "orchestrator"
+
+// Activate sets the repo's default agent to the pack's bound
+// orchestrator (or --agent override). Requires an enabled ledger row;
+// refuses to overwrite an agent key it does not own.
+func Activate(opts Options, agentOverride string) error {
+	if err := opts.normalize(); err != nil {
+		return err
+	}
+	led, err := ledger.Load(opts.LedgerPath)
+	if err != nil {
+		return err
+	}
+	row := led.RepoRow(opts.RepoDir, opts.Pack)
+	if row == nil {
+		return fmt.Errorf("%s is not enabled in %s; run 'sideshow enable %s' first (activate only flips the persona)", opts.Pack, opts.RepoDir, opts.Pack)
+	}
+
+	prefix := opts.Prefix
+	if prefix == "" {
+		prefix = opts.Pack
+	}
+	agent := agentOverride
+	if agent == "" {
+		agent = prefix + "-" + defaultAgentSuffix
+	}
+	if !strings.HasPrefix(agent, prefix+"-") {
+		return fmt.Errorf("agent %q does not carry the %s- binding prefix; activate only sets agents this pack ships", agent, prefix)
+	}
+
+	// Platform drift warning (upstream re-activation check, reframed
+	// against the ledger record).
+	if detected, derr := detectPlatform(); derr == nil && row.Platform != "" && row.Platform != detected {
+		fmt.Fprintf(os.Stderr, "warning: repo was enabled for platform %s but this host is %s; the bound dispatcher may not run here — re-enable on this host (disable + enable) to rebind\n",
+			row.Platform, detected)
+	}
+
+	settings := settingsFile(opts.RepoDir, bindings.RepoScope(row.SettingsScope))
+	changed, prev, err := setAgentKey(settings, agent, prefix)
+	if err != nil {
+		return err
+	}
+	if !changed {
+		fmt.Printf("agent already %s in %s; nothing to do\n", prev, opts.RepoDir)
+		return nil
+	}
+	fmt.Printf("activated: default agent is now %s in %s (scope %s)\n", agent, opts.RepoDir, row.SettingsScope)
+	fmt.Println("Reverse with 'sideshow deactivate'; this only affects this repo.")
+	return nil
+}
+
+// Deactivate removes the default-agent key, guarded: if the key does
+// not point at one of this pack's bound (prefixed) agents, it is
+// someone else's choice and deactivate refuses rather than cleaning
+// it (the upstream step-2 guard, re-expressed against the .51
+// naming).
+func Deactivate(opts Options) error {
+	if err := opts.normalize(); err != nil {
+		return err
+	}
+	led, err := ledger.Load(opts.LedgerPath)
+	if err != nil {
+		return err
+	}
+	prefix := opts.Prefix
+	if prefix == "" {
+		prefix = opts.Pack
+	}
+	scope := bindings.ScopeLocal
+	if row := led.RepoRow(opts.RepoDir, opts.Pack); row != nil {
+		scope = bindings.RepoScope(row.SettingsScope)
+	}
+
+	settings := settingsFile(opts.RepoDir, scope)
+	removed, prev, err := clearAgentKey(settings, prefix)
+	if err != nil {
+		return err
+	}
+	switch {
+	case prev == "":
+		fmt.Printf("no default agent set in %s; nothing to do\n", opts.RepoDir)
+	case !removed:
+		return fmt.Errorf("default agent is %q, which is not a %s- agent; refusing to remove a persona this pack did not set", prev, prefix)
+	default:
+		fmt.Printf("deactivated: default agent %s removed in %s (bindings stay enabled; 'sideshow disable' removes those)\n", prev, opts.RepoDir)
+	}
+	return nil
+}
+
+// setAgentKey writes the agent key, refusing a foreign value.
+// Returns changed=false when the key already holds agent.
+func setAgentKey(path, agent, prefix string) (changed bool, prev string, err error) {
+	settings, _, err := readSettingsJSON(path)
+	if err != nil {
+		return false, "", err
+	}
+	if raw, ok := settings["agent"]; ok {
+		s, _ := raw.(string)
+		if s == agent {
+			return false, s, nil
+		}
+		if !strings.HasPrefix(s, prefix+"-") {
+			return false, s, fmt.Errorf("default agent is already %q (not a %s- agent); sideshow never overwrites a persona choice it does not own — remove it yourself first if intended", s, prefix)
+		}
+	}
+	settings["agent"] = agent
+	return true, agent, writeSettingsJSON(path, settings)
+}
+
+// clearAgentKey removes the agent key only when it carries the
+// pack's prefix. Returns prev="" when no key exists.
+func clearAgentKey(path, prefix string) (removed bool, prev string, err error) {
+	settings, existed, err := readSettingsJSON(path)
+	if err != nil {
+		return false, "", err
+	}
+	if !existed {
+		return false, "", nil
+	}
+	raw, ok := settings["agent"]
+	if !ok {
+		return false, "", nil
+	}
+	s, _ := raw.(string)
+	if !strings.HasPrefix(s, prefix+"-") {
+		return false, s, nil
+	}
+	delete(settings, "agent")
+	return true, s, writeSettingsJSON(path, settings)
+}
+
+// readSettingsJSON / writeSettingsJSON mirror the bindings package's
+// settings helpers (read-merge-write, fail closed on malformed).
+func readSettingsJSON(path string) (map[string]any, bool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return map[string]any{}, false, nil
+		}
+		return nil, false, fmt.Errorf("read settings %s: %w", path, err)
+	}
+	var settings map[string]any
+	if err := json.Unmarshal(data, &settings); err != nil {
+		return nil, false, fmt.Errorf("parse settings %s (refusing to merge into a file that cannot round-trip): %w", path, err)
+	}
+	if settings == nil {
+		settings = map[string]any{}
+	}
+	return settings, true, nil
+}
+
+func writeSettingsJSON(path string, settings map[string]any) error {
+	data, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal settings: %w", err)
+	}
+	if err := os.WriteFile(path, append(data, '\n'), 0o644); err != nil {
+		return fmt.Errorf("write settings %s: %w", path, err)
+	}
+	return nil
+}

--- a/internal/enable/activate_test.go
+++ b/internal/enable/activate_test.go
@@ -1,0 +1,140 @@
+package enable
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ArcavenAE/sideshow/internal/ledger"
+)
+
+// enabledFixture stands up an enabled repo: ledger row + settings
+// file, without running the full Enable pipeline.
+func enabledFixture(t *testing.T, settingsContent string) (Options, string) {
+	t.Helper()
+	repo := t.TempDir()
+	settings := filepath.Join(repo, ".claude", "settings.local.json")
+	if err := os.MkdirAll(filepath.Dir(settings), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if settingsContent != "" {
+		if err := os.WriteFile(settings, []byte(settingsContent), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	ledgerPath := filepath.Join(t.TempDir(), "repo-bindings.yaml")
+	led := &ledger.Ledger{}
+	platform, _ := detectPlatform()
+	if err := led.SetRow(repo, "vsdd-factory", ledger.Row{
+		Version: "1.0.0-rc.23", StorePath: "/store/1.0.0-rc.23",
+		Channel: "sideshow-native", Platform: platform, SettingsScope: "local",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := led.Save(ledgerPath); err != nil {
+		t.Fatal(err)
+	}
+
+	return Options{
+		RepoDir: repo, Pack: "vsdd-factory", Prefix: "vsdd",
+		LedgerPath: ledgerPath, ConfigDir: t.TempDir(),
+	}, settings
+}
+
+func readAgent(t *testing.T, settings string) string {
+	t.Helper()
+	m, _, err := readSettingsJSON(settings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s, _ := m["agent"].(string)
+	return s
+}
+
+func TestActivateDeactivate_RoundTrip(t *testing.T) {
+	t.Parallel()
+	opts, settings := enabledFixture(t, `{"env": {"OTEL_SERVICE_NAME": "kept"}}`)
+
+	if err := Activate(opts, ""); err != nil {
+		t.Fatalf("Activate: %v", err)
+	}
+	if got := readAgent(t, settings); got != "vsdd-orchestrator" {
+		t.Errorf("agent = %q, want vsdd-orchestrator", got)
+	}
+	// The .50 env write and unrelated env keys survive.
+	m, _, err := readSettingsJSON(settings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	env, _ := m["env"].(map[string]any)
+	if env["OTEL_SERVICE_NAME"] != "kept" {
+		t.Errorf("sibling env key disturbed: %v", m)
+	}
+	// No upstream state blocks are written; the ledger is the record.
+	if _, ok := m["vsdd-factory"]; ok {
+		t.Error("activated_platform block written into settings; the ledger is the single record")
+	}
+
+	if err := Deactivate(opts); err != nil {
+		t.Fatalf("Deactivate: %v", err)
+	}
+	if got := readAgent(t, settings); got != "" {
+		t.Errorf("agent survived deactivate: %q", got)
+	}
+}
+
+func TestActivate_RefusesForeignAgentKey(t *testing.T) {
+	t.Parallel()
+	opts, settings := enabledFixture(t, `{"agent": "my-own-agent"}`)
+
+	err := Activate(opts, "")
+	if err == nil || !strings.Contains(err.Error(), "my-own-agent") {
+		t.Fatalf("Activate = %v, want refusal naming the foreign agent", err)
+	}
+	if got := readAgent(t, settings); got != "my-own-agent" {
+		t.Errorf("foreign agent key disturbed: %q", got)
+	}
+}
+
+func TestActivate_RequiresEnabledRow(t *testing.T) {
+	t.Parallel()
+	opts := Options{
+		RepoDir: t.TempDir(), Pack: "vsdd-factory", Prefix: "vsdd",
+		LedgerPath: filepath.Join(t.TempDir(), "repo-bindings.yaml"),
+		ConfigDir:  t.TempDir(),
+	}
+	err := Activate(opts, "")
+	if err == nil || !strings.Contains(err.Error(), "not enabled") {
+		t.Fatalf("Activate = %v, want not-enabled refusal", err)
+	}
+}
+
+func TestActivate_RefusesUnprefixedAgentOverride(t *testing.T) {
+	t.Parallel()
+	opts, _ := enabledFixture(t, "")
+	err := Activate(opts, "orchestrator")
+	if err == nil || !strings.Contains(err.Error(), "binding prefix") {
+		t.Fatalf("Activate = %v, want prefix refusal", err)
+	}
+}
+
+func TestDeactivate_GuardRefusesForeignPersona(t *testing.T) {
+	t.Parallel()
+	opts, settings := enabledFixture(t, `{"agent": "someone-elses-agent"}`)
+
+	err := Deactivate(opts)
+	if err == nil || !strings.Contains(err.Error(), "refusing to remove") {
+		t.Fatalf("Deactivate = %v, want guard refusal", err)
+	}
+	if got := readAgent(t, settings); got != "someone-elses-agent" {
+		t.Errorf("foreign persona disturbed: %q", got)
+	}
+
+	// Absent key is a clean no-op, not an error.
+	opts2, _ := enabledFixture(t, "")
+	if err := Deactivate(opts2); err != nil {
+		t.Errorf("Deactivate on empty settings: %v", err)
+	}
+}


### PR DESCRIPTION
The upstream activate/deactivate skills are excluded from the binding set because both write into the frozen shared store — under a shared store, deactivating repo A would silently disarm repo B. But their logic is the right spec for the persona flip, so this PR ports it without the store writes, and keeps enable's deliberate no-hijack property: making artifacts available never changes your default persona; that flip is always a separate, consented act.

## What ships

- **`sideshow activate <pack> [--repo] [--agent]`** — sets the repo default agent to the bound orchestrator (prefixed bare name; repo scope has no namespace-qualified form). Requires an enabled ledger row, refuses to overwrite a persona it does not own, and warns on platform drift read from the ledger. The upstream `activated_platform` / `activated_plugin_version` settings blocks are not written: the ledger row is the single record of both.
- **`sideshow deactivate <pack> [--repo]`** — removes the agent key only when it carries the pack's binding prefix (the upstream guard, re-expressed against the prefixed naming); anything else is refused, not cleaned. Bindings and hooks stay — that's `disable`.
- **Replacement skills** — the bound variant now synthesizes sideshow-authored `<prefix>-activate` / `<prefix>-deactivate` SKILL.md files for the excluded pair, so an in-session `/vsdd-activate` resolves to instructions that route through the verbs. A test asserts no replacement carries store-write instructions.
- Env coexistence covered by test: the flip preserves OTEL_* and other sibling env keys beside the `CLAUDE_PLUGIN_ROOT` shim.

Refs: aae-orc-d3nq.60, finding-091, finding-094