### PR TITLE
feat(preserve): compiled floor under every removal path, plus the register declaration

### DIFF
--- a/internal/bindings/bound_variant.go
+++ b/internal/bindings/bound_variant.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/ArcavenAE/sideshow/internal/pack"
+	"github.com/ArcavenAE/sideshow/internal/preserve"
 )
 
 // The bound variant is the transformed derivative of a plugin pack's
@@ -48,6 +49,14 @@ func BoundVariantDir(packName, version string) string {
 func RenderBoundVariant(storeRoot string, inv *PluginInventory, packName, prefix, destDir string) (*PluginInventory, error) {
 	if prefix == "" {
 		return nil, fmt.Errorf("empty binding prefix for pack %s", packName)
+	}
+	// The bound variant is class 2 (regenerable machine state), so
+	// clearing it is correct — but destDir is a parameter, and this is
+	// the one removal in the codebase with no containment predicate
+	// above it. The floor is what stands between a miswired caller and
+	// a recursive delete of whatever it pointed at (aae-orc-d3nq.42).
+	if err := preserve.Check(destDir); err != nil {
+		return nil, err
 	}
 	if err := os.RemoveAll(destDir); err != nil {
 		return nil, fmt.Errorf("clear bound variant dir: %w", err)

--- a/internal/bindings/repo_materialize.go
+++ b/internal/bindings/repo_materialize.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/ArcavenAE/sideshow/internal/preserve"
 )
 
 // execManifestName is the pack-root executable census emitted by the
@@ -347,6 +349,14 @@ func RemoveRepoArtifacts(t RepoTarget, artifacts []RepoArtifact) (int, error) {
 			(rel != "." || rootAsParentDir)
 		if !underHarness && !compatRemovalAllowed(a) {
 			return 0, fmt.Errorf("refusing removal: artifact %q (kind %s) resolves outside the allowed binding roots of %s", a.Path, a.Kind, repoDir)
+		}
+		// The compiled preserve floor, checked independently of the
+		// containment predicate above (aae-orc-d3nq.42). Containment
+		// answers "is this inside the area I manage"; the floor answers
+		// "is this something nobody may delete". Both must pass, so a
+		// bug in the first is survivable while the second holds.
+		if err := preserve.Check(p); err != nil {
+			return 0, err
 		}
 		abs[i] = p
 	}

--- a/internal/bindings/repo_materialize_test.go
+++ b/internal/bindings/repo_materialize_test.go
@@ -369,3 +369,93 @@ func TestMaterializeRepo_HarnessDirIsAParameter(t *testing.T) {
 		t.Errorf("parameterized harness dir not pruned (err=%v)", err)
 	}
 }
+
+// TestRemoveRepoArtifacts_PreserveFloorRefusesClassOne is the floor
+// firing in the real removal path (aae-orc-d3nq.42). Containment and
+// the floor are independent checks: containment asks whether a path is
+// inside the area sideshow manages, the floor asks whether it is
+// something nobody may delete. These rows are shaped to slip past
+// containment — they resolve UNDER <repo>/.claude — so only the floor
+// stands between a corrupt ledger and a running factory.
+func TestRemoveRepoArtifacts_PreserveFloorRefusesClassOne(t *testing.T) {
+	t.Parallel()
+	repo := t.TempDir()
+
+	planted := map[string]string{
+		".claude/.factory/wave-state.yaml":        "wave: 3\n",
+		".claude/_vsdd-factory-custom/weave.yaml": "schema_version: 0.1.0\n",
+		".claude/_vsdd-factory-output/report.md":  "# results\n",
+		".claude/.worktrees/STORY-14/main.go":     "package main\n",
+	}
+	for rel, content := range planted {
+		p := filepath.Join(repo, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	target := RepoTarget{RepoDir: repo, Scope: ScopeLocal}
+	for _, bad := range []RepoArtifact{
+		{Kind: ArtifactSkillDir, Path: ".claude/.factory"},
+		{Kind: ArtifactAgentFile, Path: ".claude/.factory/wave-state.yaml"},
+		{Kind: ArtifactSkillDir, Path: ".claude/_vsdd-factory-custom"},
+		{Kind: ArtifactSkillDir, Path: ".claude/_vsdd-factory-output"},
+		{Kind: ArtifactSkillDir, Path: ".claude/.worktrees/STORY-14"},
+	} {
+		_, err := RemoveRepoArtifacts(target, []RepoArtifact{bad})
+		if err == nil {
+			t.Errorf("artifact %+v: removal accepted, want the preserve floor to refuse", bad)
+			continue
+		}
+		if !strings.Contains(err.Error(), "protected user state") {
+			t.Errorf("artifact %+v: refused for the wrong reason: %v", bad, err)
+		}
+	}
+
+	// Nothing was removed, including by the rows that were refused
+	// partway through a set.
+	for rel, content := range planted {
+		got, err := os.ReadFile(filepath.Join(repo, rel))
+		if err != nil {
+			t.Fatalf("class 1 file %s removed: %v", rel, err)
+		}
+		if string(got) != content {
+			t.Errorf("class 1 file %s modified", rel)
+		}
+	}
+}
+
+// A protected path anywhere in the set refuses the whole set, so a
+// partial removal cannot begin.
+func TestRemoveRepoArtifacts_PreserveFloorIsASetPreflight(t *testing.T) {
+	t.Parallel()
+	repo := t.TempDir()
+	for _, rel := range []string{".claude/skills/vsdd-jira/SKILL.md", ".claude/.factory/STATE.md"} {
+		p := filepath.Join(repo, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte("x\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	target := RepoTarget{RepoDir: repo, Scope: ScopeLocal}
+	set := []RepoArtifact{
+		{Kind: ArtifactSkillDir, Path: ".claude/skills/vsdd-jira"},
+		{Kind: ArtifactSkillDir, Path: ".claude/.factory"},
+	}
+	removed, err := RemoveRepoArtifacts(target, set)
+	if err == nil {
+		t.Fatal("set containing class 1 state was accepted")
+	}
+	if removed != 0 {
+		t.Errorf("removed %d paths before refusing; the floor must preflight the whole set", removed)
+	}
+	if _, err := os.Stat(filepath.Join(repo, ".claude", "skills", "vsdd-jira", "SKILL.md")); err != nil {
+		t.Errorf("legitimate artifact removed despite the set being refused: %v", err)
+	}
+}

--- a/internal/enable/enable_test.go
+++ b/internal/enable/enable_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -328,4 +329,108 @@ func TestHookEntries_WiresAllTwelveEvents(t *testing.T) {
 			t.Errorf("event %s not wired", ev)
 		}
 	}
+}
+
+// writeMidWaveFactory plants the class-1 durable state a repo running a
+// factory carries mid-wave: the worktree and its run state, the pack's
+// customization and output trees, and a STORY wave checkout. Returns a
+// snapshot of exactly that state.
+func writeMidWaveFactory(t *testing.T, repo string) map[string]string {
+	t.Helper()
+	for rel, content := range map[string]string{
+		".factory/STATE.md":                   "# wave 3 in flight\n",
+		".factory/wave-state.yaml":            "wave: 3\nstatus: running\n",
+		".factory/logs/burst-014.log":         "burst 14 output\n",
+		".factory-project/config.toml":        "[project]\nname = \"x\"\n",
+		".worktrees/STORY-14/src/main.go":     "package main\n",
+		"_vsdd-factory-custom/weave.yaml":     "schema_version: 0.1.0\n",
+		"_vsdd-factory-custom/skills/mine.md": "# my skill\n",
+		"_vsdd-factory-output/report-014.md":  "# results\n",
+		"HANDOFF.md":                          "# handoff\n",
+	} {
+		p := filepath.Join(repo, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	snap := map[string]string{}
+	for _, dir := range []string{".factory", ".factory-project", ".worktrees", "_vsdd-factory-custom", "_vsdd-factory-output"} {
+		for rel, hash := range snapshot(t, filepath.Join(repo, dir)) {
+			snap[dir+"/"+rel] = hash
+		}
+	}
+	return snap
+}
+
+// TestEnableDisable_MidWaveFactorySurvives is the aae-orc-d3nq.42
+// acceptance criterion: class 1 durable user state is bit-identical
+// across a full enable/disable cycle. Sideshow has no uninstall verb,
+// so disable's ledger replay is the removal path that runs inside a
+// user's repo, and it is the one that has to be safe.
+func TestEnableDisable_MidWaveFactorySurvives(t *testing.T) {
+	t.Parallel()
+	store := writeStore(t)
+	repo := writeRepo(t)
+	opts := baseOpts(t, repo, store)
+
+	classOne := writeMidWaveFactory(t, repo)
+	if len(classOne) == 0 {
+		t.Fatal("fixture planted no class 1 state")
+	}
+
+	// A mid-wave factory makes the running-factory guard refuse, which
+	// is correct and is tested elsewhere. The case worth pinning here is
+	// the one past it: an operator who knowingly overrides still must not
+	// lose class 1 state. The guard is policy; the floor is the property
+	// that holds when policy has been overridden.
+	opts.OverrideStaleLock = true
+
+	if err := Enable(opts); err != nil {
+		t.Fatalf("Enable: %v", err)
+	}
+	if diff := diffSnapshots(classOne, snapshotClassOne(t, repo)); diff != "" {
+		t.Fatalf("enable disturbed class 1 state:\n%s", diff)
+	}
+
+	if err := Disable(opts); err != nil {
+		t.Fatalf("Disable: %v", err)
+	}
+	if diff := diffSnapshots(classOne, snapshotClassOne(t, repo)); diff != "" {
+		t.Fatalf("disable disturbed class 1 state:\n%s", diff)
+	}
+}
+
+func snapshotClassOne(t *testing.T, repo string) map[string]string {
+	t.Helper()
+	snap := map[string]string{}
+	for _, dir := range []string{".factory", ".factory-project", ".worktrees", "_vsdd-factory-custom", "_vsdd-factory-output"} {
+		for rel, hash := range snapshot(t, filepath.Join(repo, dir)) {
+			snap[dir+"/"+rel] = hash
+		}
+	}
+	return snap
+}
+
+func diffSnapshots(want, got map[string]string) string {
+	var lines []string
+	for rel, w := range want {
+		g, ok := got[rel]
+		switch {
+		case !ok:
+			lines = append(lines, "REMOVED: "+rel)
+		case g != w:
+			lines = append(lines, "CHANGED: "+rel)
+		}
+	}
+	for rel := range got {
+		if _, ok := want[rel]; !ok {
+			lines = append(lines, "ADDED: "+rel)
+		}
+	}
+	sort.Strings(lines)
+	return strings.Join(lines, "\n")
 }

--- a/internal/preserve/preserve.go
+++ b/internal/preserve/preserve.go
@@ -1,0 +1,133 @@
+// Package preserve is the compiled-in conservative floor under every
+// sideshow removal path (aae-orc-d3nq.42).
+//
+// The register (sideshow-packs registry/<pack>-pack-support.yaml) is the
+// authoritative never-remove declaration: it names, per pack, the durable
+// user state sideshow must never write, delete, or clean. This package is
+// the floor beneath that declaration — the subset that holds when no
+// register is on hand, which is every removal running against a machine
+// that only has the binary and a ledger.
+//
+// Three classes, per the taxonomy the register encodes:
+//
+//   - Class 1, durable user state. A running factory's worktree and
+//     branches, the pack's customization and output trees, in-repo run
+//     state. Never touched by any verb, through install, version flips,
+//     and conversion in either direction. This package enforces class 1.
+//   - Class 2, regenerable machine state. Rendered hooks, bound-variant
+//     caches. Droppable and re-derivable; removal is expected.
+//   - Class 3, harness config. Per-repo enable entries, the default
+//     agent. Touched only per an explicit allowlist, with consent.
+//
+// The floor is a denylist by path shape, deliberately independent of the
+// containment allowlists elsewhere (RemoveRepoArtifacts confines removal
+// to the harness root; this refuses protected paths wherever they turn
+// up). Two independent checks that must both pass is the point: a
+// containment predicate answers "is this inside the area I manage", and
+// this answers "is this something nobody may delete". A bug in the first
+// is survivable while the second holds.
+package preserve
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// ErrProtected marks a refused removal. Callers wrap it; tests match it
+// with errors.Is.
+type ErrProtected struct {
+	Path      string
+	Component string
+	Reason    string
+}
+
+func (e *ErrProtected) Error() string {
+	return fmt.Sprintf("refusing removal: %s is protected user state (%s: %s); sideshow never removes it, through install, uninstall, version flips, or conversion in either direction",
+		e.Path, e.Component, e.Reason)
+}
+
+// protectedComponents are exact path components that are class 1
+// wherever they appear. Matching on the component rather than a prefix
+// means a nested checkout or a worktree at any depth is covered.
+var protectedComponents = map[string]string{
+	".git":             "git metadata; every ref, including the factory-artifacts branch, lives here",
+	".factory":         "the running factory's worktree and its state",
+	".factory-project": "factory project state",
+	".worktrees":       "linked worktrees, including STORY-* wave checkouts",
+}
+
+// IsProtected reports whether path is class 1 durable user state, and
+// why. Paths are matched by component, so both a path TO protected
+// state and a path INSIDE it refuse.
+//
+// The underscore conventions (_<pack>-custom, _<pack>-output) are
+// matched by shape rather than by pack name, so a pack whose register
+// sideshow has never seen still gets the floor.
+func IsProtected(path string) (bool, string, string) {
+	cleaned := filepath.ToSlash(filepath.Clean(path))
+	for _, part := range strings.Split(cleaned, "/") {
+		if part == "" || part == "." || part == ".." {
+			continue
+		}
+		if reason, ok := protectedComponents[part]; ok {
+			return true, part, reason
+		}
+		if isCustomOrOutput(part) {
+			return true, part, "pack customization or output tree; checked-in territory that survives version switches"
+		}
+	}
+	return false, "", ""
+}
+
+// isCustomOrOutput matches the _<pack>-custom / _<pack>-output
+// convention. The pack name is not checked: the shape is the contract,
+// and a floor that only protected packs it recognized would fail
+// exactly where it matters most.
+func isCustomOrOutput(part string) bool {
+	if !strings.HasPrefix(part, "_") || len(part) < 2 {
+		return false
+	}
+	return strings.HasSuffix(part, "-custom") || strings.HasSuffix(part, "-output")
+}
+
+// Check refuses removal of protected state. Every removal path calls it
+// immediately before the syscall, not at plan time: a plan can be stale,
+// and the floor's whole value is that it holds when everything upstream
+// of it was wrong.
+func Check(path string) error {
+	if protected, component, reason := IsProtected(path); protected {
+		return &ErrProtected{Path: path, Component: component, Reason: reason}
+	}
+	return nil
+}
+
+// CheckAll refuses if any path in the set is protected, naming the first
+// offender. Use it as a preflight over a whole removal set so a partial
+// removal cannot begin.
+func CheckAll(paths []string) error {
+	for _, p := range paths {
+		if err := Check(p); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// DestructiveGitSubcommands is the set sideshow must never invoke.
+// Sideshow's git usage is read-only by construction (rev-parse, status);
+// this list exists so the guard test in this package keeps it that way
+// rather than relying on nobody adding one. Git-side protection is verb
+// behavior, not a path list: a branch or a ref is not something a
+// containment predicate can see.
+var DestructiveGitSubcommands = []string{
+	"branch -D",
+	"branch -d",
+	"push --delete",
+	"worktree remove",
+	"worktree prune",
+	"reset --hard",
+	"clean -fd",
+	"checkout --",
+	"update-ref -d",
+}

--- a/internal/preserve/preserve_test.go
+++ b/internal/preserve/preserve_test.go
@@ -1,0 +1,156 @@
+package preserve
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestIsProtected(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		// Class 1: durable user state, refused wherever it appears.
+		{"factory worktree", "/repo/.factory", true},
+		{"inside the factory worktree", "/repo/.factory/state/wave.yaml", true},
+		{"factory project state", "/repo/.factory-project", true},
+		{"linked worktrees dir", "/repo/.worktrees", true},
+		{"a STORY wave checkout", "/repo/.worktrees/STORY-14/src", true},
+		{"git metadata carries every ref", "/repo/.git", true},
+		{"a ref file under git", "/repo/.git/refs/heads/factory-artifacts", true},
+		{"pack customization tree", "/repo/_vsdd-factory-custom", true},
+		{"inside a customization tree", "/repo/_bmad-custom/skills/x", true},
+		{"pack output tree", "/repo/_vsdd-factory-output", true},
+		{"protected state at depth", "/a/b/c/.factory/d", true},
+		{"a pack sideshow has never seen still gets the floor", "/repo/_totally-new-pack-custom", true},
+
+		// Class 2 and 3: removal is expected.
+		{"bound variant cache", "/data/bound/vsdd-factory/1.0.0", false},
+		{"harness dir", "/repo/.claude", false},
+		{"a bound skill dir", "/repo/.claude/skills/vsdd-orchestrator", false},
+		{"the store", "/data/packs/vsdd-factory/1.0.0", false},
+		{"a settings file", "/repo/.claude/settings.local.json", false},
+
+		// Near misses: the shape has to actually match.
+		{"custom without the underscore", "/repo/vsdd-factory-custom", false},
+		{"underscore without the suffix", "/repo/_vsdd-factory", false},
+		{"a bare underscore", "/repo/_", false},
+		{"factory as a substring, not a component", "/repo/my.factory.notes", false},
+		{"output as a substring", "/repo/_outputs", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, _, _ := IsProtected(tc.path)
+			if got != tc.want {
+				t.Fatalf("IsProtected(%q) = %v, want %v", tc.path, got, tc.want)
+			}
+			err := Check(tc.path)
+			if (err != nil) != tc.want {
+				t.Fatalf("Check(%q) error = %v, want protected=%v", tc.path, err, tc.want)
+			}
+		})
+	}
+}
+
+func TestCheck_ErrorNamesTheComponentAndIsTyped(t *testing.T) {
+	t.Parallel()
+	err := Check("/repo/.factory/wave-state.yaml")
+	if err == nil {
+		t.Fatal("protected path was not refused")
+	}
+	var protected *ErrProtected
+	if !errors.As(err, &protected) {
+		t.Fatalf("error is not *ErrProtected: %T", err)
+	}
+	if protected.Component != ".factory" {
+		t.Errorf("component = %q, want .factory", protected.Component)
+	}
+	// The operator has to be able to tell WHAT was refused and why from
+	// the message alone.
+	for _, want := range []string{".factory", "protected user state"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("message does not contain %q: %v", want, err)
+		}
+	}
+}
+
+func TestCheckAll_RefusesTheWholeSetOnOneOffender(t *testing.T) {
+	t.Parallel()
+	set := []string{
+		"/repo/.claude/skills/a",
+		"/repo/.claude/skills/b",
+		"/repo/.factory",
+		"/repo/.claude/skills/c",
+	}
+	err := CheckAll(set)
+	if err == nil {
+		t.Fatal("set containing protected state was accepted")
+	}
+	if !strings.Contains(err.Error(), ".factory") {
+		t.Errorf("refusal did not name the offender: %v", err)
+	}
+	if err := CheckAll(set[:2]); err != nil {
+		t.Errorf("clean set refused: %v", err)
+	}
+}
+
+// TestNoDestructiveGitInvocations keeps ticket item 3 true rather than
+// assuming it stays true. Git-side protection is verb behavior, not a
+// path list: a branch or a ref is not something a containment predicate
+// can see, so the guard is that sideshow never invokes the subcommands
+// at all. Measured 2026-08-01: git usage is rev-parse and status only.
+func TestNoDestructiveGitInvocations(t *testing.T) {
+	t.Parallel()
+
+	root, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var offenders []string
+	walkErr := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if d.Name() == ".git" || d.Name() == "vendor" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		body := string(data)
+		for _, sub := range DestructiveGitSubcommands {
+			// Match the argv shape sideshow would use: the subcommand
+			// and its flag as adjacent quoted strings.
+			parts := strings.Fields(sub)
+			needle := `"` + parts[0] + `", "` + parts[1] + `"`
+			if strings.Contains(body, needle) {
+				rel, _ := filepath.Rel(root, path)
+				offenders = append(offenders, rel+": "+sub)
+			}
+		}
+		return nil
+	})
+	if walkErr != nil {
+		t.Fatal(walkErr)
+	}
+	if len(offenders) > 0 {
+		t.Fatalf("destructive git invocations found; sideshow's git usage must stay read-only:\n  %s",
+			strings.Join(offenders, "\n  "))
+	}
+}


### PR DESCRIPTION
The class-1 corpus a running factory carries — its worktree and run state, the pack's customization and output trees, wave checkouts, and every git ref — had no declared protection and no enforcement that did not depend on a containment predicate being correct. Per drbothen/vsdd-factory#413 that corpus doubles as the data model for the future service, so it is a product contract rather than housekeeping, and it is worth guarding before a public release rather than after.

Last of the code items on the vsdd-factory release gate.

## Two halves

The **register** (`sideshow-packs/registry/<pack>-pack-support.yaml`) is authoritative and now carries the full three-class taxonomy for both vsdd-factory and bmad. bmad's class 1 is just the custom and output trees; declared anyway rather than omitted, because an absent section reads as "not yet considered" and the two contracts should be comparable at a glance.

The **floor** (`internal/preserve`) is what holds beneath it, on a machine with the binary and a ledger but no register on hand — which is every consumer machine.

## Design

**Component matching, not prefix.** Protected state at any depth refuses, so a nested checkout or a worktree several levels down is covered.

**Shape matching, not pack name.** The `_<pack>-custom` / `_<pack>-output` convention protects a pack sideshow has never seen. A floor that only covered packs it recognized would fail exactly where it matters most.

**Independent of containment, deliberately.** `RemoveRepoArtifacts` already confines removal to the harness root. Containment asks "is this inside the area I manage"; the floor asks "is this something nobody may delete". Two independent checks that must both pass means a bug in the first is survivable while the second holds. The hostile tests use ledger rows shaped to resolve *under* `.claude/`, so they slip past containment and only the floor stops them.

**`RenderBoundVariant` gets it too.** Its `os.RemoveAll` takes `destDir` as a parameter and had no containment above it at all. The bound variant is class 2 and clearing it is correct, but that was the one place a miswired caller could have recursed through whatever it pointed at.

**Git protection is verb behavior.** A branch or a ref is not something a containment predicate can see. Sideshow's git usage is already read-only by construction (measured: `rev-parse` and `status` only), so this ships a guard test that keeps it that way rather than a fix.

## Scope note

The ticket names `uninstall` as a target. Sideshow has no `uninstall` verb. The removal paths that actually run inside a user's repo are `disable`'s ledger replay and sync reconciliation, and those are what the floor covers. Flagged here rather than silently reinterpreted.

## Tests

- 22 table cases on the predicate, including near-misses that must **not** match (`vsdd-factory-custom` without the underscore, `_vsdd-factory` without the suffix, `my.factory.notes` where `factory` is a substring rather than a component).
- Typed-error and set-preflight guards: one protected path refuses the whole set, so a partial removal cannot begin.
- The floor firing in the real removal path, asserting nothing was removed.
- **The acceptance criterion**: a mid-wave factory is bit-identical across enable and disable. Run with the running-factory guard deliberately overridden, because the guard refusing is correct and tested elsewhere; the case worth pinning is the one *past* policy. The guard is policy, the floor is the property that holds when policy has been overridden.

The two removal-path guards were run with the floor removed and fail there.

`gofmt`, `go vet` and `golangci-lint` clean; full suite passes.

## Cost of merge

Additive. No existing behavior changes for any path that was not already refusing, and the existing containment and factory-guard tests are untouched and still green.

Refs: `aae-orc-d3nq.42`