### PR TITLE
feat(adopt): per-repo conversion from the foreign channel

### DIFF
--- a/cmd/sideshow/adopt.go
+++ b/cmd/sideshow/adopt.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/ArcavenAE/sideshow/internal/adopt"
+	"github.com/ArcavenAE/sideshow/internal/bindings"
+)
+
+// runAdopt is the conversion verb (aae-orc-d3nq.22):
+//
+//	sideshow adopt <pack>[@<version>] [--repo <path>] [--scope local|project]
+//	               [--allow-version-change] [--rewrite-agent] [--dry-run]
+//	               [--override-stale-lock] [--finish]
+//
+// --finish runs the residue report instead of a conversion: it lists
+// remaining foreign traces and the operator commands that retire
+// them, and executes nothing.
+func runAdopt(args []string) error {
+	if len(args) < 1 || len(args[0]) == 0 || args[0][0] == '-' {
+		return fmt.Errorf("usage: sideshow adopt <pack>[@<version>] [--repo <path>] [--scope local|project] [--allow-version-change] [--rewrite-agent] [--dry-run] [--override-stale-lock] [--finish]")
+	}
+	packName, version, _ := strings.Cut(args[0], "@")
+	repoDir, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("resolve working directory: %w", err)
+	}
+	opts := adopt.Options{Pack: packName, Version: version, RepoDir: repoDir}
+	finish := false
+	for i := 1; i < len(args); i++ {
+		switch args[i] {
+		case "--repo":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--repo requires a path")
+			}
+			i++
+			opts.RepoDir = args[i]
+		case "--scope":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--scope requires local or project")
+			}
+			i++
+			if args[i] == "user" {
+				return fmt.Errorf("--scope user is refused: a per-repo-required pack never activates machine-wide (containment mandate); use local or project")
+			}
+			opts.Scope = bindings.RepoScope(args[i])
+		case "--allow-version-change":
+			opts.AllowVersionChange = true
+		case "--rewrite-agent":
+			opts.RewriteAgent = true
+		case "--dry-run":
+			opts.DryRun = true
+		case "--override-stale-lock":
+			opts.OverrideStaleLock = true
+		case "--finish":
+			finish = true
+		default:
+			return fmt.Errorf("unknown flag: %s", args[i])
+		}
+	}
+	if finish {
+		return adopt.Finish(opts)
+	}
+	_, err = adopt.Adopt(opts)
+	return err
+}

--- a/cmd/sideshow/main.go
+++ b/cmd/sideshow/main.go
@@ -46,6 +46,8 @@ Usage:
   sideshow activate <pack> [--repo <path>] [--agent <name>]  Consented persona flip (repo default agent)
   sideshow deactivate <pack> [--repo <path>]  Remove the persona flip only (prefix-guarded)
   sideshow coexist-check <pack> [--repo <path>]  Read-only enable/adopt preflight (ten checks)
+  sideshow adopt <pack> [--repo <path>] [--rewrite-agent] [--dry-run]  Convert a repo from the foreign (claude-mp) channel
+  sideshow adopt <pack> --finish          Report remaining foreign residue (print-only)
   sideshow version                        Show version
 
 Install options:
@@ -138,6 +140,8 @@ func main() {
 		err = runDisable(os.Args[2:])
 	case "coexist-check":
 		err = runCoexistCheck(os.Args[2:])
+	case "adopt":
+		err = runAdopt(os.Args[2:])
 	case "coexist":
 		err = runCoexist(os.Args[2:])
 	case "version", "--version", "-V":

--- a/internal/adopt/adopt.go
+++ b/internal/adopt/adopt.go
@@ -1,0 +1,477 @@
+// Package adopt converts a repo running the foreign (claude-mp)
+// channel of a plugin-shaped pack onto sideshow-native repo bindings
+// (aae-orc-d3nq.22). The conversion is per-repo and reversible:
+// suppress the foreign identity in THIS repo (a repo-side settings
+// override; the foreign install itself is never touched), enable the
+// sideshow channel at the version the foreign tree was actually
+// running, then prove equivalence against the foreign install tree.
+//
+// Ordering is load-bearing: suppression precedes enable so the
+// coexistence preflight's same-repo-double-dispatch check sees the
+// foreign identity already silenced.
+//
+// Machine-level retirement (uninstalling the foreign channel, purging
+// its cache, removing the marketplace) is deliberately NOT performed
+// here. Finish reports the residue and prints the operator commands;
+// executing them is the operator's act — the foreign census stays
+// read-only.
+package adopt
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/ArcavenAE/sideshow/internal/bindings"
+	"github.com/ArcavenAE/sideshow/internal/coexistcheck"
+	"github.com/ArcavenAE/sideshow/internal/enable"
+	"github.com/ArcavenAE/sideshow/internal/foreign"
+	"github.com/ArcavenAE/sideshow/internal/ledger"
+)
+
+// Options configures an adoption.
+type Options struct {
+	RepoDir    string
+	Pack       string
+	Version    string // "" adopts at the foreign tree's running version
+	Scope      bindings.RepoScope
+	LedgerPath string
+	ConfigDir  string
+	// OverrideStaleLock passes through to enable's factory guard.
+	OverrideStaleLock bool
+	// AllowVersionChange permits adopting at a version other than the
+	// one the foreign tree is running. Without it, drift refuses:
+	// equivalence is only provable at version equality.
+	AllowVersionChange bool
+	// RewriteAgent consents to flipping a foreign-form default agent
+	// (<pack>:...) to the bound orchestrator. Off by default; adopt
+	// never rewrites a persona choice without this flag.
+	RewriteAgent bool
+	// DryRun prints the plan and writes nothing.
+	DryRun bool
+	// StoreRoot, Prefix, BoundDir inject test fixtures (same seam as
+	// enable.Options).
+	StoreRoot string
+	Prefix    string
+	BoundDir  string
+	Now       time.Time
+}
+
+// Outcome reports what an adoption did, for the caller and for tests.
+type Outcome struct {
+	Identity       string // foreign identity suppressed
+	Version        string // version enabled on the sideshow channel
+	Suppressed     bool
+	AgentRewritten bool
+	// Equivalence lines are the E1-E4 report (docs: honest
+	// equivalence; E3 is never provable headless).
+	Equivalence []string
+	// FootprintDrift is non-empty if machine-level harness state
+	// changed during adoption. It must be empty: adopt only writes
+	// repo-side files.
+	FootprintDrift []string
+}
+
+func (o *Options) normalize() error {
+	if o.ConfigDir == "" {
+		o.ConfigDir = foreign.ConfigDir()
+	}
+	if o.LedgerPath == "" {
+		o.LedgerPath = ledger.Path()
+	}
+	if o.Scope == "" {
+		o.Scope = bindings.ScopeLocal
+	}
+	if o.Now.IsZero() {
+		o.Now = time.Now().UTC()
+	}
+	abs, err := filepath.Abs(o.RepoDir)
+	if err != nil {
+		return fmt.Errorf("resolve repo dir: %w", err)
+	}
+	o.RepoDir = abs
+	return nil
+}
+
+// Adopt runs the conversion.
+func Adopt(opts Options) (*Outcome, error) {
+	if err := opts.normalize(); err != nil {
+		return nil, err
+	}
+
+	census, err := foreign.TakeCensus(opts.ConfigDir, opts.Pack)
+	if err != nil {
+		return nil, err
+	}
+	view, err := census.ResolveRepo(opts.RepoDir)
+	if err != nil {
+		return nil, err
+	}
+	switch len(view.EffectivelyEnabled) {
+	case 0:
+		return nil, fmt.Errorf("no foreign %s channel dispatches in %s; nothing to adopt — use 'sideshow enable %s' for a fresh repo", opts.Pack, opts.RepoDir, opts.Pack)
+	case 1:
+		// the adoption target
+	default:
+		return nil, fmt.Errorf("multiple foreign identities dispatch in %s (%s); resolve with 'sideshow coexist' before adopting", opts.RepoDir, strings.Join(view.EffectivelyEnabled, ", "))
+	}
+	identity := view.EffectivelyEnabled[0]
+
+	// User-scope enable is the containment-mandate defect (Diagnose
+	// grades it ERROR): a machine-wide enable of a per-repo-required
+	// pack. Adopt refuses the direct flip — migrating the machine
+	// posture (removing the user-scope entry, adding per-repo enables
+	// in every repo that still wants the foreign channel) is the
+	// operator's act, because only the operator knows which repos
+	// those are.
+	if census.UserEnabled(identity) {
+		return nil, fmt.Errorf("%s is enabled at USER scope (machine-wide); adopt refuses the direct flip — first move the enable per-repo: remove the entry from the user settings, add a project/local-scope enable in each repo that should keep the foreign channel, then re-run adopt here", identity)
+	}
+
+	install := findInstall(census, identity)
+	if install == nil {
+		return nil, fmt.Errorf("%s is enabled in %s but has no install record (orphaned enable, trial T14); there is no running tree to adopt from — clean the orphan per 'sideshow coexist', then use plain enable", identity, opts.RepoDir)
+	}
+
+	// Version gate: the foreign tree's plugin.json is the version
+	// authority (trial T13; the marketplace label is ref-pinned).
+	runningVersion := install.TreeVersion
+	if runningVersion == "" {
+		runningVersion = install.Version
+	}
+	adoptVersion := opts.Version
+	if adoptVersion == "" {
+		adoptVersion = runningVersion
+	}
+	if adoptVersion == "" {
+		return nil, fmt.Errorf("cannot determine the running version of %s (tree at %s unreadable and no registry version); pass an explicit version with %s@<version> --allow-version-change", identity, install.InstallPath, opts.Pack)
+	}
+	if runningVersion != "" && adoptVersion != runningVersion && !opts.AllowVersionChange {
+		return nil, fmt.Errorf("foreign tree runs %s but adoption targets %s; equivalence is only provable at version equality — re-run with --allow-version-change to accept the drift", runningVersion, adoptVersion)
+	}
+
+	// Pre-state snapshot.
+	footBefore, err := coexistcheck.SnapshotForeignFootprint(opts.ConfigDir)
+	if err != nil {
+		return nil, fmt.Errorf("snapshot foreign footprint: %w", err)
+	}
+	agentBefore := readAgentKey(opts.RepoDir)
+
+	if opts.DryRun {
+		fmt.Printf("adopt plan for %s in %s (dry run, nothing written):\n", opts.Pack, opts.RepoDir)
+		fmt.Printf("  1. suppress foreign identity %s in this repo only (settings.local.json override; the install is untouched)\n", identity)
+		fmt.Printf("  2. sideshow enable %s@%s --scope %s\n", opts.Pack, adoptVersion, opts.Scope)
+		if agentBefore != "" && strings.HasPrefix(agentBefore, opts.Pack+":") {
+			if opts.RewriteAgent {
+				fmt.Printf("  3. rewrite default agent %q to the bound orchestrator (consented via --rewrite-agent)\n", agentBefore)
+			} else {
+				fmt.Printf("  3. default agent %q is the foreign form; it will KEEP pointing at the suppressed channel — pass --rewrite-agent to flip it, or run 'sideshow activate' after\n", agentBefore)
+			}
+		}
+		fmt.Printf("  4. prove equivalence against the foreign tree at %s\n", install.InstallPath)
+		return &Outcome{Identity: identity, Version: adoptVersion}, nil
+	}
+
+	// Step 1: repo-side suppression, BEFORE enable (see package doc).
+	settingsCreated, err := foreign.SuppressInRepo(opts.RepoDir, identity)
+	if err != nil {
+		return nil, err
+	}
+
+	// Step 2: enable the sideshow channel; roll the suppression back
+	// on any failure so the repo is exactly as found.
+	eOpts := enable.Options{
+		RepoDir: opts.RepoDir, Pack: opts.Pack, Version: adoptVersion,
+		Scope: opts.Scope, LedgerPath: opts.LedgerPath, ConfigDir: opts.ConfigDir,
+		OverrideStaleLock: opts.OverrideStaleLock,
+		StoreRoot:         opts.StoreRoot, Prefix: opts.Prefix, BoundDir: opts.BoundDir,
+		Now: opts.Now,
+	}
+	if err := enable.Enable(eOpts); err != nil {
+		rollbackSuppression(opts.RepoDir, identity, settingsCreated)
+		return nil, fmt.Errorf("enable failed; suppression rolled back, repo unchanged: %w", err)
+	}
+
+	out := &Outcome{Identity: identity, Version: adoptVersion, Suppressed: true}
+
+	// Step 3: consented agent flip. Only the foreign form of THIS
+	// pack's persona is eligible; anything else is the user's choice.
+	led, err := ledger.Load(opts.LedgerPath)
+	if err != nil {
+		return out, err
+	}
+	row := led.RepoRow(opts.RepoDir, opts.Pack)
+	if row == nil {
+		return out, fmt.Errorf("enable reported success but no ledger row exists for %s; refusing to continue", opts.RepoDir)
+	}
+	prefix := opts.Prefix
+	if prefix == "" {
+		prefix = opts.Pack
+	}
+	if opts.RewriteAgent && strings.HasPrefix(agentBefore, opts.Pack+":") {
+		bound := prefix + "-orchestrator"
+		if err := writeAgentKey(opts.RepoDir, bound); err != nil {
+			return out, err
+		}
+		out.AgentRewritten = true
+		fmt.Printf("default agent rewritten: %q -> %q\n", agentBefore, bound)
+	} else if agentBefore != "" && strings.HasPrefix(agentBefore, opts.Pack+":") {
+		fmt.Printf("note: default agent %q still names the suppressed foreign channel; flip it with 'sideshow activate %s --repo %s'\n", agentBefore, opts.Pack, opts.RepoDir)
+	}
+
+	// Step 4: honest equivalence, sideshow store vs foreign tree.
+	out.Equivalence = equivalenceReport(row, install)
+	for _, line := range out.Equivalence {
+		fmt.Println(line)
+	}
+
+	// Step 5: prove adopt touched no machine-level harness state.
+	footAfter, err := coexistcheck.SnapshotForeignFootprint(opts.ConfigDir)
+	if err != nil {
+		return out, fmt.Errorf("post-adopt footprint snapshot: %w", err)
+	}
+	out.FootprintDrift = coexistcheck.DiffFootprints(footBefore, footAfter)
+	if len(out.FootprintDrift) > 0 {
+		fmt.Printf("WARNING: machine-level harness state changed during adoption (it must not): %s\n", strings.Join(out.FootprintDrift, ", "))
+	}
+
+	fmt.Printf("adopted: %s@%s now serves %s via repo bindings; foreign identity %s is suppressed in this repo only\n", opts.Pack, adoptVersion, opts.RepoDir, identity)
+	fmt.Println("Retreat: 'sideshow disable' removes the bindings; the suppression override in .claude/settings.local.json can then be deleted to restore the foreign channel exactly as found.")
+	fmt.Printf("Machine-level residue (install, cache, marketplace) is untouched; review it with 'sideshow adopt %s --finish'.\n", opts.Pack)
+	return out, nil
+}
+
+// Finish is the residue sweep: report every remaining foreign trace
+// and the operator commands that retire each one. Print-only — the
+// foreign channel is never modified by sideshow.
+func Finish(opts Options) error {
+	if err := opts.normalize(); err != nil {
+		return err
+	}
+	census, err := foreign.TakeCensus(opts.ConfigDir, opts.Pack)
+	if err != nil {
+		return err
+	}
+	view, err := census.ResolveRepo(opts.RepoDir)
+	if err != nil {
+		return err
+	}
+
+	if len(census.Installs) == 0 && len(view.Orphans) == 0 {
+		fmt.Printf("no foreign %s residue found under %s; nothing to finish\n", opts.Pack, opts.ConfigDir)
+		return nil
+	}
+
+	fmt.Printf("foreign %s residue (nothing below is executed by sideshow; run what you consent to):\n", opts.Pack)
+	for _, in := range census.Installs {
+		fmt.Printf("  install %s scope=%s tree=%s version=%s\n", in.Identity, in.Scope, in.InstallPath, firstNonEmpty(in.TreeVersion, in.Version, "unknown"))
+		fmt.Printf("    retire: claude plugin uninstall %s --scope %s\n", in.PluginName, in.Scope)
+		if in.InstallPath != "" {
+			fmt.Printf("    then remove the cache tree if uninstall leaves it: rm -rf %s\n", in.InstallPath)
+		}
+	}
+	for _, orphan := range view.Orphans {
+		fmt.Printf("  orphaned enable %s scope=%s in %s (no install behind it; the harness is silent about these, trial T14)\n", orphan.Identity, orphan.Scope, orphan.Path)
+		fmt.Printf("    remove the entry from that settings file by hand\n")
+	}
+	fmt.Println("  marketplace removal: only after confirming it serves no other plugin — claude plugin marketplace remove <name>")
+	fmt.Println("Re-run this command after acting; it reports until the census is clean.")
+	return nil
+}
+
+func findInstall(c *foreign.Census, identity string) *foreign.Install {
+	var fallback *foreign.Install
+	for i := range c.Installs {
+		if c.Installs[i].Identity != identity {
+			continue
+		}
+		if c.Installs[i].InstallPath != "" {
+			return &c.Installs[i]
+		}
+		if fallback == nil {
+			fallback = &c.Installs[i]
+		}
+	}
+	return fallback
+}
+
+func rollbackSuppression(repoDir, identity string, settingsCreated bool) {
+	if settingsCreated {
+		// The suppression was the file's only reason to exist.
+		if err := os.Remove(filepath.Join(repoDir, ".claude", "settings.local.json")); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: could not remove the suppression settings file: %v\n", err)
+		}
+		return
+	}
+	if _, err := foreign.UnsuppressInRepo(repoDir, identity); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not roll back the suppression override for %s: %v\n", identity, err)
+	}
+}
+
+// equivalenceReport is E1-E4 from the bead: content hash parity over
+// the discovery trees (E1), count parity (E2), a live-session note
+// for dispatcher behavior (E3), and dispatcher binary identity (E4).
+// Invocation names, addressing form, and harness plugin details are
+// declared NOT comparable across channels and are not checked.
+func equivalenceReport(row *ledger.Row, install *foreign.Install) []string {
+	var lines []string
+	cache := install.InstallPath
+	if cache == "" || !dirExists(cache) {
+		return []string{fmt.Sprintf("equivalence: foreign tree absent at %q (cache-resident installs can be pruned by the harness, trial T13); E1/E2/E4 not provable — the store artifact's cosign verification is the remaining integrity evidence", cache)}
+	}
+
+	storeHashes, storeErr := hashTrees(row.StorePath, "skills", "agents")
+	cacheHashes, cacheErr := hashTrees(cache, "skills", "agents")
+	if storeErr != nil || cacheErr != nil {
+		return []string{fmt.Sprintf("equivalence: tree walk failed (store: %v, cache: %v)", storeErr, cacheErr)}
+	}
+
+	mismatches := diffHashes(storeHashes, cacheHashes)
+	if len(mismatches) == 0 {
+		lines = append(lines, fmt.Sprintf("E1 content parity: PASS — %d files identical across store and foreign tree (unrewritten originals; the bound variant's renames are by-design divergence)", len(storeHashes)))
+	} else {
+		show := mismatches
+		if len(show) > 10 {
+			show = show[:10]
+		}
+		lines = append(lines, fmt.Sprintf("E1 content parity: FAIL — %d differing paths (first %d: %s); same-version trees should be identical — verify the store artifact before trusting the adoption", len(mismatches), len(show), strings.Join(show, ", ")))
+	}
+
+	lines = append(lines, fmt.Sprintf("E2 count parity: store=%d cache=%d discovery files", len(storeHashes), len(cacheHashes)))
+
+	lines = append(lines, "E3 dispatcher behavior: not provable headless — start a session in the repo and confirm hook events reach the dispatcher (the enable pipeline already verified the settings hook chain)")
+
+	dispatcher := filepath.Join("hooks", "dispatcher", "bin", row.Platform, dispatcherName(row.Platform))
+	storeSha, sErr := fileSha(filepath.Join(row.StorePath, dispatcher))
+	cacheSha, cErr := fileSha(filepath.Join(cache, dispatcher))
+	switch {
+	case sErr != nil || cErr != nil:
+		lines = append(lines, fmt.Sprintf("E4 dispatcher identity: not provable (store: %v, cache: %v)", sErr, cErr))
+	case storeSha == cacheSha:
+		lines = append(lines, "E4 dispatcher identity: PASS — byte-identical binary for "+row.Platform)
+	default:
+		lines = append(lines, fmt.Sprintf("E4 dispatcher identity: FAIL — store %s vs cache %s for %s", storeSha[:12], cacheSha[:12], row.Platform))
+	}
+	return lines
+}
+
+func dispatcherName(platform string) string {
+	if strings.HasPrefix(platform, "windows") {
+		return "factory-dispatcher.exe"
+	}
+	return "factory-dispatcher"
+}
+
+// hashTrees maps <subdir>/<relpath> -> sha256 for regular files under
+// the named subdirs of root. A missing subdir contributes nothing.
+func hashTrees(root string, subdirs ...string) (map[string]string, error) {
+	out := map[string]string{}
+	for _, sub := range subdirs {
+		base := filepath.Join(root, sub)
+		if !dirExists(base) {
+			continue
+		}
+		err := filepath.WalkDir(base, func(path string, d fs.DirEntry, werr error) error {
+			if werr != nil || d.IsDir() {
+				return werr
+			}
+			sha, err := fileSha(path)
+			if err != nil {
+				return err
+			}
+			rel, err := filepath.Rel(root, path)
+			if err != nil {
+				return err
+			}
+			out[filepath.ToSlash(rel)] = sha
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
+}
+
+func diffHashes(a, b map[string]string) []string {
+	var out []string
+	for k, v := range a {
+		if b[k] != v {
+			out = append(out, k)
+		}
+	}
+	for k := range b {
+		if _, ok := a[k]; !ok {
+			out = append(out, k)
+		}
+	}
+	return out
+}
+
+func fileSha(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%x", sha256.Sum256(data)), nil
+}
+
+func dirExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// readAgentKey reads the default-agent key from the repo's settings
+// chain, local over project (the same precedence the harness applies).
+func readAgentKey(repoDir string) string {
+	for _, name := range []string{"settings.local.json", "settings.json"} {
+		data, err := os.ReadFile(filepath.Join(repoDir, ".claude", name))
+		if err != nil {
+			continue
+		}
+		var m struct {
+			Agent string `json:"agent"`
+		}
+		if json.Unmarshal(data, &m) == nil && m.Agent != "" {
+			return m.Agent
+		}
+	}
+	return ""
+}
+
+// writeAgentKey sets the agent key in settings.local.json,
+// read-merge-write, preserving siblings.
+func writeAgentKey(repoDir, agent string) error {
+	path := filepath.Join(repoDir, ".claude", "settings.local.json")
+	settings := map[string]any{}
+	if data, err := os.ReadFile(path); err == nil {
+		if err := json.Unmarshal(data, &settings); err != nil {
+			return fmt.Errorf("parse settings %s (refusing to merge into a file that cannot round-trip): %w", path, err)
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("read settings %s: %w", path, err)
+	}
+	settings["agent"] = agent
+	data, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal settings: %w", err)
+	}
+	if err := os.WriteFile(path, append(data, '\n'), 0o644); err != nil {
+		return fmt.Errorf("write settings %s: %w", path, err)
+	}
+	return nil
+}

--- a/internal/adopt/adopt_test.go
+++ b/internal/adopt/adopt_test.go
@@ -1,0 +1,298 @@
+package adopt
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ArcavenAE/sideshow/internal/ledger"
+)
+
+func platform(t *testing.T) string {
+	t.Helper()
+	m := map[string]string{
+		"darwin/arm64": "darwin-arm64", "darwin/amd64": "darwin-x64",
+		"linux/arm64": "linux-arm64", "linux/amd64": "linux-x64",
+		"windows/amd64": "windows-x64",
+	}
+	p, ok := m[runtime.GOOS+"/"+runtime.GOARCH]
+	if !ok {
+		t.Skipf("no canonical platform tuple for %s/%s", runtime.GOOS, runtime.GOARCH)
+	}
+	return p
+}
+
+func mustWrite(t *testing.T, root, rel, content string, mode os.FileMode) {
+	t.Helper()
+	p := filepath.Join(root, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(content), mode); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// writeTree lays down the plugin-shaped content used for BOTH the
+// sideshow store and the foreign cache tree, so E1/E4 compare
+// byte-identical trees.
+func writeTree(t *testing.T, root, plat string) {
+	t.Helper()
+	mustWrite(t, root, ".claude-plugin/plugin.json", `{"name": "vsdd-factory", "version": "1.0.0-rc.23"}`, 0o644)
+	mustWrite(t, root, "skills/jira/SKILL.md", "---\nname: jira\n---\n\nRun /vsdd-factory:github-ops.\n", 0o644)
+	mustWrite(t, root, "agents/github-ops.md", "---\nname: github-ops\n---\n\nbody\n", 0o644)
+	mustWrite(t, root, "hooks/dispatcher/bin/"+plat+"/factory-dispatcher", "#!/bin/sh\nexit 0\n", 0o755)
+
+	tmpl := map[string]any{"hooks": map[string]any{}}
+	hooks := tmpl["hooks"].(map[string]any)
+	for _, ev := range []string{"PreToolUse", "SessionStart", "SessionEnd", "Stop"} {
+		h := map[string]any{
+			"type":    "command",
+			"command": "${CLAUDE_PLUGIN_ROOT}/hooks/dispatcher/bin/" + plat + "/factory-dispatcher",
+			"timeout": 10000,
+		}
+		if ev == "SessionStart" || ev == "SessionEnd" {
+			h["once"] = true
+		}
+		hooks[ev] = []any{map[string]any{"hooks": []any{h}}}
+	}
+	data, err := json.MarshalIndent(tmpl, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, root, "hooks/hooks.json."+plat, string(data), 0o644)
+}
+
+// fixture stands up the full adoption scene: a store, a foreign cache
+// tree with an install record, and a repo where the foreign identity
+// is enabled at the given scope ("project" writes the repo's
+// settings.json; "user" writes the config dir's settings.json).
+func fixture(t *testing.T, enableScope string) (opts Options, repo, cache string) {
+	t.Helper()
+	plat := platform(t)
+
+	store := filepath.Join(t.TempDir(), "1.0.0-rc.23")
+	writeTree(t, store, plat)
+	cache = filepath.Join(t.TempDir(), "cache", "vsdd-factory")
+	writeTree(t, cache, plat)
+
+	configDir := t.TempDir()
+	reg := fmt.Sprintf(`{"version": 2, "plugins": {"vsdd-factory@claude-mp": [
+	  {"scope": %q, "installPath": %q, "version": "1.0.0-rc.23", "gitCommitSha": "abc123"}
+	]}}`, enableScope, cache)
+	mustWrite(t, configDir, "plugins/installed_plugins.json", reg, 0o644)
+
+	repo = t.TempDir()
+	enableJSON := `{"enabledPlugins": {"vsdd-factory@claude-mp": true}}`
+	switch enableScope {
+	case "user":
+		mustWrite(t, configDir, "settings.json", enableJSON, 0o644)
+	default:
+		mustWrite(t, repo, ".claude/settings.json", enableJSON, 0o644)
+	}
+
+	opts = Options{
+		RepoDir: repo, Pack: "vsdd-factory",
+		LedgerPath: filepath.Join(t.TempDir(), "repo-bindings.yaml"),
+		ConfigDir:  configDir,
+		StoreRoot:  store, Prefix: "vsdd",
+		BoundDir: filepath.Join(t.TempDir(), "bound"),
+		Now:      time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC),
+	}
+	return opts, repo, cache
+}
+
+func readLocalSettings(t *testing.T, repo string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(repo, ".claude", "settings.local.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatal(err)
+	}
+	return m
+}
+
+func TestAdopt_EndToEnd(t *testing.T) {
+	opts, repo, _ := fixture(t, "project")
+	// A foreign-form default agent, to exercise the consented flip.
+	mustWrite(t, repo, ".claude/settings.local.json", `{"agent": "vsdd-factory:orchestrator:orchestrator"}`, 0o644)
+	opts.RewriteAgent = true
+
+	out, err := Adopt(opts)
+	if err != nil {
+		t.Fatalf("Adopt: %v", err)
+	}
+	if !out.Suppressed || out.Identity != "vsdd-factory@claude-mp" {
+		t.Errorf("outcome = %+v, want suppression of vsdd-factory@claude-mp", out)
+	}
+	if !out.AgentRewritten {
+		t.Error("agent not rewritten despite consent flag")
+	}
+	if len(out.FootprintDrift) != 0 {
+		t.Errorf("machine-level harness state changed: %v", out.FootprintDrift)
+	}
+
+	joined := strings.Join(out.Equivalence, "\n")
+	for _, want := range []string{"E1 content parity: PASS", "E4 dispatcher identity: PASS"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("equivalence report missing %q:\n%s", want, joined)
+		}
+	}
+
+	local := readLocalSettings(t, repo)
+	enables, _ := local["enabledPlugins"].(map[string]any)
+	if v, ok := enables["vsdd-factory@claude-mp"].(bool); !ok || v {
+		t.Errorf("suppression override missing or true: %v", local)
+	}
+	if agent, _ := local["agent"].(string); agent != "vsdd-orchestrator" {
+		t.Errorf("agent = %q, want vsdd-orchestrator", agent)
+	}
+
+	led, err := ledger.Load(opts.LedgerPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	row := led.RepoRow(repo, "vsdd-factory")
+	if row == nil || row.Version != "1.0.0-rc.23" {
+		t.Fatalf("ledger row = %+v, want version 1.0.0-rc.23", row)
+	}
+
+	// Finish is print-only; it must not error against real residue.
+	if err := Finish(opts); err != nil {
+		t.Errorf("Finish: %v", err)
+	}
+}
+
+func TestAdopt_NothingToAdopt(t *testing.T) {
+	opts, _, _ := fixture(t, "project")
+	// Remove the enable: install record exists, but nothing dispatches.
+	if err := os.Remove(filepath.Join(opts.RepoDir, ".claude", "settings.json")); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Adopt(opts)
+	if err == nil || !strings.Contains(err.Error(), "nothing to adopt") {
+		t.Fatalf("Adopt = %v, want nothing-to-adopt refusal", err)
+	}
+}
+
+func TestAdopt_UserScopeEnableRefuses(t *testing.T) {
+	opts, repo, _ := fixture(t, "user")
+	before := snapshotDir(t, repo)
+	_, err := Adopt(opts)
+	if err == nil || !strings.Contains(err.Error(), "USER scope") {
+		t.Fatalf("Adopt = %v, want user-scope refusal", err)
+	}
+	if diff := diffSnapshots(before, snapshotDir(t, repo)); len(diff) != 0 {
+		t.Errorf("refusal wrote into the repo: %v", diff)
+	}
+}
+
+func TestAdopt_VersionDriftRefuses(t *testing.T) {
+	opts, _, _ := fixture(t, "project")
+	opts.Version = "2.0.0"
+	_, err := Adopt(opts)
+	if err == nil || !strings.Contains(err.Error(), "--allow-version-change") {
+		t.Fatalf("Adopt = %v, want version-drift refusal", err)
+	}
+}
+
+func TestAdopt_OrphanedEnableRefuses(t *testing.T) {
+	opts, _, _ := fixture(t, "project")
+	// Drop the install registry: the enable survives with no record.
+	if err := os.Remove(filepath.Join(opts.ConfigDir, "plugins", "installed_plugins.json")); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Adopt(opts)
+	if err == nil || !strings.Contains(err.Error(), "orphaned") {
+		t.Fatalf("Adopt = %v, want orphaned-enable refusal", err)
+	}
+}
+
+func TestAdopt_DryRunWritesNothing(t *testing.T) {
+	opts, repo, _ := fixture(t, "project")
+	opts.DryRun = true
+	before := snapshotDir(t, repo)
+
+	out, err := Adopt(opts)
+	if err != nil {
+		t.Fatalf("Adopt dry run: %v", err)
+	}
+	if out.Suppressed {
+		t.Error("dry run reported suppression")
+	}
+	if diff := diffSnapshots(before, snapshotDir(t, repo)); len(diff) != 0 {
+		t.Errorf("dry run wrote into the repo: %v", diff)
+	}
+	if _, err := os.Stat(opts.LedgerPath); !os.IsNotExist(err) {
+		t.Errorf("dry run created a ledger: %v", err)
+	}
+}
+
+func TestAdopt_RollsBackSuppressionOnEnableFailure(t *testing.T) {
+	opts, repo, _ := fixture(t, "project")
+	// Break the store so enable fails after suppression is written.
+	if err := os.RemoveAll(filepath.Join(opts.StoreRoot, "hooks")); err != nil {
+		t.Fatal(err)
+	}
+	before := snapshotDir(t, repo)
+
+	_, err := Adopt(opts)
+	if err == nil || !strings.Contains(err.Error(), "suppression rolled back") {
+		t.Fatalf("Adopt = %v, want enable failure with rollback", err)
+	}
+	if diff := diffSnapshots(before, snapshotDir(t, repo)); len(diff) != 0 {
+		t.Errorf("repo not restored after rollback: %v", diff)
+	}
+}
+
+func snapshotDir(t *testing.T, dir string) map[string]string {
+	t.Helper()
+	snap := map[string]string{}
+	err := filepath.WalkDir(dir, func(path string, d os.DirEntry, werr error) error {
+		if werr != nil {
+			return werr
+		}
+		rel, err := filepath.Rel(dir, path)
+		if err != nil || rel == "." {
+			return err
+		}
+		if d.IsDir() {
+			snap[rel] = "dir"
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		snap[rel] = fmt.Sprintf("%x", sha256.Sum256(data))
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return snap
+}
+
+func diffSnapshots(a, b map[string]string) []string {
+	var out []string
+	for k, v := range a {
+		if b[k] != v {
+			out = append(out, k)
+		}
+	}
+	for k := range b {
+		if _, ok := a[k]; !ok {
+			out = append(out, k)
+		}
+	}
+	return out
+}

--- a/internal/foreign/census.go
+++ b/internal/foreign/census.go
@@ -210,6 +210,15 @@ func TakeCensus(configDir, pack string) (*Census, error) {
 	return c, nil
 }
 
+// UserEnabled reports whether the identity carries a user-scope
+// (machine-wide) enable set to true. Callers use it to refuse flows
+// that would leave a per-repo-required pack activating everywhere
+// (the containment mandate; Diagnose grades the same state ERROR).
+func (c *Census) UserEnabled(identity string) bool {
+	e, ok := c.userEnables[identity]
+	return ok && e.value
+}
+
 // RepoView resolves the census against one repo's settings scopes.
 type RepoView struct {
 	RepoDir string

--- a/internal/foreign/suppress.go
+++ b/internal/foreign/suppress.go
@@ -1,0 +1,117 @@
+package foreign
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// SuppressInRepo and UnsuppressInRepo are the ONE consented write in
+// this otherwise read-only package: they set (or remove) a repo-side
+// enabledPlugins override in the CONSUMER repo's
+// .claude/settings.local.json. This is exactly option 2 of the
+// refusal menu (RefusalOptions) and the T10 trial mechanism: a
+// project/local false beats a user-scope true, so the foreign
+// identity stops dispatching in THIS repo only. Nothing here touches
+// harness state, the foreign install, its cache, or any other repo —
+// paqn clause (d) holds: sideshow never auto-disables or
+// auto-uninstalls a foreign install; these run only inside explicit,
+// consented verbs (adopt).
+
+// SuppressInRepo writes enabledPlugins[identity] = false into the
+// repo's settings.local.json, preserving every other key. Reports
+// whether the file was created.
+func SuppressInRepo(repoDir, identity string) (created bool, err error) {
+	path := localSettingsPath(repoDir)
+	settings, existed, err := readSettingsObject(path)
+	if err != nil {
+		return false, err
+	}
+	enables, err := enabledPluginsObject(settings, path)
+	if err != nil {
+		return false, err
+	}
+	enables[identity] = false
+	settings["enabledPlugins"] = enables
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return false, fmt.Errorf("create settings dir: %w", err)
+	}
+	return !existed, writeSettingsObject(path, settings)
+}
+
+// UnsuppressInRepo removes the identity's override only when it is
+// the suppression this package writes (false); a true value is the
+// user's own choice and is left alone. Prunes an emptied
+// enabledPlugins object.
+func UnsuppressInRepo(repoDir, identity string) (removed bool, err error) {
+	path := localSettingsPath(repoDir)
+	settings, existed, err := readSettingsObject(path)
+	if err != nil {
+		return false, err
+	}
+	if !existed {
+		return false, nil
+	}
+	enables, err := enabledPluginsObject(settings, path)
+	if err != nil {
+		return false, err
+	}
+	v, ok := enables[identity]
+	b, isBool := v.(bool)
+	if !ok || !isBool || b {
+		return false, nil
+	}
+	delete(enables, identity)
+	if len(enables) == 0 {
+		delete(settings, "enabledPlugins")
+	} else {
+		settings["enabledPlugins"] = enables
+	}
+	return true, writeSettingsObject(path, settings)
+}
+
+func localSettingsPath(repoDir string) string {
+	return filepath.Join(repoDir, ".claude", "settings.local.json")
+}
+
+func readSettingsObject(path string) (map[string]any, bool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return map[string]any{}, false, nil
+		}
+		return nil, false, fmt.Errorf("read settings %s: %w", path, err)
+	}
+	var settings map[string]any
+	if err := json.Unmarshal(data, &settings); err != nil {
+		return nil, false, fmt.Errorf("parse settings %s (refusing to merge into a file that cannot round-trip): %w", path, err)
+	}
+	if settings == nil {
+		settings = map[string]any{}
+	}
+	return settings, true, nil
+}
+
+func enabledPluginsObject(settings map[string]any, path string) (map[string]any, error) {
+	raw, ok := settings["enabledPlugins"]
+	if !ok {
+		return map[string]any{}, nil
+	}
+	obj, ok := raw.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("settings %s: enabledPlugins is not an object; refusing to merge", path)
+	}
+	return obj, nil
+}
+
+func writeSettingsObject(path string, settings map[string]any) error {
+	data, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal settings: %w", err)
+	}
+	if err := os.WriteFile(path, append(data, '\n'), 0o644); err != nil {
+		return fmt.Errorf("write settings %s: %w", path, err)
+	}
+	return nil
+}

--- a/internal/foreign/suppress_test.go
+++ b/internal/foreign/suppress_test.go
@@ -1,0 +1,123 @@
+package foreign
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSuppressUnsuppress_RoundTrip(t *testing.T) {
+	t.Parallel()
+	repo := t.TempDir()
+	path := filepath.Join(repo, ".claude", "settings.local.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(`{"env": {"KEPT": "yes"}, "enabledPlugins": {"other@mp": true}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	created, err := SuppressInRepo(repo, "vsdd-factory@claude-mp")
+	if err != nil {
+		t.Fatalf("SuppressInRepo: %v", err)
+	}
+	if created {
+		t.Error("created=true on a pre-existing file")
+	}
+	settings, _, err := readSettingsObject(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	enables := settings["enabledPlugins"].(map[string]any)
+	if v, ok := enables["vsdd-factory@claude-mp"].(bool); !ok || v {
+		t.Errorf("suppression missing or true: %v", enables)
+	}
+	if enables["other@mp"] != true {
+		t.Errorf("sibling enable disturbed: %v", enables)
+	}
+	env := settings["env"].(map[string]any)
+	if env["KEPT"] != "yes" {
+		t.Errorf("sibling key disturbed: %v", settings)
+	}
+
+	removed, err := UnsuppressInRepo(repo, "vsdd-factory@claude-mp")
+	if err != nil || !removed {
+		t.Fatalf("UnsuppressInRepo = %v, %v", removed, err)
+	}
+	settings, _, err = readSettingsObject(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	enables = settings["enabledPlugins"].(map[string]any)
+	if _, ok := enables["vsdd-factory@claude-mp"]; ok {
+		t.Errorf("suppression survived unsuppress: %v", enables)
+	}
+	if enables["other@mp"] != true {
+		t.Errorf("sibling enable lost: %v", enables)
+	}
+}
+
+func TestSuppress_CreatesFileAndUnsuppressPrunes(t *testing.T) {
+	t.Parallel()
+	repo := t.TempDir()
+
+	created, err := SuppressInRepo(repo, "vsdd-factory@claude-mp")
+	if err != nil || !created {
+		t.Fatalf("SuppressInRepo = created %v, %v; want created on a fresh repo", created, err)
+	}
+
+	removed, err := UnsuppressInRepo(repo, "vsdd-factory@claude-mp")
+	if err != nil || !removed {
+		t.Fatalf("UnsuppressInRepo = %v, %v", removed, err)
+	}
+	data, err := os.ReadFile(filepath.Join(repo, ".claude", "settings.local.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := m["enabledPlugins"]; ok {
+		t.Errorf("emptied enabledPlugins object not pruned: %s", data)
+	}
+}
+
+func TestUnsuppress_LeavesUserTrueAlone(t *testing.T) {
+	t.Parallel()
+	repo := t.TempDir()
+	path := filepath.Join(repo, ".claude", "settings.local.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(`{"enabledPlugins": {"vsdd-factory@claude-mp": true}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	removed, err := UnsuppressInRepo(repo, "vsdd-factory@claude-mp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if removed {
+		t.Error("removed a true entry; that is the user's own choice")
+	}
+}
+
+func TestSuppress_RefusesMalformedSettings(t *testing.T) {
+	t.Parallel()
+	repo := t.TempDir()
+	path := filepath.Join(repo, ".claude", "settings.local.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(`{broken`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := SuppressInRepo(repo, "vsdd-factory@claude-mp")
+	if err == nil || !strings.Contains(err.Error(), "round-trip") {
+		t.Fatalf("SuppressInRepo = %v, want fail-closed parse refusal", err)
+	}
+}


### PR DESCRIPTION
Closes the last verb of the unshaping spine (aae-orc-d3nq.22): a repo already running vsdd-factory through the foreign (claude-mp) channel can now convert to repo bindings in one reversible step, with the foreign install left untouched and equivalence proven rather than assumed.

## What adopt does

1. Census + refusals: nothing dispatching, same-repo double-dispatch, orphaned enables (T14), version drift without `--allow-version-change`, user-scope enables (containment mandate; migrating machine posture stays the operator's act, with instructions).
2. Suppress the foreign identity in THIS repo only (repo-side `settings.local.json` override, trial T10) before enable, so the coexistence preflight sees one dispatch chain.
3. `enable` at the version the foreign tree actually runs (`plugin.json` is the authority, T13). Enable failure rolls the suppression back to the byte.
4. Consented persona flip (`--rewrite-agent`) from the foreign-form agent key to the bound orchestrator.
5. Honest equivalence report: E1 content parity over unrewritten trees, E2 counts, E4 dispatcher byte identity; E3 declared a live-session check. Invocation names and addressing form are by-design divergence, not compared.
6. A machine-footprint before/after diff proves adopt wrote no harness state.

`adopt --finish` is the print-only residue report: every remaining foreign trace plus the operator command that retires it. Sideshow executes none of them.

## Policy

The suppression writer lives in `internal/foreign` — the policy test's one exempt prefix — as that package's single consented write; everything else in the package stays read-only. `TestPolicy_NoPluginDeliveryVerbsInShippedSource` still passes.

Additive only: no existing verb changes behavior. 7 new tests (end-to-end with byte-level rollback assertion, dry-run write-nothing, four refusal paths) plus 4 suppression round-trip tests.