### PR TITLE
feat(distribute): files: artifact type for arbitrary repo-relative paths

### DIFF
--- a/cmd/sideshow/main.go
+++ b/cmd/sideshow/main.go
@@ -325,7 +325,14 @@ func runInitProject(projectRoot, manifestPath, packFilter string, dryRun bool) e
 		}
 
 		for _, repo := range repos {
-			result := distribute.ToRepo(repo, &p.manifest, opts)
+			// File artifacts have no in-file ownership marker, so the prior
+			// receipt is how distributeFile tells its own unmodified output
+			// from a file the user has since edited. Per repo, per pack.
+			repoOpts := opts
+			repoOpts.PriorChecksums = distribute.PriorChecksums(
+				reg, id.ID, projectRoot, filepath.Base(manifestPath), repo.Name, p.name)
+
+			result := distribute.ToRepo(repo, &p.manifest, repoOpts)
 			allResults = append(allResults, result)
 
 			if result.Skipped {
@@ -635,6 +642,13 @@ func runProjectInitForPack(args []string) error {
 		Present: true,
 	}
 
+	// PriorChecksums is deliberately nil here. This path operates on cwd alone
+	// and has no project installation context (no project id, no repos.yaml), so
+	// there is no receipt to read. The effect on `files:` artifacts is fail-safe
+	// but incomplete: sideshow creates a missing file and then leaves it alone on
+	// every later run, because without a receipt it cannot distinguish its own
+	// output from a user's file. Refreshing a file artifact needs the
+	// `init --scope project` path. Tracked as a follow-on to aae-orc-rx3.
 	result := distribute.ToRepo(repo, &packYAML.Distribute, distribute.Options{
 		DryRun:      dryRun,
 		PackName:    packYAML.Name,

--- a/internal/distribute/distribute.go
+++ b/internal/distribute/distribute.go
@@ -60,6 +60,14 @@ type Options struct {
 	PackName    string
 	PackVersion string
 	PackRoot    string // resolved pack root on disk
+
+	// PriorChecksums maps a repo-relative target path to the sha256 sideshow
+	// recorded the last time it wrote that path into THIS repo for THIS pack.
+	// Only `files:` artifacts consult it, because they carry no in-file
+	// ownership marker. Nil is safe and means "no prior record": every existing
+	// target is then treated as user-authored and left alone, which is the
+	// fail-safe direction.
+	PriorChecksums map[string]string
 }
 
 // ToRepo distributes artifacts from the manifest to a single subrepo.
@@ -103,6 +111,11 @@ func ToRepo(repo project.Subrepo, manifest *Manifest, opts Options) Result {
 		}
 		actions := distributeRuntimeLinks(repo.AbsPath, shimDir, manifest.RuntimeLinks, opts)
 		result.Actions = append(result.Actions, actions...)
+	}
+
+	for _, file := range manifest.Files {
+		action := distributeFile(repo.AbsPath, file, opts)
+		result.Actions = append(result.Actions, action)
 	}
 
 	for _, line := range manifest.Gitignore {
@@ -806,6 +819,145 @@ func distributeGitignore(repoRoot string, line string, opts Options) Action {
 		Line: line,
 	}
 	return action
+}
+
+// distributeFile places an arbitrary file at a repo-relative path.
+//
+// Ownership is decided by comparing the on-disk content against the checksum
+// recorded when sideshow last wrote this path (opts.PriorChecksums), because a
+// file artifact carries no in-file marker. Four cases:
+//
+//	absent                          -> write ("created")
+//	present, hash == recorded       -> sideshow's, unmodified: refresh or skip
+//	present, hash != recorded       -> user edited it: SKIP, report drift
+//	present, no record              -> not ours: SKIP, user-authored
+//
+// The third case is the one the marker model gets wrong. distributeRule
+// overwrites whenever it sees its marker, so a user edit to a managed rule file
+// is lost silently. Here an edit is detected and preserved.
+func distributeFile(repoRoot string, file FileArtifact, opts Options) Action {
+	action := Action{Type: "files", Path: file.Target}
+
+	if file.Source == "" || file.Target == "" {
+		action.Status = "error"
+		action.Detail = "file artifact needs both source and target"
+		return action
+	}
+	// A target must stay inside the repo. `..` would let a pack write anywhere
+	// on the filesystem, and unlike the typed artifacts this path is arbitrary.
+	cleaned := filepath.Clean(file.Target)
+	if filepath.IsAbs(cleaned) || cleaned == ".." || strings.HasPrefix(cleaned, ".."+string(filepath.Separator)) {
+		action.Status = "error"
+		action.Detail = "target escapes the repo root"
+		return action
+	}
+
+	sourceData, err := os.ReadFile(filepath.Join(opts.PackRoot, file.Source))
+	if err != nil {
+		action.Status = "error"
+		action.Detail = fmt.Sprintf("read source: %v", err)
+		return action
+	}
+
+	sourceSum := sha256hex(sourceData)
+	action.Artifact = pack.DistributedArtifact{
+		Type:     "files",
+		Path:     file.Target,
+		Checksum: "sha256:" + sourceSum,
+	}
+
+	targetPath := filepath.Join(repoRoot, cleaned)
+	existing, readErr := os.ReadFile(targetPath)
+	switch {
+	case readErr != nil && !os.IsNotExist(readErr):
+		action.Status = "error"
+		action.Detail = fmt.Sprintf("read target: %v", readErr)
+		return action
+
+	case readErr == nil:
+		onDisk := sha256hex(existing)
+		recorded, known := opts.PriorChecksums[file.Target]
+		switch {
+		case !known:
+			action.Status = "skipped"
+			action.Detail = "exists and sideshow has no record of writing it (user-authored)"
+			return action
+		case strings.TrimPrefix(recorded, "sha256:") != onDisk:
+			action.Status = "skipped"
+			action.Detail = "modified since sideshow wrote it (user edit preserved)"
+			return action
+		case onDisk == sourceSum:
+			action.Status = "skipped"
+			action.Detail = "already current"
+			return action
+		}
+	}
+
+	if opts.DryRun {
+		action.Status = "wrote"
+		if readErr == nil {
+			action.Detail = "would update (sideshow-managed, unmodified)"
+		} else {
+			action.Detail = "would create"
+		}
+		return action
+	}
+
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+		action.Status = "error"
+		action.Detail = fmt.Sprintf("create dir: %v", err)
+		return action
+	}
+	// Verbatim. No marker, no trailing newline fixup: the pack ships the bytes
+	// the consumer needs to parse.
+	if err := os.WriteFile(targetPath, sourceData, 0o644); err != nil {
+		action.Status = "error"
+		action.Detail = fmt.Sprintf("write: %v", err)
+		return action
+	}
+
+	action.Status = "wrote"
+	action.Detail = "created"
+	if readErr == nil {
+		action.Detail = "updated (sideshow-managed, unmodified)"
+	}
+	return action
+}
+
+// PriorChecksums returns the checksums recorded for file artifacts the last time
+// sideshow distributed packName into repoName, keyed by repo-relative path. It
+// is the read side of what RecordResults writes. An absent record yields an
+// empty map, which distributeFile treats as "own nothing".
+func PriorChecksums(reg *pack.Registry, projectID, root, manifest, repoName, packName string) map[string]string {
+	out := map[string]string{}
+	if reg == nil {
+		return out
+	}
+	proj := reg.FindProject(projectID)
+	if proj == nil {
+		return out
+	}
+	for _, inst := range proj.Installations {
+		if inst.Root != root || inst.Manifest != manifest {
+			continue
+		}
+		for _, repo := range inst.Repos {
+			if repo.Name != repoName {
+				continue
+			}
+			for _, pd := range repo.Packs {
+				if pd.Pack != packName {
+					continue
+				}
+				for _, a := range pd.Artifacts {
+					if a.Type == "files" && a.Path != "" && a.Checksum != "" {
+						out[a.Path] = a.Checksum
+					}
+				}
+			}
+		}
+	}
+	return out
 }
 
 func sha256hex(data []byte) string {

--- a/internal/distribute/files_test.go
+++ b/internal/distribute/files_test.go
@@ -1,0 +1,352 @@
+package distribute
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ArcavenAE/sideshow/internal/pack"
+	"github.com/ArcavenAE/sideshow/internal/project"
+)
+
+// editorconfig is deliberately a non-markdown format. An HTML comment marker
+// would corrupt it, which is why file artifacts are written verbatim.
+const editorconfig = "root = true\n\n[*]\nindent_style = tab\n"
+
+func filesPackRoot(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	dist := filepath.Join(root, "distribute")
+	if err := os.MkdirAll(filepath.Join(dist, "workflows"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dist, "editorconfig"), []byte(editorconfig), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dist, "workflows", "codeql.yml"),
+		[]byte("name: codeql\non: push\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+func filesRepo(t *testing.T) project.Subrepo {
+	t.Helper()
+	return project.Subrepo{Name: "testrepo", AbsPath: t.TempDir(), Present: true}
+}
+
+func sum(b []byte) string {
+	h := sha256.Sum256(b)
+	return "sha256:" + hex.EncodeToString(h[:])
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}
+
+func onlyAction(t *testing.T, result Result) Action {
+	t.Helper()
+	if len(result.Actions) != 1 {
+		t.Fatalf("expected 1 action, got %d: %+v", len(result.Actions), result.Actions)
+	}
+	return result.Actions[0]
+}
+
+func editorconfigManifest() *Manifest {
+	return &Manifest{Files: []FileArtifact{{Source: "distribute/editorconfig", Target: ".editorconfig"}}}
+}
+
+// --- creation ---
+
+// The headline requirement: the bytes on disk are the bytes the pack shipped.
+// No ownership marker, because `#` is the comment character in this format and
+// `<!-- -->` would break it.
+func TestDistributeFile_WritesVerbatimWithNoMarker(t *testing.T) {
+	t.Parallel()
+	packRoot := filesPackRoot(t)
+	repo := filesRepo(t)
+
+	action := onlyAction(t, ToRepo(repo, editorconfigManifest(), defaultOpts(packRoot)))
+	if action.Status != "wrote" {
+		t.Fatalf("status = %q (%s)", action.Status, action.Detail)
+	}
+	if action.Type != "files" {
+		t.Errorf("type = %q, want files", action.Type)
+	}
+
+	got := readFile(t, filepath.Join(repo.AbsPath, ".editorconfig"))
+	if got != editorconfig {
+		t.Errorf("content is not verbatim:\n got %q\nwant %q", got, editorconfig)
+	}
+	if strings.Contains(got, markerPrefix) || strings.Contains(got, "<!--") {
+		t.Error("an ownership marker was injected into a non-markdown file")
+	}
+	if want := sum([]byte(editorconfig)); action.Artifact.Checksum != want {
+		t.Errorf("receipt checksum = %q, want %q", action.Artifact.Checksum, want)
+	}
+}
+
+func TestDistributeFile_CreatesNestedDirectories(t *testing.T) {
+	t.Parallel()
+	packRoot := filesPackRoot(t)
+	repo := filesRepo(t)
+	m := &Manifest{Files: []FileArtifact{
+		{Source: "distribute/workflows/codeql.yml", Target: ".github/workflows/codeql.yml"},
+	}}
+
+	if action := onlyAction(t, ToRepo(repo, m, defaultOpts(packRoot))); action.Status != "wrote" {
+		t.Fatalf("status = %q (%s)", action.Status, action.Detail)
+	}
+	if got := readFile(t, filepath.Join(repo.AbsPath, ".github/workflows/codeql.yml")); got == "" {
+		t.Error("nested target was not written")
+	}
+}
+
+// --- ownership: the four cases ---
+
+func TestDistributeFile_SkipsPreexistingWithNoReceipt(t *testing.T) {
+	t.Parallel()
+	packRoot := filesPackRoot(t)
+	repo := filesRepo(t)
+	target := filepath.Join(repo.AbsPath, ".editorconfig")
+	if err := os.WriteFile(target, []byte("root = true\n# mine\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	action := onlyAction(t, ToRepo(repo, editorconfigManifest(), defaultOpts(packRoot)))
+	if action.Status != "skipped" {
+		t.Fatalf("status = %q, want skipped (%s)", action.Status, action.Detail)
+	}
+	if got := readFile(t, target); got != "root = true\n# mine\n" {
+		t.Errorf("a user-authored file was overwritten: %q", got)
+	}
+}
+
+// The case the marker model gets wrong. distributeRule overwrites whenever it
+// sees its marker, so an edit to a managed rule file is lost. Here it survives.
+func TestDistributeFile_PreservesUserEditAfterSideshowWroteIt(t *testing.T) {
+	t.Parallel()
+	packRoot := filesPackRoot(t)
+	repo := filesRepo(t)
+	target := filepath.Join(repo.AbsPath, ".editorconfig")
+
+	edited := editorconfig + "indent_size = 4\n"
+	if err := os.WriteFile(target, []byte(edited), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	opts := defaultOpts(packRoot)
+	// Receipt says we wrote the pristine version; disk says otherwise.
+	opts.PriorChecksums = map[string]string{".editorconfig": sum([]byte(editorconfig))}
+
+	action := onlyAction(t, ToRepo(repo, editorconfigManifest(), opts))
+	if action.Status != "skipped" {
+		t.Fatalf("status = %q, want skipped (%s)", action.Status, action.Detail)
+	}
+	if !strings.Contains(action.Detail, "modified") {
+		t.Errorf("detail should report drift, got %q", action.Detail)
+	}
+	if got := readFile(t, target); got != edited {
+		t.Errorf("user edit was clobbered:\n got %q\nwant %q", got, edited)
+	}
+}
+
+func TestDistributeFile_UpdatesWhenUnmodifiedAndSourceChanged(t *testing.T) {
+	t.Parallel()
+	packRoot := filesPackRoot(t)
+	repo := filesRepo(t)
+	target := filepath.Join(repo.AbsPath, ".editorconfig")
+
+	stale := "root = true\n"
+	if err := os.WriteFile(target, []byte(stale), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	opts := defaultOpts(packRoot)
+	opts.PriorChecksums = map[string]string{".editorconfig": sum([]byte(stale))}
+
+	action := onlyAction(t, ToRepo(repo, editorconfigManifest(), opts))
+	if action.Status != "wrote" {
+		t.Fatalf("status = %q, want wrote (%s)", action.Status, action.Detail)
+	}
+	if got := readFile(t, target); got != editorconfig {
+		t.Errorf("target was not refreshed: %q", got)
+	}
+}
+
+func TestDistributeFile_SkipsWhenAlreadyCurrent(t *testing.T) {
+	t.Parallel()
+	packRoot := filesPackRoot(t)
+	repo := filesRepo(t)
+	if err := os.WriteFile(filepath.Join(repo.AbsPath, ".editorconfig"), []byte(editorconfig), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	opts := defaultOpts(packRoot)
+	opts.PriorChecksums = map[string]string{".editorconfig": sum([]byte(editorconfig))}
+
+	action := onlyAction(t, ToRepo(repo, editorconfigManifest(), opts))
+	if action.Status != "skipped" || !strings.Contains(action.Detail, "current") {
+		t.Fatalf("status = %q, detail = %q; want skipped/already current", action.Status, action.Detail)
+	}
+}
+
+// Applying twice must converge. Second run feeds back the first run's receipt.
+func TestDistributeFile_IsIdempotent(t *testing.T) {
+	t.Parallel()
+	packRoot := filesPackRoot(t)
+	repo := filesRepo(t)
+
+	first := onlyAction(t, ToRepo(repo, editorconfigManifest(), defaultOpts(packRoot)))
+	opts := defaultOpts(packRoot)
+	opts.PriorChecksums = map[string]string{".editorconfig": first.Artifact.Checksum}
+
+	second := onlyAction(t, ToRepo(repo, editorconfigManifest(), opts))
+	if second.Status != "skipped" {
+		t.Errorf("second run status = %q, want skipped (%s)", second.Status, second.Detail)
+	}
+	if got := readFile(t, filepath.Join(repo.AbsPath, ".editorconfig")); got != editorconfig {
+		t.Errorf("content drifted across runs: %q", got)
+	}
+}
+
+// --- guards ---
+
+// Target is arbitrary, so unlike the typed artifacts it has to be constrained.
+func TestDistributeFile_RejectsEscapingTarget(t *testing.T) {
+	t.Parallel()
+	packRoot := filesPackRoot(t)
+	repo := filesRepo(t)
+
+	for _, target := range []string{"../escaped", "../../etc/hosts", "a/../../escaped"} {
+		m := &Manifest{Files: []FileArtifact{{Source: "distribute/editorconfig", Target: target}}}
+		action := onlyAction(t, ToRepo(repo, m, defaultOpts(packRoot)))
+		if action.Status != "error" {
+			t.Errorf("target %q: status = %q, want error", target, action.Status)
+		}
+	}
+}
+
+func TestDistributeFile_RequiresSourceAndTarget(t *testing.T) {
+	t.Parallel()
+	packRoot := filesPackRoot(t)
+	repo := filesRepo(t)
+
+	for name, f := range map[string]FileArtifact{
+		"no target": {Source: "distribute/editorconfig"},
+		"no source": {Target: ".editorconfig"},
+	} {
+		action := onlyAction(t, ToRepo(repo, &Manifest{Files: []FileArtifact{f}}, defaultOpts(packRoot)))
+		if action.Status != "error" {
+			t.Errorf("%s: status = %q, want error", name, action.Status)
+		}
+	}
+}
+
+func TestDistributeFile_ErrorsOnMissingSource(t *testing.T) {
+	t.Parallel()
+	repo := filesRepo(t)
+	m := &Manifest{Files: []FileArtifact{{Source: "distribute/absent", Target: ".editorconfig"}}}
+
+	action := onlyAction(t, ToRepo(repo, m, defaultOpts(filesPackRoot(t))))
+	if action.Status != "error" || !strings.Contains(action.Detail, "read source") {
+		t.Errorf("status = %q, detail = %q", action.Status, action.Detail)
+	}
+}
+
+func TestDistributeFile_DryRunWritesNothing(t *testing.T) {
+	t.Parallel()
+	packRoot := filesPackRoot(t)
+	repo := filesRepo(t)
+	opts := defaultOpts(packRoot)
+	opts.DryRun = true
+
+	action := onlyAction(t, ToRepo(repo, editorconfigManifest(), opts))
+	if action.Status != "wrote" || !strings.Contains(action.Detail, "would") {
+		t.Errorf("status = %q, detail = %q", action.Status, action.Detail)
+	}
+	if _, err := os.Stat(filepath.Join(repo.AbsPath, ".editorconfig")); !os.IsNotExist(err) {
+		t.Error("dry run wrote to disk")
+	}
+}
+
+// --- manifest plumbing ---
+
+func TestManifest_FilesCountsTowardIsEmpty(t *testing.T) {
+	t.Parallel()
+	m := Manifest{Files: []FileArtifact{{Source: "a", Target: "b"}}}
+	if m.IsEmpty() {
+		t.Error("a manifest with only files should not be empty")
+	}
+}
+
+func TestLoadPackYAML_ParsesFiles(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	body := `name: fleet-bootstrap
+version: 0.1.0
+distribute:
+  files:
+    - source: distribute/editorconfig
+      target: .editorconfig
+    - source: distribute/workflows/codeql.yml
+      target: .github/workflows/codeql.yml
+`
+	if err := os.WriteFile(filepath.Join(root, "pack.yaml"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	p, err := LoadPackYAML(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(p.Distribute.Files) != 2 {
+		t.Fatalf("parsed %d files, want 2", len(p.Distribute.Files))
+	}
+	if got := p.Distribute.Files[1].Target; got != ".github/workflows/codeql.yml" {
+		t.Errorf("target = %q", got)
+	}
+}
+
+// --- receipt round trip ---
+
+// PriorChecksums is the read side of RecordResults. If they disagree on shape,
+// every second run reports drift on files it wrote itself.
+func TestPriorChecksums_RoundTripsWithRecordResults(t *testing.T) {
+	t.Parallel()
+	packRoot := filesPackRoot(t)
+	repo := filesRepo(t)
+	opts := defaultOpts(packRoot)
+
+	result := ToRepo(repo, editorconfigManifest(), opts)
+	reg := &pack.Registry{}
+	RecordResults(reg, "proj-uuid", "/root", "repos.yaml", []Result{result}, opts)
+
+	got := PriorChecksums(reg, "proj-uuid", "/root", "repos.yaml", repo.Name, opts.PackName)
+	want := sum([]byte(editorconfig))
+	if got[".editorconfig"] != want {
+		t.Fatalf("round trip lost the checksum: got %q, want %q\nfull map: %+v",
+			got[".editorconfig"], want, got)
+	}
+
+	// And feeding it back must produce a skip, not a rewrite.
+	opts.PriorChecksums = got
+	if action := onlyAction(t, ToRepo(repo, editorconfigManifest(), opts)); action.Status != "skipped" {
+		t.Errorf("second run after a real receipt: status = %q (%s)", action.Status, action.Detail)
+	}
+}
+
+func TestPriorChecksums_EmptyForUnknownProject(t *testing.T) {
+	t.Parallel()
+	if got := PriorChecksums(&pack.Registry{}, "nope", "/root", "repos.yaml", "repo", "pack"); len(got) != 0 {
+		t.Errorf("expected empty map, got %+v", got)
+	}
+	if got := PriorChecksums(nil, "nope", "/root", "repos.yaml", "repo", "pack"); len(got) != 0 {
+		t.Errorf("nil registry should yield empty map, got %+v", got)
+	}
+}

--- a/internal/distribute/manifest.go
+++ b/internal/distribute/manifest.go
@@ -23,6 +23,7 @@ type Manifest struct {
 	Hooks        []HookArtifact        `yaml:"hooks,omitempty"`
 	ClaudeMD     []ClaudeMDArtifact    `yaml:"claude_md,omitempty"`
 	Symlinks     []SymlinkArtifact     `yaml:"symlinks,omitempty"`
+	Files        []FileArtifact        `yaml:"files,omitempty"`
 	Gitignore    []string              `yaml:"gitignore,omitempty"`
 	CustomBridge *CustomBridgeArtifact `yaml:"custom_bridge,omitempty"`
 	RuntimeLinks []RuntimeLink         `yaml:"runtime_links,omitempty"`
@@ -55,6 +56,27 @@ type CustomBridgeArtifact struct {
 type RuleArtifact struct {
 	Source string `yaml:"source"` // relative to pack root
 	Target string `yaml:"target"` // relative to repo root (e.g. .claude/rules/task-workflow.md)
+}
+
+// FileArtifact is an arbitrary file to place at a repo-relative path.
+//
+// This is the escape hatch for project-lifecycle scaffolding that does not fit
+// a typed artifact: .editorconfig, lefthook.yml, .golangci.yml,
+// rust-toolchain.toml, .github/workflows/*.yml. Target is any path relative to
+// the repo root; source is relative to the pack root.
+//
+// Unlike RuleArtifact, a file artifact is written VERBATIM with no ownership
+// marker prepended. Rules can carry an HTML comment because they are markdown.
+// These cannot: `#` is the comment character in YAML, TOML, INI, and
+// .editorconfig; `//` in Go and Rust; and JSON has no comment syntax at all.
+// Injecting a marker would corrupt the file for its actual consumer, and
+// prepending a line would break anything whose first line is significant.
+//
+// Ownership is therefore tracked out of band, by the sha256 recorded in the
+// distribution receipt (pack.DistributedArtifact.Checksum). See distributeFile.
+type FileArtifact struct {
+	Source string `yaml:"source"` // relative to pack root
+	Target string `yaml:"target"` // relative to repo root (e.g. .editorconfig)
 }
 
 // HookArtifact is a hook to merge into .claude/settings.json.
@@ -107,6 +129,7 @@ func (m *Manifest) IsEmpty() bool {
 		len(m.Hooks) == 0 &&
 		len(m.ClaudeMD) == 0 &&
 		len(m.Symlinks) == 0 &&
+		len(m.Files) == 0 &&
 		len(m.Gitignore) == 0 &&
 		m.CustomBridge == nil &&
 		len(m.RuntimeLinks) == 0


### PR DESCRIPTION
The fleet-bootstrap pack has been stalled since April because sideshow has no way to place `.editorconfig`, `lefthook.yml`, `.golangci.yml`, `rust-toolchain.toml`, or GHA workflow yamls into a repo. None of those fit `rules`, `hooks`, `claude_md`, `symlinks`, or `gitignore`, so only the rules and CLAUDE.md portions of that pack could ever be distributed. This adds the missing artifact type.

```yaml
distribute:
  files:
    - source: distribute/editorconfig
      target: .editorconfig
    - source: distribute/workflows/codeql.yml
      target: .github/workflows/codeql.yml
```

**Cost of merge:** additive. No existing artifact type changes behavior, and the full suite passes. 19 new tests.

## Two departures from the ticket, both forced by the formats

The ticket says "same ownership marker as rules." That does not survive contact with arbitrary files, so:

**Files are written verbatim, with no marker.** Rules can carry an HTML comment because rules are markdown. These cannot: `#` is the comment character in YAML, TOML, INI, and `.editorconfig`; `//` in Go and Rust; and JSON has no comment syntax at all. Prepending a line also breaks anything whose first line is significant. A marker here corrupts the file for the tool that has to parse it.

**Ownership is tracked by checksum instead.** `pack.DistributedArtifact.Checksum` already existed and was already being recorded on every write; nothing ever read it back. This adds the read side (`distribute.PriorChecksums`) and threads it through `Options`. Four cases:

| on disk | vs receipt | action |
|---|---|---|
| absent | n/a | write |
| present | matches | refresh if source changed, else `already current` |
| present | differs | **skip**, report drift |
| present | no receipt | skip, user-authored |

That third row is behavior `rules` does not have. `distributeRule` overwrites whenever it sees its marker, so a user edit to a managed rule file is lost silently. The ticket asked for "skip if user-edited, drift detected," which is what file artifacts now do. I left `rules` alone; changing its contract is a separate decision, not something to slip into this PR.

One guard added because `target` is arbitrary in a way the typed artifacts are not: a target containing `..`, or an absolute path, is rejected rather than allowed to write outside the repo.

## Verified end to end, not only by unit test

Built the binary and ran `init --scope project` against a throwaway orchestrator in an isolated `SIDESHOW_HOME`:

- dry run wrote nothing to disk
- apply created all three targets, including a nested `.github/workflows/` path
- all three `diff` clean against the pack source, and no marker present in any of them
- re-apply reported `already current` for all three
- a hand edit to `.editorconfig` survived re-apply with its comment intact, reported as `modified since sideshow wrote it (user edit preserved)`
- changing the pack's copy refreshed the unmodified target

Also confirmed the real `~/.claude/settings.json` was untouched. I used `--no-permissions` out of caution, which turned out to be unnecessary: `install` now detects `SIDESHOW_HOME` and prints `SIDESHOW_HOME is set; skipping Claude Code permission configuration`. An earlier version of this description said that leak was still live; it is fixed.

## Known gap, documented at the call site

`sideshow project init <pack>` operates on cwd with no project installation context, so there is no receipt to read. `PriorChecksums` is nil there. That is fail-safe but incomplete: a file artifact is created once and then left alone forever, because without a receipt sideshow cannot distinguish its own output from a user's file. Refreshing a file artifact needs the `init --scope project` path. I have written this as a comment where it happens rather than leaving it to be rediscovered, and it is a follow-on to `aae-orc-rx3`.

Refs: `aae-orc-rx3`. Unblocks `aae-orc-0jl`.

