### PR TITLE
fix(install,adopt): refuse consent nobody gave, and check the store before step 1

### DIFF
--- a/cmd/sideshow/main.go
+++ b/cmd/sideshow/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -501,18 +502,8 @@ func runInstall(args []string) error {
 	packPath := pack.PacksDir()
 	settingsFile := permissions.SettingsPath(scope, ".")
 
-	if !autoYes {
-		fmt.Printf("\nConfigure Claude Code to read from %s?\n", packPath)
-		fmt.Printf("  This adds Read(%s/) to %s\n", packPath, settingsFile)
-		fmt.Printf("  [Y/n]: ")
-
-		reader := bufio.NewReader(os.Stdin)
-		answer, _ := reader.ReadString('\n')
-		answer = strings.TrimSpace(strings.ToLower(answer))
-		if answer == "n" || answer == "no" {
-			fmt.Println("Skipped. You may be prompted by Claude Code when accessing pack files.")
-			return nil
-		}
+	if !autoYes && !consentToPermissions(os.Stdin, os.Stdout, stdinIsTerminal(), packPath, settingsFile) {
+		return nil
 	}
 
 	if err := permissions.ConfigureForScope(scope, packPath, "."); err != nil {
@@ -521,6 +512,62 @@ func runInstall(args []string) error {
 	}
 
 	return nil
+}
+
+// stdinIsTerminal reports whether stdin is an interactive terminal.
+// Fails closed: a Stat error means "not a terminal", because the
+// consequence of guessing wrong is writing a permission nobody
+// approved.
+func stdinIsTerminal() bool {
+	fi, err := os.Stdin.Stat()
+	if err != nil {
+		return false
+	}
+	return fi.Mode()&os.ModeCharDevice != 0
+}
+
+// consentToPermissions asks whether to write Claude Code permission
+// entries and reports the answer.
+//
+// It never infers consent from an absent answer (sideshow#94). The
+// prompt documents a [Y/n] default, and the original read treated
+// anything that was not "n"/"no" as yes — including the empty string
+// an EOF returns. A piped or redirected install therefore granted
+// Read permissions with nobody answering. Two cases now mean no: a
+// non-interactive stdin, which cannot answer at all, and an EOF with
+// nothing typed. Same family as the SIDESHOW_HOME contamination fix
+// just above: the install path must not assume an environment it did
+// not check.
+//
+// A bare Enter on a terminal is still yes. The bug is answers that
+// were never given, not answers given tersely. --yes remains the
+// intentional automation path and is handled by the caller.
+// The writer is injected rather than written through fmt.Printf so the
+// tests can run in parallel without swapping os.Stdout. Write errors on
+// the prompt stream are discarded explicitly: a consent decision must
+// not turn on whether the terminal accepted the question.
+func consentToPermissions(in io.Reader, out io.Writer, isTerminal bool, packPath, settingsFile string) bool {
+	if !isTerminal {
+		_, _ = fmt.Fprintf(out, "\nstdin is not a terminal, so the permission prompt cannot be answered.\n")
+		_, _ = fmt.Fprintf(out, "Skipping Claude Code permission configuration; re-run with --yes to configure it without prompting.\n")
+		return false
+	}
+
+	_, _ = fmt.Fprintf(out, "\nConfigure Claude Code to read from %s?\n", packPath)
+	_, _ = fmt.Fprintf(out, "  This adds Read(%s/) to %s\n", packPath, settingsFile)
+	_, _ = fmt.Fprintf(out, "  [Y/n]: ")
+
+	answer, readErr := bufio.NewReader(in).ReadString('\n')
+	answer = strings.TrimSpace(strings.ToLower(answer))
+	if readErr != nil && answer == "" {
+		_, _ = fmt.Fprintf(out, "\nNo answer read (input closed). Skipping; re-run with --yes to configure permissions.\n")
+		return false
+	}
+	if answer == "n" || answer == "no" {
+		_, _ = fmt.Fprintf(out, "Skipped. You may be prompted by Claude Code when accessing pack files.\n")
+		return false
+	}
+	return true
 }
 
 // runUse activates an installed pack version and re-syncs bindings so

--- a/cmd/sideshow/main_test.go
+++ b/cmd/sideshow/main_test.go
@@ -60,3 +60,63 @@ func TestRunStatus_FailsClosedOnUnreadableActivation(t *testing.T) {
 		t.Errorf("status evaluated bindings for a pack with unreadable activation (fail open), got: %q", out)
 	}
 }
+
+// TestConsentToPermissions is the regression guard for sideshow#94:
+// the consent read treated anything that was not "n"/"no" as yes,
+// including the empty string an EOF returns, so a piped or redirected
+// install wrote Read permissions with nobody answering.
+func TestConsentToPermissions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		isTerminal bool
+		input      string
+		want       bool
+		// unanswered marks the refusals where nobody declined: the
+		// message has to name --yes, or an unattended caller has no way
+		// forward. An operator who typed "n" chose, and is not nudged.
+		unanswered bool
+	}{
+		{"non-interactive stdin never consents", false, "", false, true},
+		{"non-interactive stdin ignores even a typed yes", false, "y\n", false, true},
+		{"eof with nothing typed is not consent", true, "", false, true},
+		{"explicit n declines", true, "n\n", false, false},
+		{"explicit no declines", true, "no\n", false, false},
+		{"uppercase N declines", true, "N\n", false, false},
+		{"bare enter keeps the documented [Y/n] default", true, "\n", true, false},
+		{"explicit y accepts", true, "y\n", true, false},
+		{"a terse answer without a newline still counts", true, "yes", true, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var out bytes.Buffer
+			got := consentToPermissions(
+				strings.NewReader(tc.input), &out, tc.isTerminal,
+				"/packs", "/settings.json",
+			)
+			if got != tc.want {
+				t.Fatalf("consent = %v, want %v (output: %q)", got, tc.want, out.String())
+			}
+			if tc.unanswered && !strings.Contains(out.String(), "--yes") {
+				t.Errorf("unanswered refusal did not name --yes: %q", out.String())
+			}
+		})
+	}
+}
+
+// TestConsentToPermissions_NonInteractiveDoesNotPrompt guards the
+// half that matters for unattended installs: a non-terminal stdin is
+// not asked a question it cannot answer.
+func TestConsentToPermissions_NonInteractiveDoesNotPrompt(t *testing.T) {
+	t.Parallel()
+	var out bytes.Buffer
+	if consentToPermissions(strings.NewReader(""), &out, false, "/packs", "/settings.json") {
+		t.Fatal("non-interactive stdin consented")
+	}
+	if strings.Contains(out.String(), "[Y/n]") {
+		t.Errorf("prompted a non-interactive stdin: %q", out.String())
+	}
+}

