### PR TITLE
fix(coexist,adopt): rc23 smoke-test defects, plus operator docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,40 @@ Full walkthrough with signed-release verification and a roster test:
 [`examples/bmad/`](examples/bmad/README.md). How pack content finds its
 paths (rewriting vs shim vs fallback): [`docs/path-resolution.md`](docs/path-resolution.md).
 
+## Plugin-shaped packs (repo bindings)
+
+Packs that upstream ships as a claude plugin (vsdd-factory) install
+into the same store but activate per repo, never machine-wide:
+
+```bash
+# Activate in one repo: skills/agents materialize prefixed under
+# .claude/, hook chain and env shim register in the settings chain,
+# a ledger row records everything written
+cd ~/work/myrepo && sideshow enable vsdd-factory@1.0.0-rc.23
+
+# Read-only preflight / posture checks
+sideshow coexist-check vsdd-factory     # ten-check enable/adopt preflight
+sideshow coexist vsdd-factory           # foreign-install census + findings
+
+# Consented persona flip (enable never touches your default agent)
+sideshow activate vsdd-factory          # default agent -> vsdd-orchestrator
+sideshow deactivate vsdd-factory        # remove the flip only
+
+# Exact reversal: replays the enable record in reverse, byte-exact
+sideshow disable vsdd-factory
+
+# Convert a repo already on the claude plugin channel (reversible,
+# dry-runnable; the plugin install itself is never touched)
+sideshow adopt vsdd-factory --dry-run
+sideshow adopt vsdd-factory
+sideshow adopt vsdd-factory --finish    # print-only residue report
+```
+
+Runbook: [`docs/repo-bindings-enablement.md`](docs/repo-bindings-enablement.md).
+Why this channel exists and what it deliberately does differently:
+[`docs/unshaping-spec.md`](docs/unshaping-spec.md),
+[`docs/divergence-register.md`](docs/divergence-register.md).
+
 ## Project status
 
 ### Done
@@ -208,6 +242,10 @@ paths (rewriting vs shim vs fallback): [`docs/path-resolution.md`](docs/path-res
 - Command/skill sync with path rewriting + read-only fallback footer
 - Claude Code permission management
 - Init command — config shim satisfies BMAD's init gate
+- Repo-bindings channel for plugin-shaped packs — per-repo
+  enable/disable (exact ledger replay), coexistence census + ten-check
+  preflight, consented persona flip, adopt from the claude-mp channel
+  with equivalence reporting
 
 ### To do
 

--- a/cmd/sideshow/coexist_check.go
+++ b/cmd/sideshow/coexist_check.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/ArcavenAE/sideshow/internal/bindings"
@@ -56,7 +57,12 @@ func runCoexistCheck(args []string) error {
 				opts.PerRepoRequired = act.PerRepoRequired
 			}
 		}
+		// Resolve through the `current` symlink so check 6 compares
+		// version dirs, not the symlink's basename.
 		opts.StoreRoot = p.Path
+		if resolved, rErr := filepath.EvalSymlinks(p.Path); rErr == nil {
+			opts.StoreRoot = resolved
+		}
 		if inv, invErr := bindings.DiscoverPluginLayout(*p); invErr == nil {
 			opts.Inventory = inv
 		}

--- a/docs/repo-bindings-enablement.md
+++ b/docs/repo-bindings-enablement.md
@@ -31,11 +31,32 @@ before your first enable.
 
 ## 1. Obtain and verify
 
-Install the pack into the store from a signed release (unchanged from
-the standard sideshow flow):
+Signed releases are published by
+[sideshow-packs](https://github.com/ArcavenAE/sideshow-packs) — built
+in CI from the pinned upstream source, cosign-signed,
+Sigstore-attested. Direct fetch-and-verify by `sideshow install` is
+not yet shipped (aae-orc-wk92); until then, download and verify by
+hand, then install from the extracted tree:
 
 ```sh
-sideshow install vsdd-factory --from <path-or-release>
+mkdir -p /tmp/vsdd-install && cd /tmp/vsdd-install
+gh release download vsdd-factory-v1.0.0-rc.23 -R ArcavenAE/sideshow-packs \
+  -p 'vsdd-factory-1.0.0-rc.23-arcaven.tar.gz*' -p 'install.meta.json'
+
+# Integrity: tarball sha256 must match the provenance manifest
+shasum -a 256 -c <(python3 -c \
+  "import json; m=json.load(open('install.meta.json')); \
+   print(m['artifact']['tarball_sha256'], ' vsdd-factory-1.0.0-rc.23-arcaven.tar.gz')")
+
+# Authenticity: cosign keyless verification against the CI identity
+cosign verify-blob \
+  --bundle vsdd-factory-1.0.0-rc.23-arcaven.tar.gz.bundle \
+  --certificate-identity-regexp 'github.com/ArcavenAE/sideshow-packs' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  vsdd-factory-1.0.0-rc.23-arcaven.tar.gz     # expect: Verified OK
+
+tar -xzf vsdd-factory-1.0.0-rc.23-arcaven.tar.gz
+sideshow install vsdd-factory --from /tmp/vsdd-install/vsdd-factory-1.0.0-rc.23
 ```
 
 Install verifies the file manifest and the executable census
@@ -144,6 +165,66 @@ enable is refused):
    exactly (the preflight records a retreat anchor — the
    `factory-artifacts` tip and `.factory` status — so you can prove
    the trial changed nothing it should not have).
