### PR TITLE
fix(adopt,docs): first fixes from the .23 pilot report

### DIFF
--- a/cmd/sideshow/main.go
+++ b/cmd/sideshow/main.go
@@ -42,7 +42,7 @@ Usage:
   sideshow status                         Show installation status
   sideshow coexist <pack> [--repo <path>]  Read-only foreign-install census and coexistence findings
   sideshow enable <pack>[@<ver>] [--repo <path>] [--scope local|project]  Activate a pack in one repo (repo-bindings)
-  sideshow disable <pack> [--repo <path>]  Reverse an enable exactly (ledger replay)
+  sideshow disable <pack> [--repo <path>] [--override-stale-lock]  Reverse an enable exactly (ledger replay)
   sideshow activate <pack> [--repo <path>] [--agent <name>]  Consented persona flip (repo default agent)
   sideshow deactivate <pack> [--repo <path>]  Remove the persona flip only (prefix-guarded)
   sideshow coexist-check <pack> [--repo <path>]  Read-only enable/adopt preflight (ten checks)

--- a/docs/divergence-register.md
+++ b/docs/divergence-register.md
@@ -99,6 +99,13 @@ executed for a claude-mp consumer. Their first observed outcome is a
 trial before it is a claim; record the outcome here, and verify the
 :1311 blocker does not break tool use.
 
+**Outcome recorded (2026-08-01, .23 pilot, aae-orc#128):** live on a
+consumer machine. `protect-secrets` blocked a real `.env` Read in a
+headless session; the block reached the model as a `tool_result`
+error and was logged by the pack's own audit trail, and tool use
+otherwise continued. Verified-firing set grows to SessionStart,
+SessionEnd, PreToolUse (blocking), PostToolUse, Stop, SubagentStop.
+
 ## 10. Standing per-release census-diff cost
 
 Every upstream release must be census-diffed against the unshape
@@ -106,3 +113,16 @@ declaration (deny-by-default: a new top-level unit fails the build
 until dispositioned) before a pack is cut (aae-orc-d3nq.59). This is
 recurring maintainer work the plugin channel does not have, priced
 here so release planning counts it.
+
+## 11. Headless NDJSON surfaces hook lifecycle frames for SessionStart only
+
+Observed on the .23 pilot (aae-orc#128): in headless forestage
+NDJSON sessions, `hook_started`/`hook_response` frames appear only
+for SessionStart. The other events execute (dispatcher logs and an
+honored blocking PreToolUse prove it) but emit no lifecycle frames; a
+block is visible only as a `tool_result` error. This looks like
+harness stream behavior rather than a sideshow defect (investigation
+filed on forestage), but it is priced here because anything that
+plans to OBSERVE hook activity on this channel by parsing NDJSON will
+under-report. Use the dispatcher's own logs under `.factory/logs/`
+for ground truth.

--- a/docs/repo-bindings-enablement.md
+++ b/docs/repo-bindings-enablement.md
@@ -36,7 +36,11 @@ Signed releases are published by
 in CI from the pinned upstream source, cosign-signed,
 Sigstore-attested. Direct fetch-and-verify by `sideshow install` is
 not yet shipped (aae-orc-wk92); until then, download and verify by
-hand, then install from the extracted tree:
+hand, then install from the extracted tree.
+
+Prerequisites for this section: `gh` (release download), `cosign`
+(signature verification), `python3` (checksum extraction from the
+provenance manifest). On macOS: `brew install gh cosign`.
 
 ```sh
 mkdir -p /tmp/vsdd-install && cd /tmp/vsdd-install
@@ -136,6 +140,20 @@ deleted. Your own settings entries, hooks, and skills are untouched
 (removal never guesses; it only removes what enable recorded).
 Re-enable is a fresh `sideshow enable`.
 
+Disable runs the same running-factory guard as enable, and the
+pack's own hook activity trips it: any dispatcher log write inside
+the last 45 minutes is a soft in-flight signal, so disabling right
+after using the pack refuses with `[recent-burst-log]`. That refusal
+protects a genuinely mid-flight factory run; if the activity was
+yours and is done, pass the same escape hatch enable uses:
+
+```sh
+sideshow disable vsdd-factory --override-stale-lock
+```
+
+An unexpired factory lock still refuses either way (never
+overridable).
+
 ## 5. Per-repo version toggle
 
 ```sh
@@ -164,7 +182,12 @@ enable is refused):
 4. Exit paths: `sideshow disable vsdd-factory` restores the repo
    exactly (the preflight records a retreat anchor — the
    `factory-artifacts` tip and `.factory` status — so you can prove
-   the trial changed nothing it should not have).
+   the trial changed nothing it should not have). If the trial's own
+   hook activity is under 45 minutes old, add `--override-stale-lock`
+   (see section 4). Note the dispatcher writes working state under
+   `.factory/` during the trial; that is the pack's class-1 state and
+   disable deliberately leaves it (gitignore it or remove it yourself
+   after retreat).
 
 ## 7. Activate and deactivate (the persona flip)
 