--- a/internal/adopt/adopt.go
+++ b/internal/adopt/adopt.go
@@ -156,6 +156,24 @@ func Adopt(opts Options) (*Outcome, error) {
 		return nil, fmt.Errorf("foreign tree runs %s but adoption targets %s; equivalence is only provable at version equality — re-run with --allow-version-change to accept the drift", runningVersion, adoptVersion)
 	}
 
+	// Store gate (sideshow#96). Step 2 hands adoptVersion to enable,
+	// which resolves it against the store. When the version was
+	// DEFAULTED from the foreign tree, nothing guarantees the store
+	// holds it — and the equality gate above cannot catch that, because
+	// a defaulted adoptVersion equals runningVersion by construction, so
+	// the gate compares a value against itself and never fires. Without
+	// this check the failure surfaces inside enable, at step 2, after
+	// step 1 has already written.
+	//
+	// Computed here rather than returned, so the dry run can predict it
+	// instead of only the real run hitting it. Skipped when StoreRoot is
+	// injected, mirroring enable's resolveStore, which short-circuits on
+	// the same seam and never consults the registry.
+	var storeErr error
+	if opts.StoreRoot == "" {
+		storeErr = checkStoreHasVersion(opts.Pack, adoptVersion, opts.Version == "")
+	}
+
 	// Pre-state snapshot.
 	footBefore, err := coexistcheck.SnapshotForeignFootprint(opts.ConfigDir)
 	if err != nil {
@@ -176,6 +194,9 @@ func Adopt(opts Options) (*Outcome, error) {
 		fmt.Printf("adopt plan for %s in %s (dry run, nothing written):\n", opts.Pack, opts.RepoDir)
 		fmt.Printf("  1. suppress foreign identity %s in this repo only (settings.local.json override; the install is untouched)\n", identity)
 		fmt.Printf("  2. sideshow enable %s@%s --scope %s\n", opts.Pack, adoptVersion, opts.Scope)
+		if storeErr != nil {
+			fmt.Printf("     WOULD FAIL: %v\n", storeErr)
+		}
 		switch {
 		case strings.HasPrefix(agentBefore, opts.Pack+":") && opts.RewriteAgent:
 			fmt.Printf("  3. rewrite default agent %q to the bound orchestrator (consented via --rewrite-agent)\n", agentBefore)
@@ -185,11 +206,16 @@ func Adopt(opts Options) (*Outcome, error) {
 			fmt.Println("  3. no foreign-form default agent to rewrite (nothing to do at this step)")
 		}
 		fmt.Printf("  4. prove equivalence against the foreign tree at %s\n", install.InstallPath)
-		if refused {
-			return &Outcome{Identity: identity, Version: adoptVersion}, fmt.Errorf("the real run would REFUSE: the preflight reported the errors above; resolve them before adopting")
+		if refused || storeErr != nil {
+			return &Outcome{Identity: identity, Version: adoptVersion}, fmt.Errorf("the real run would REFUSE: the plan above reports the errors; resolve them before adopting")
 		}
-		fmt.Println("preflight clean: the real run would proceed")
+		fmt.Println("preflight clean and every plan step resolves: the real run would proceed")
 		return &Outcome{Identity: identity, Version: adoptVersion}, nil
+	}
+
+	// Refuse before step 1 writes anything.
+	if storeErr != nil {
+		return nil, storeErr
 	}
 
 	// Step 1: repo-side suppression, BEFORE enable (see package doc).
@@ -302,6 +328,39 @@ func Finish(opts Options) error {
 	fmt.Println("  marketplace removal: only after confirming it serves no other plugin — claude plugin marketplace remove <name>")
 	fmt.Println("Re-run this command after acting; it reports until the census is clean.")
 	return nil
+}
+
+// checkStoreHasVersion reports why enable would fail to resolve
+// pack@version against the store, or nil when it would resolve.
+//
+// defaulted says the version came from the foreign tree rather than
+// from the operator, which changes the advice: an operator who typed a
+// version wants that version installed, while a defaulted one is a
+// drift the operator has not seen yet and can accept explicitly.
+func checkStoreHasVersion(packName, version string, defaulted bool) error {
+	packs, err := pack.List()
+	if err != nil {
+		return fmt.Errorf("read the pack registry to confirm %s@%s is installed: %w", packName, version, err)
+	}
+	var installed []string
+	for _, p := range packs {
+		if p.Name != packName {
+			continue
+		}
+		if p.Version == version {
+			return nil
+		}
+		installed = append(installed, p.Version)
+	}
+
+	held := "no versions of it"
+	if len(installed) > 0 {
+		held = strings.Join(installed, ", ")
+	}
+	if defaulted {
+		return fmt.Errorf("adoption targets %s@%s, the version the foreign tree is running, but the store holds %s; install that version, or adopt at an installed one with '%s@<version> --allow-version-change' (equivalence is only provable at version equality, so the drift has to be explicit)", packName, version, held, packName)
+	}
+	return fmt.Errorf("adoption targets %s@%s but the store holds %s; install that version first", packName, version, held)
 }
 
 // dryRunPreflight runs the same coexistence preflight enable will,

--- a/internal/adopt/adopt_test.go
+++ b/internal/adopt/adopt_test.go
@@ -313,3 +313,80 @@ func diffSnapshots(a, b map[string]string) []string {
 	}
 	return out
 }
+
+// storeWith points SIDESHOW_HOME at a registry holding exactly the
+// given pack versions, so the store gate resolves against a real
+// registry instead of the injected StoreRoot seam.
+func storeWith(t *testing.T, versions ...string) {
+	t.Helper()
+	home := t.TempDir()
+	var b strings.Builder
+	b.WriteString("packs:\n")
+	for _, v := range versions {
+		fmt.Fprintf(&b, "  - name: vsdd-factory\n    version: %q\n    path: %q\n",
+			v, filepath.Join(home, "packs", "vsdd-factory", v))
+	}
+	mustWrite(t, home, "registry.yaml", b.String(), 0o644)
+	t.Setenv("SIDESHOW_HOME", home)
+}
+
+// TestAdopt_DefaultVersionAbsentFromStoreRefuses is the regression
+// guard for sideshow#96. The default path sets adoptVersion to the
+// foreign tree's running version, so the equality gate compares that
+// value against itself and never fires. Nothing then confirmed the
+// store actually held it, and enable failed at step 2 after step 1 had
+// written.
+func TestAdopt_DefaultVersionAbsentFromStoreRefuses(t *testing.T) {
+	opts, repo, _ := fixture(t, "project")
+	// The real seam: no injected StoreRoot, and a store that holds a
+	// different version than the foreign tree runs (rc.23).
+	opts.StoreRoot = ""
+	storeWith(t, "1.0.0-rc.99")
+
+	_, err := Adopt(opts)
+	if err == nil {
+		t.Fatal("adopt proceeded with a version the store does not hold")
+	}
+	for _, want := range []string{"1.0.0-rc.23", "1.0.0-rc.99", "--allow-version-change"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("refusal does not name %q: %v", want, err)
+		}
+	}
+
+	// Refused BEFORE step 1: the repo is exactly as found.
+	if _, statErr := os.Stat(filepath.Join(repo, ".claude", "settings.local.json")); !os.IsNotExist(statErr) {
+		t.Error("step 1 wrote a suppression override before the refusal")
+	}
+}
+
+// TestAdopt_DryRunPredictsStoreRefusal is the other half: a dry run
+// must validate every step of the plan it prints, not just the
+// preconditions of step one. Before the fix it printed step 2 and
+// then reported "the real run would proceed".
+func TestAdopt_DryRunPredictsStoreRefusal(t *testing.T) {
+	opts, _, _ := fixture(t, "project")
+	opts.StoreRoot = ""
+	opts.DryRun = true
+	storeWith(t, "1.0.0-rc.99")
+
+	_, err := Adopt(opts)
+	if err == nil {
+		t.Fatal("dry run predicted success for a plan whose step 2 cannot resolve")
+	}
+	if !strings.Contains(err.Error(), "would REFUSE") {
+		t.Errorf("dry run did not report a refusal: %v", err)
+	}
+}
+
+// TestAdopt_DefaultVersionPresentInStoreProceeds pins the other side,
+// so the gate cannot be satisfied by refusing everything.
+func TestAdopt_DefaultVersionPresentInStoreProceeds(t *testing.T) {
+	opts, _, _ := fixture(t, "project")
+	opts.StoreRoot = ""
+	opts.DryRun = true
+	storeWith(t, "1.0.0-rc.23")
+
+	if _, err := Adopt(opts); err != nil {
+		t.Fatalf("dry run refused a version the store holds: %v", err)
+	}
+}


### PR DESCRIPTION
Two pilot-round-2 defects in the path the first vsdd-factory release ships. Neither corrupted anything, and both rollbacks held. Both granted or promised something on the strength of a check that was never made, which is the class worth closing before a public release rather than after.

Closes sideshow#94 and sideshow#96.

## sideshow#94: consent prompt granted permissions on non-TTY stdin

The read treated anything that was not `n`/`no` as yes, including the empty string an EOF returns. A piped or redirected install wrote `Read` permissions to `settings.json` with nobody answering. Reproduced during the pilot with `< /dev/null` under an isolated HOME.

Two cases now mean no: a non-interactive stdin, which cannot answer at all, and an EOF with nothing typed. A bare Enter on a terminal is still yes, per the documented `[Y/n]` default. The bug is answers that were never given, not answers given tersely. `--yes` remains the intentional automation path, and every unanswered refusal names it so an unattended caller has a way forward from the message alone.

TTY detection is `os.Stdin.Stat()` against `ModeCharDevice`, failing closed on a Stat error, rather than adding `x/term` for one predicate. The repo has a single indirect dependency and this does not earn a second.

Same family as the `SIDESHOW_HOME` contamination fix two lines above: the install path must not assume an environment it did not check.

## sideshow#96: adopt could not reach its own version-equality refusal

Default adopt sets `adoptVersion` to the foreign tree's running version, so the equality gate compares that value against itself and never fires. Nothing then confirmed the store held it, and `enable` failed with `pack @rc.22 not installed` at step 2, after step 1 had already written its suppression override.

Adopt now resolves the version against the registry before any write and refuses with a message naming the running version, what the store actually holds, and the `@<version> --allow-version-change` path. The check is skipped when `StoreRoot` is injected, mirroring `enable`'s `resolveStore`, which short-circuits on that same seam and never consults the registry.

The dry run predicts it rather than only the real run hitting it. N1 is D1 mirrored: D1 taught the dry run to run the preflight, but not to validate the plan it prints. The general rule, for this verb and future ones: **a dry run must validate every step of the plan it prints, not just the preconditions of step one.**

## Tests

Nine table cases on the consent decision (non-interactive with and without typed input, EOF with nothing typed, explicit `n`/`no`/`N`, bare Enter, explicit `y`, a terse answer with no trailing newline), plus a guard that a non-interactive stdin is never asked a question it cannot answer.

Three on the store gate: the refusal naming both versions and the escape path, the dry run predicting it, and the version that *is* present, so the gate cannot be satisfied by refusing everything. The refusal test also asserts the repo is byte-unchanged, since refusing after step 1 would defeat the point.

All five new guards were run against the unfixed code and fail there. The consent guards were checked by restoring the original semantics inside the new signature, since the old code had no seam to test.

`gofmt`, `go vet` and `golangci-lint` clean; full suite passes.

## Cost of merge

The consent change makes unattended installs stop configuring permissions where they previously did so silently. That is the defect, not a regression, and `--yes` covers the intentional case. The adopt change refuses earlier than before and never later.

Refs: `aae-orc-eqs8`, `aae-orc-d3nq.64`