+
+## 7. Activate and deactivate (the persona flip)
+
+Enable never touches your default agent (no-hijack-on-enable, kept
+from upstream). Making the pack's orchestrator drive plain sessions
+is a separate, explicit act:
+
+```sh
+sideshow activate vsdd-factory                # default agent -> vsdd-orchestrator
+sideshow activate vsdd-factory --agent vsdd-<name>   # a different bound agent
+sideshow deactivate vsdd-factory              # remove the flip only
+```
+
+Activate requires an enabled repo and refuses to overwrite an agent
+key it does not own; deactivate removes the key only when it carries
+the pack's `vsdd-` prefix and refuses a foreign persona. Bindings are
+unaffected either way — `sideshow disable` is the verb that removes
+those.
+
+## 8. Adopting a repo from the claude-mp channel
+
+If a repo already runs vsdd-factory through the claude plugin
+channel, `adopt` converts it in one reversible step:
+
+```sh
+cd /path/to/adopting/repo
+sideshow adopt vsdd-factory --dry-run    # print the plan, write nothing
+sideshow adopt vsdd-factory              # convert
+```
+
+What it does, in order: refuses on hazards (nothing dispatching,
+double-dispatch, orphaned enables, user-scope enables, version
+drift); suppresses the foreign identity in THIS repo only (one
+settings override — the plugin install itself is never touched);
+enables the sideshow channel at the version the foreign tree is
+actually running; then prints an equivalence report (content parity,
+counts, dispatcher byte identity) against the foreign tree, plus a
+proof that no machine-level harness state changed.
+
+Flags: `--rewrite-agent` consents to flipping a foreign-form default
+agent (`vsdd-factory:...`) to the bound orchestrator;
+`--allow-version-change` accepts adopting at a version other than the
+running one (equivalence is only provable at version equality);
+`--repo`, `--scope`, `--override-stale-lock` as on enable.
+
+Retreat: `sideshow disable vsdd-factory` removes the bindings, and
+deleting the suppression override from `.claude/settings.local.json`
+restores the foreign channel exactly as found.
+
+**Machine-level retirement is not automated.** After adopting the
+repos you care about:
+
+```sh
+sideshow adopt vsdd-factory --finish
+```
+
+prints every remaining foreign trace (installs per scope, orphaned
+enables, the cache tree, the marketplace) with the operator command
+that retires each one. Sideshow executes none of them — uninstalling
+the plugin channel is your act, run only what you consent to.
 
 ## Divergence notice
 

--- a/internal/adopt/adopt.go
+++ b/internal/adopt/adopt.go
@@ -32,6 +32,7 @@ import (
 	"github.com/ArcavenAE/sideshow/internal/enable"
 	"github.com/ArcavenAE/sideshow/internal/foreign"
 	"github.com/ArcavenAE/sideshow/internal/ledger"
+	"github.com/ArcavenAE/sideshow/internal/pack"
 )
 
 // Options configures an adoption.