--- a/examples/bmad/README.md
+++ b/examples/bmad/README.md
@@ -10,6 +10,10 @@ Releases are published by
 [sideshow-packs](https://github.com/ArcavenAE/sideshow-packs) — built
 in CI from pinned upstream sources, cosign-signed, Sigstore-attested.
 
+Prerequisites: `gh`, `cosign`, and `python3` (macOS:
+`brew install gh cosign`). Every verification step below fails
+without them.
+
 ```bash
 mkdir -p /tmp/bmad-install && cd /tmp/bmad-install
 gh release download bmad-v6.10.0 -R ArcavenAE/sideshow-packs \

--- a/internal/adopt/adopt.go
+++ b/internal/adopt/adopt.go
@@ -164,17 +164,31 @@ func Adopt(opts Options) (*Outcome, error) {
 	agentBefore := readAgentKey(opts.RepoDir)
 
 	if opts.DryRun {
+		// The dry run's job is to predict the real run, so it runs the
+		// same preflight enable will (D1, report on the .23 pilot).
+		// The one finding filtered out is same-repo-dual-enable for the
+		// identity being adopted: step 1's suppression silences it
+		// before enable's own preflight sees the repo.
+		refused, err := dryRunPreflight(opts, identity)
+		if err != nil {
+			return nil, err
+		}
 		fmt.Printf("adopt plan for %s in %s (dry run, nothing written):\n", opts.Pack, opts.RepoDir)
 		fmt.Printf("  1. suppress foreign identity %s in this repo only (settings.local.json override; the install is untouched)\n", identity)
 		fmt.Printf("  2. sideshow enable %s@%s --scope %s\n", opts.Pack, adoptVersion, opts.Scope)
-		if agentBefore != "" && strings.HasPrefix(agentBefore, opts.Pack+":") {
-			if opts.RewriteAgent {
-				fmt.Printf("  3. rewrite default agent %q to the bound orchestrator (consented via --rewrite-agent)\n", agentBefore)
-			} else {
-				fmt.Printf("  3. default agent %q is the foreign form; it will KEEP pointing at the suppressed channel — pass --rewrite-agent to flip it, or run 'sideshow activate' after\n", agentBefore)
-			}
+		switch {
+		case strings.HasPrefix(agentBefore, opts.Pack+":") && opts.RewriteAgent:
+			fmt.Printf("  3. rewrite default agent %q to the bound orchestrator (consented via --rewrite-agent)\n", agentBefore)
+		case strings.HasPrefix(agentBefore, opts.Pack+":"):
+			fmt.Printf("  3. default agent %q is the foreign form; it will KEEP pointing at the suppressed channel — pass --rewrite-agent to flip it, or run 'sideshow activate' after\n", agentBefore)
+		default:
+			fmt.Println("  3. no foreign-form default agent to rewrite (nothing to do at this step)")
 		}
 		fmt.Printf("  4. prove equivalence against the foreign tree at %s\n", install.InstallPath)
+		if refused {
+			return &Outcome{Identity: identity, Version: adoptVersion}, fmt.Errorf("the real run would REFUSE: the preflight reported the errors above; resolve them before adopting")
+		}
+		fmt.Println("preflight clean: the real run would proceed")
 		return &Outcome{Identity: identity, Version: adoptVersion}, nil
 	}
 
@@ -288,6 +302,35 @@ func Finish(opts Options) error {
 	fmt.Println("  marketplace removal: only after confirming it serves no other plugin — claude plugin marketplace remove <name>")
 	fmt.Println("Re-run this command after acting; it reports until the census is clean.")
 	return nil
+}
+
+// dryRunPreflight runs the same coexistence preflight enable will,
+// printing every finding except same-repo-dual-enable for the
+// adoption identity (which step 1's suppression resolves before
+// enable runs). Reports whether the real run would refuse.
+func dryRunPreflight(opts Options, identity string) (refused bool, err error) {
+	rep, err := coexistcheck.Run(coexistcheck.Options{
+		RepoDir:         opts.RepoDir,
+		Pack:            opts.Pack,
+		Prefix:          opts.Prefix,
+		ConfigDir:       opts.ConfigDir,
+		LedgerPath:      opts.LedgerPath,
+		PerRepoRequired: true,
+		Now:             opts.Now,
+	})
+	if err != nil {
+		return false, err
+	}
+	for _, r := range rep.Results {
+		if r.Name == "same-repo-dual-enable" && strings.Contains(r.Detail, identity) {
+			continue
+		}
+		fmt.Printf("  %s [%d %s]: %s\n", r.Severity, r.Check, r.Name, r.Detail)
+		if r.Severity == foreign.Error {
+			refused = true
+		}
+	}
+	return refused, nil
 }
 
 func findInstall(c *foreign.Census, identity string) *foreign.Install {

--- a/internal/adopt/adopt_test.go
+++ b/internal/adopt/adopt_test.go
@@ -237,6 +237,23 @@ func TestAdopt_DryRunWritesNothing(t *testing.T) {
 	}
 }
 
+func TestAdopt_DryRunPredictsPreflightRefusal(t *testing.T) {
+	opts, repo, _ := fixture(t, "project")
+	opts.DryRun = true
+	// An unexpired factory lock is a hazard the real run refuses on;
+	// the dry run must predict it (D1 from the .23 pilot report).
+	lock := "---\nfactory_lock:\n  holder: dev@example.com\n  locked_at: " +
+		opts.Now.Add(-10*time.Minute).Format(time.RFC3339) +
+		"\n  expires_at: " + opts.Now.Add(30*time.Minute).Format(time.RFC3339) +
+		"\n---\n\n# Factory State\n"
+	mustWrite(t, repo, ".factory/STATE.md", lock, 0o644)
+
+	_, err := Adopt(opts)
+	if err == nil || !strings.Contains(err.Error(), "the real run would REFUSE") {
+		t.Fatalf("Adopt dry run = %v, want predicted refusal", err)
+	}
+}
+
 func TestAdopt_RollsBackSuppressionOnEnableFailure(t *testing.T) {
 	opts, repo, _ := fixture(t, "project")
 	// Break the store so enable fails after suppression is written.

--- a/internal/pack/activation.go
+++ b/internal/pack/activation.go
@@ -81,8 +81,8 @@ func (a *Activation) PrintInstallNotice() {
 	if !a.PluginClass() {
 		return
 	}
-	fmt.Printf("NOTE: this pack activates via %q, which sideshow does not activate yet.\n", a.Mechanism)
-	fmt.Println("The store copy is producer-validated content; nothing is enabled and 'commands sync' does not apply.")
+	fmt.Printf("NOTE: this pack activates per repo via %q; install does not enable it anywhere.\n", a.Mechanism)
+	fmt.Println("The store copy is producer-validated content; run 'sideshow enable' in each repo that should get it ('commands sync' does not apply).")
 	if a.PerRepoRequired {
 		fmt.Println("Activation is per-repo only; never enable this pack at user scope.")
 	}

--- a/internal/pack/activation_test.go
+++ b/internal/pack/activation_test.go
@@ -139,8 +139,8 @@ func TestInstallFromLocal_PluginClassNoticeReplacesSyncHint(t *testing.T) {
 	})
 
 	for _, want := range []string{
-		"activates via \"claude-plugin\"",
-		"nothing is enabled",
+		"activates per repo via \"claude-plugin\"; install does not enable",
+		"run 'sideshow enable' in each repo",
 		"per-repo only",
 		"https://example.com/runbook",
 	} {


### PR DESCRIPTION
Skippy's consumer-side pilot (ArcavenAE/aae-orc#128) filed nine defects; this lands the four small high-leverage ones and the doc gaps where the report showed the docs and the tool disagreeing. The remaining five are filed as issues (#85 status verdict, #86 count mismatch, #87 disable residue, #88 disable guard behavior, forestage#115 NDJSON frames).

- **D1 (high):** `adopt --dry-run` now runs the same coexistence preflight the real run will, printing findings and failing with "the real run would REFUSE" on any ERROR. The one finding filtered is same-repo-dual-enable for the adoption identity, which step 1's suppression resolves before enable's own preflight; anything else (remote-safety, factory locks) surfaces exactly as it would live. Regression test uses an unexpired factory lock.
- **D2:** dry-run plan always prints step 3; no more skipped numbering.
- **D3:** prerequisites (gh, cosign, python3) documented in the runbook and bmad example; they were the pilot's first hard stop.
- **D4:** install notice reworded; it read as "this channel is not implemented" and nearly stopped the pilot at step 5.
- **D9 (docs half):** disable's `--override-stale-lock` escape hatch is now in the help text, runbook §4, and the §6 retreat recipe, with the 45-minute soft-signal window explained. §6 also names the `.factory/` residue as deliberate. The behavior question is #88.
- **Divergence register:** entry 9's dormant-grant outcome recorded (blocking protect-secrets honored live), new entry 11 prices the headless NDJSON observability gap.

Additive plus wording changes; the only behavior change is dry-run gaining the preflight it was documented as implying. Suite and lint green.