@@ -211,7 +212,12 @@ func Adopt(opts Options) (*Outcome, error) {
 	}
 	prefix := opts.Prefix
 	if prefix == "" {
+		// Resolve the binding prefix the way enable did: from the
+		// store's activation record (falling back to the pack name).
 		prefix = opts.Pack
+		if act, actErr := pack.LoadActivation(row.StorePath); actErr == nil {
+			prefix = act.Prefix(opts.Pack)
+		}
 	}
 	if opts.RewriteAgent && strings.HasPrefix(agentBefore, opts.Pack+":") {
 		bound := prefix + "-orchestrator"

--- a/internal/coexistcheck/coexistcheck.go
+++ b/internal/coexistcheck/coexistcheck.go
@@ -167,7 +167,10 @@ func Run(opts Options) (*Report, error) {
 
 	// (9) pre-existing content collision: everything materialization
 	// would write that already exists. Refuse rather than clobber.
-	if opts.Inventory != nil {
+	// Skipped for a bound repo: the existing artifacts there are the
+	// ledger's own writes, not collisions (a bound repo's integrity is
+	// check 4's job; re-enable goes through disable+enable per check 6).
+	if opts.Inventory != nil && row == nil {
 		for _, rel := range plannedPaths(opts) {
 			if _, err := os.Lstat(filepath.Join(opts.RepoDir, filepath.FromSlash(rel))); err == nil {
 				rep.add(9, "content-collision", foreign.Error,
@@ -217,7 +220,7 @@ func checkPlatformBind(rep *Report, opts Options, row *ledger.Row) {
 	if err := bindings.VerifyEnvShim(settingsPath, "CLAUDE_PLUGIN_ROOT", row.StorePath); err != nil {
 		rep.add(4, "platform-bind", foreign.Error, err.Error())
 	}
-	dispatcher := findDispatcher(row.StorePath)
+	dispatcher := findDispatcher(row.StorePath, row.Platform)
 	if dispatcher == "" {
 		rep.add(4, "platform-bind", foreign.Warn,
 			"no dispatcher binary found under the bound store path; hook commands referencing it will fail")
@@ -230,8 +233,19 @@ func checkPlatformBind(rep *Report, opts Options, row *ledger.Row) {
 }
 
 // findDispatcher locates the platform dispatcher under the store
-// tree (hooks/dispatcher/<binary> per the upstream layout).
-func findDispatcher(storeRoot string) string {
+// tree (hooks/dispatcher/bin/<platform>/factory-dispatcher per the
+// upstream layout; enable.verifyDispatcher checks the same path).
+// Falls back to a flat hooks/dispatcher/<binary> entry for packs
+// without per-platform bins.
+func findDispatcher(storeRoot, platform string) string {
+	name := "factory-dispatcher"
+	if strings.HasPrefix(platform, "windows") {
+		name += ".exe"
+	}
+	p := filepath.Join(storeRoot, "hooks", "dispatcher", "bin", platform, name)
+	if _, err := os.Stat(p); err == nil {
+		return p
+	}
 	dir := filepath.Join(storeRoot, "hooks", "dispatcher")
 	entries, err := os.ReadDir(dir)
 	if err != nil {

--- a/internal/coexistcheck/coexistcheck_test.go
+++ b/internal/coexistcheck/coexistcheck_test.go
@@ -137,6 +137,23 @@ func TestRun_ContentCollisionRefuses(t *testing.T) {
 	}
 }
 
+func TestRun_BoundRepoOwnArtifactsAreNotCollisions(t *testing.T) {
+	t.Parallel()
+	opts := baseOptions(t)
+	// The repo is bound: its ledger row exists and the materialized
+	// artifacts are the ledger's own writes, not collisions.
+	write(t, opts.RepoDir, ".claude/skills/vsdd-pr-manager/SKILL.md", "# ours\n")
+	write(t, "", opts.LedgerPath, "schema_version: \"0.1.0\"\nrepos:\n  "+opts.RepoDir+":\n    vsdd-factory:\n      version: 1.0.0-rc.23\n      store_path: /store/1.0.0-rc.23\n      settings_scope: local\n")
+
+	rep, err := Run(opts)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if sevs := severities(rep, 9); len(sevs) != 0 {
+		t.Errorf("check 9 fired on a bound repo's own artifacts: %v", sevs)
+	}
+}
+
 func TestRun_RunningFactorySignals(t *testing.T) {
 	t.Parallel()
 	opts := baseOptions(t)


### PR DESCRIPTION
A full smoke test against the freshly published sideshow-packs vsdd-factory-v1.0.0-rc.23 release (download, checksum, cosign verify, install, enable, coexist-check, activate, deactivate, adopt, disable) surfaced three defects an operator would hit on day one. All are fixed here with regression tests, and the operator docs the upcoming pilot relies on are brought current with the shipped verbs.

## Fixes

- **coexist-check screamed at its own work.** On a repo sideshow itself enabled, check 9 reported ERROR content-collisions against the ledger's own artifacts (126 of them), refusing the preflight the runbook promises is a bound-repo verification. Check 9 now runs only for unbound repos; a bound repo's integrity is check 4's job.
- **check 4 warned "no dispatcher binary" on every correctly bound repo.** findDispatcher looked at `hooks/dispatcher/<entry>`, one level above the real `hooks/dispatcher/bin/<platform>/factory-dispatcher` path (enable's verifyDispatcher already used the right one).
- **adopt --rewrite-agent wrote `vsdd-factory-orchestrator` instead of the bound `vsdd-orchestrator`.** The prefix fallback used the pack name when the CLI had not resolved the activation; Adopt now loads the binding prefix from the store activation, as enable does. Also: the coexist-check CLI resolves the store path through the `current` symlink so check 6 compares version dirs rather than warning about "current".

## Docs

- Runbook §1 gains the concrete download-and-verify commands for the published release (sideshow cannot fetch releases itself yet, aae-orc-wk92).
- New runbook §7 (activate/deactivate) and §8 (adopt, including the print-only `--finish` contract and the retreat path).
- README gains a repo-bindings quickstart block and the channel in the status list.

No behavior changes outside the two check corrections and the prefix resolution; full suite and lint green.