### PR TITLE
feat(adopt): consented user-scope migration plus rollback fidelity

### DIFF
--- a/cmd/sideshow/adopt.go
+++ b/cmd/sideshow/adopt.go
@@ -9,18 +9,21 @@ import (
 	"github.com/ArcavenAE/sideshow/internal/bindings"
 )
 
-// runAdopt is the conversion verb (aae-orc-d3nq.22):
+const adoptUsage = "usage: sideshow adopt <pack>[@<version>] [--repo <path>] [--scope local|project] " +
+	"[--allow-version-change] [--rewrite-agent] [--dry-run] [--override-stale-lock] [--finish] " +
+	"[--migrate-user-scope [--also-repo <path>] [--sweep-root <dir>] [--commit-consent] [--yes]]"
+
+// runAdopt is the conversion verb (aae-orc-d3nq.22). Three modes:
 //
-//	sideshow adopt <pack>[@<version>] [--repo <path>] [--scope local|project]
-//	               [--allow-version-change] [--rewrite-agent] [--dry-run]
-//	               [--override-stale-lock] [--finish]
-//
-// --finish runs the residue report instead of a conversion: it lists
-// remaining foreign traces and the operator commands that retire
-// them, and executes nothing.
+//   - default: convert this repo from the foreign channel.
+//   - --finish: report remaining foreign residue and the operator
+//     command that retires each trace. Executes nothing.
+//   - --migrate-user-scope: move a machine-wide enable to per-repo
+//     enables, the consented precondition for adopting a repo whose
+//     foreign channel comes from user scope.
 func runAdopt(args []string) error {
 	if len(args) < 1 || len(args[0]) == 0 || args[0][0] == '-' {
-		return fmt.Errorf("usage: sideshow adopt <pack>[@<version>] [--repo <path>] [--scope local|project] [--allow-version-change] [--rewrite-agent] [--dry-run] [--override-stale-lock] [--finish]")
+		return fmt.Errorf("%s", adoptUsage)
 	}
 	packName, version, _ := strings.Cut(args[0], "@")
 	repoDir, err := os.Getwd()
@@ -28,40 +31,82 @@ func runAdopt(args []string) error {
 		return fmt.Errorf("resolve working directory: %w", err)
 	}
 	opts := adopt.Options{Pack: packName, Version: version, RepoDir: repoDir}
-	finish := false
+	mig := adopt.MigrateOptions{Pack: packName, RepoDir: repoDir}
+	finish, migrate, autoYes := false, false, false
+
+	need := func(i int, flag, what string) error {
+		if i+1 >= len(args) {
+			return fmt.Errorf("%s requires %s", flag, what)
+		}
+		return nil
+	}
 	for i := 1; i < len(args); i++ {
 		switch args[i] {
 		case "--repo":
-			if i+1 >= len(args) {
-				return fmt.Errorf("--repo requires a path")
+			if err := need(i, "--repo", "a path"); err != nil {
+				return err
 			}
 			i++
-			opts.RepoDir = args[i]
+			opts.RepoDir, mig.RepoDir = args[i], args[i]
 		case "--scope":
-			if i+1 >= len(args) {
-				return fmt.Errorf("--scope requires local or project")
+			if err := need(i, "--scope", "local or project"); err != nil {
+				return err
 			}
 			i++
 			if args[i] == "user" {
 				return fmt.Errorf("--scope user is refused: a per-repo-required pack never activates machine-wide (containment mandate); use local or project")
 			}
 			opts.Scope = bindings.RepoScope(args[i])
+			mig.Scope = args[i]
 		case "--allow-version-change":
 			opts.AllowVersionChange = true
 		case "--rewrite-agent":
 			opts.RewriteAgent = true
 		case "--dry-run":
-			opts.DryRun = true
+			opts.DryRun, mig.DryRun = true, true
 		case "--override-stale-lock":
-			opts.OverrideStaleLock = true
+			opts.OverrideStaleLock, mig.OverrideStaleLock = true, true
 		case "--finish":
 			finish = true
+		case "--migrate-user-scope":
+			migrate = true
+		case "--also-repo":
+			if err := need(i, "--also-repo", "a path"); err != nil {
+				return err
+			}
+			i++
+			mig.AlsoRepos = append(mig.AlsoRepos, args[i])
+		case "--sweep-root":
+			if err := need(i, "--sweep-root", "a directory"); err != nil {
+				return err
+			}
+			i++
+			mig.SweepRoots = append(mig.SweepRoots, args[i])
+		case "--commit-consent":
+			mig.CommitConsent = true
+		case "--yes", "-y":
+			autoYes = true
 		default:
 			return fmt.Errorf("unknown flag: %s", args[i])
 		}
 	}
+	if finish && migrate {
+		return fmt.Errorf("--finish reports residue and --migrate-user-scope changes machine posture; run them one at a time")
+	}
 	if finish {
 		return adopt.Finish(opts)
+	}
+	if migrate {
+		// Consent for a machine-wide posture change is --yes or a typed
+		// answer, never an unanswered prompt (sideshow#94). The plan is
+		// printed by MigrateUserScope itself, so the operator sees it
+		// before the question either way: a dry run first, then --yes.
+		mig.Consented = autoYes
+		_, err := adopt.MigrateUserScope(mig)
+		return err
+	}
+	if autoYes {
+		return fmt.Errorf("--yes applies to --migrate-user-scope; a conversion asks for consent through its explicit flags (--rewrite-agent, --allow-version-change)")
 	}
 	_, err = adopt.Adopt(opts)
 	return err

--- a/cmd/sideshow/main.go
+++ b/cmd/sideshow/main.go
@@ -49,6 +49,8 @@ Usage:
   sideshow coexist-check <pack> [--repo <path>]  Read-only enable/adopt preflight (ten checks)
   sideshow adopt <pack> [--repo <path>] [--rewrite-agent] [--dry-run]  Convert a repo from the foreign (claude-mp) channel
   sideshow adopt <pack> --finish          Report remaining foreign residue (print-only)
+  sideshow adopt <pack> --migrate-user-scope [--also-repo <path>] [--sweep-root <dir>] [--yes]
+                                          Move a machine-wide foreign enable to per-repo enables
   sideshow version                        Show version
 
 Install options:

--- a/docs/repo-bindings-enablement.md
+++ b/docs/repo-bindings-enablement.md
@@ -235,7 +235,45 @@ running one (equivalence is only provable at version equality);
 
 Retreat: `sideshow disable vsdd-factory` removes the bindings, and
 deleting the suppression override from `.claude/settings.local.json`
-restores the foreign channel exactly as found.
+restores the foreign channel exactly as found. If the repo carried its
+own per-repo enable before adopting, that entry is restored rather than
+deleted, so a failed adoption leaves the foreign channel dispatching
+exactly as it was.
+
+### When the enable is machine-wide
+
+Adopt refuses outright if the foreign identity is enabled at USER
+scope. Converting one repo would leave every other repo on the machine
+loading the foreign channel, which is the posture the containment
+mandate grades an error. Move the enable per repo first:
+
+```sh
+sideshow adopt vsdd-factory --migrate-user-scope --dry-run
+sideshow adopt vsdd-factory --migrate-user-scope --yes
+```
+
+The migration pins the foreign channel in each swept repo that
+*depends* on the machine-wide enable, removes the machine-wide entry,
+and then verifies against disk, per repo, that removing it changed
+nothing. A repo already enabled independently gets no write; a repo
+that suppresses the identity gets no write. Any mismatch, or a factory
+run in flight in any swept repo, rolls the whole migration back.
+
+The sweep set is the adoption target, the sideshow ledger's repos, and
+any project-scope install the harness recorded. Extend it with
+`--also-repo <path>` (repeatable) and `--sweep-root <dir>` (scans for
+git checkouts, three levels deep).
+
+**The limit is stated in the plan, and it is real:** sideshow cannot
+enumerate every repo on the machine. Any repo outside the sweep set
+that relied on the machine-wide enable stops loading the foreign
+channel. Only you can complete that list, which is why the sweep
+sources are printed rather than assumed.
+
+Per-repo enables land in `.claude/settings.local.json` (untracked) by
+default. `--scope project` writes `.claude/settings.json` instead,
+which every clone of that repo inherits, so it also requires
+`--commit-consent`.
 
 **Machine-level retirement is not automated.** After adopting the
 repos you care about:
@@ -248,6 +286,11 @@ prints every remaining foreign trace (installs per scope, orphaned
 enables, the cache tree, the marketplace) with the operator command
 that retires each one. Sideshow executes none of them — uninstalling
 the plugin channel is your act, run only what you consent to.
+
+The marketplace question is decided rather than deferred: the report
+reads the install registry and says either "serves only vsdd-factory,
+so removal is safe" with the command, or "KEEP" naming the other
+plugins that marketplace serves.
 
 ## Divergence notice
 

--- a/internal/adopt/adopt.go
+++ b/internal/adopt/adopt.go
@@ -21,6 +21,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -33,6 +34,7 @@ import (
 	"github.com/ArcavenAE/sideshow/internal/foreign"
 	"github.com/ArcavenAE/sideshow/internal/ledger"
 	"github.com/ArcavenAE/sideshow/internal/pack"
+	"github.com/ArcavenAE/sideshow/internal/preserve"
 )
 
 // Options configures an adoption.
@@ -125,13 +127,13 @@ func Adopt(opts Options) (*Outcome, error) {
 
 	// User-scope enable is the containment-mandate defect (Diagnose
 	// grades it ERROR): a machine-wide enable of a per-repo-required
-	// pack. Adopt refuses the direct flip — migrating the machine
-	// posture (removing the user-scope entry, adding per-repo enables
-	// in every repo that still wants the foreign channel) is the
-	// operator's act, because only the operator knows which repos
-	// those are.
+	// pack. Adopt refuses the direct flip, because converting one repo
+	// would leave every other repo on the machine in that posture.
+	// --migrate-user-scope is the consented way out (migrate.go); it
+	// stays a separate, explicitly requested step because the sweep set
+	// is the operator's judgement, not sideshow's.
 	if census.UserEnabled(identity) {
-		return nil, fmt.Errorf("%s is enabled at USER scope (machine-wide); adopt refuses the direct flip — first move the enable per-repo: remove the entry from the user settings, add a project/local-scope enable in each repo that should keep the foreign channel, then re-run adopt here", identity)
+		return nil, fmt.Errorf("%s is enabled at USER scope (machine-wide); adopt refuses the direct flip. Move the enable per-repo first: 'sideshow adopt %s --migrate-user-scope --dry-run' prints the plan (add --also-repo/--sweep-root for repos it cannot find), then re-run adopt here", identity, opts.Pack)
 	}
 
 	install := findInstall(census, identity)
@@ -219,6 +221,19 @@ func Adopt(opts Options) (*Outcome, error) {
 	}
 
 	// Step 1: repo-side suppression, BEFORE enable (see package doc).
+	// The prior entry is read first so rollback can restore it exactly:
+	// a repo already carrying a per-repo enable (a hand-written one, or
+	// one the user-scope migration wrote) has a TRUE in the very key
+	// suppression overwrites, and dropping that key would switch the
+	// foreign channel off in a repo nobody converted.
+	localSettings, err := foreign.SettingsPath(opts.RepoDir, opts.ConfigDir, foreign.ScopeLocal)
+	if err != nil {
+		return nil, err
+	}
+	priorEnable, err := foreign.ReadEnable(localSettings, identity)
+	if err != nil {
+		return nil, err
+	}
 	settingsCreated, err := foreign.SuppressInRepo(opts.RepoDir, identity)
 	if err != nil {
 		return nil, err
@@ -234,7 +249,7 @@ func Adopt(opts Options) (*Outcome, error) {
 		Now: opts.Now,
 	}
 	if err := enable.Enable(eOpts); err != nil {
-		rollbackSuppression(opts.RepoDir, identity, settingsCreated)
+		rollbackSuppression(opts.RepoDir, identity, priorEnable, settingsCreated)
 		return nil, fmt.Errorf("enable failed; suppression rolled back, repo unchanged: %w", err)
 	}
 
@@ -325,9 +340,35 @@ func Finish(opts Options) error {
 		fmt.Printf("  orphaned enable %s scope=%s in %s (no install behind it; the harness is silent about these, trial T14)\n", orphan.Identity, orphan.Scope, orphan.Path)
 		fmt.Printf("    remove the entry from that settings file by hand\n")
 	}
-	fmt.Println("  marketplace removal: only after confirming it serves no other plugin — claude plugin marketplace remove <name>")
+	reportMarketplaces(os.Stdout, census)
 	fmt.Println("Re-run this command after acting; it reports until the census is clean.")
 	return nil
+}
+
+// reportMarketplaces decides the marketplace-removal question instead of
+// deferring it: a marketplace is safe to retire only when it serves no
+// other installed plugin, and the install registry answers that. The
+// verdict is still print-only; sideshow never runs the removal.
+//
+// The writer is injected so the verdict is testable without swapping
+// os.Stdout, which is also what lets those tests run in parallel.
+func reportMarketplaces(w io.Writer, census *foreign.Census) {
+	seen := map[string]bool{}
+	for _, in := range census.Installs {
+		if in.Marketplace == "" || seen[in.Marketplace] {
+			continue
+		}
+		seen[in.Marketplace] = true
+		siblings := census.MarketplaceSiblings(in.Marketplace)
+		if len(siblings) > 0 {
+			_, _ = fmt.Fprintf(w, "  marketplace %s: KEEP (it also serves %s); removing it would break them\n",
+				in.Marketplace, strings.Join(siblings, ", "))
+			continue
+		}
+		_, _ = fmt.Fprintf(w, "  marketplace %s: serves only %s, so removal is safe once the install above is gone\n",
+			in.Marketplace, census.Pack)
+		_, _ = fmt.Fprintf(w, "    retire: claude plugin marketplace remove %s\n", in.Marketplace)
+	}
 }
 
 // checkStoreHasVersion reports why enable would fail to resolve
@@ -408,10 +449,29 @@ func findInstall(c *foreign.Census, identity string) *foreign.Install {
 	return fallback
 }
 
-func rollbackSuppression(repoDir, identity string, settingsCreated bool) {
+// rollbackSuppression puts the repo back exactly as step 1 found it.
+// Three cases, in precedence order: an entry that was already there is
+// restored to its old value; a settings file that existed only to carry
+// the suppression is removed; otherwise the suppression entry alone is
+// dropped from a file that has other reasons to exist.
+func rollbackSuppression(repoDir, identity string, prior foreign.EnableEntry, settingsCreated bool) {
+	if prior.Present {
+		if _, err := foreign.SetEnable(prior.Path, identity, prior.Value); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: could not restore the prior enable entry for %s: %v\n", identity, err)
+		}
+		return
+	}
 	if settingsCreated {
-		// The suppression was the file's only reason to exist.
-		if err := os.Remove(filepath.Join(repoDir, ".claude", "settings.local.json")); err != nil {
+		// The suppression was the file's only reason to exist. The
+		// preserve floor still gates the removal: a repo path that
+		// resolves under class-1 state is a bug worth refusing over,
+		// not one worth deleting through.
+		path := filepath.Join(repoDir, ".claude", "settings.local.json")
+		if err := preserve.Check(path); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: leaving %s in place: %v\n", path, err)
+			return
+		}
+		if err := os.Remove(path); err != nil {
 			fmt.Fprintf(os.Stderr, "warning: could not remove the suppression settings file: %v\n", err)
 		}
 		return

--- a/internal/adopt/adopt_test.go
+++ b/internal/adopt/adopt_test.go
@@ -271,6 +271,41 @@ func TestAdopt_RollsBackSuppressionOnEnableFailure(t *testing.T) {
 	}
 }
 
+// TestAdopt_RollbackRestoresAPriorLocalEnable covers the repo shape a
+// per-repo enable leaves behind: the identity is enabled TRUE in the
+// same file and key adopt's suppression writes. Rollback must restore
+// that true, not delete the key. Deleting it turns the foreign channel
+// off in a repo the operator never converted.
+//
+// This is the shape the user-scope migration produces, and the shape
+// any hand-written local enable already had.
+func TestAdopt_RollbackRestoresAPriorLocalEnable(t *testing.T) {
+	opts, repo, _ := fixture(t, "project")
+	// The only enable is a local-scope true, as after a migration.
+	if err := os.Remove(filepath.Join(repo, ".claude", "settings.json")); err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, repo, ".claude/settings.local.json",
+		"{\n  \"enabledPlugins\": {\n    \"vsdd-factory@claude-mp\": true\n  }\n}\n", 0o644)
+
+	// Break the store so enable fails after suppression is written.
+	if err := os.RemoveAll(filepath.Join(opts.StoreRoot, "hooks")); err != nil {
+		t.Fatal(err)
+	}
+	before := snapshotDir(t, repo)
+
+	if _, err := Adopt(opts); err == nil {
+		t.Fatal("Adopt succeeded against a broken store")
+	}
+	if diff := diffSnapshots(before, snapshotDir(t, repo)); len(diff) != 0 {
+		t.Errorf("repo not restored after rollback: %v", diff)
+	}
+	enables, _ := readLocalSettings(t, repo)["enabledPlugins"].(map[string]any)
+	if v, ok := enables["vsdd-factory@claude-mp"].(bool); !ok || !v {
+		t.Errorf("prior local enable not restored: %v", enables)
+	}
+}
+
 func snapshotDir(t *testing.T, dir string) map[string]string {
 	t.Helper()
 	snap := map[string]string{}

--- a/internal/adopt/migrate.go
+++ b/internal/adopt/migrate.go
@@ -1,0 +1,543 @@
+package adopt
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/ArcavenAE/sideshow/internal/factoryguard"
+	"github.com/ArcavenAE/sideshow/internal/foreign"
+	"github.com/ArcavenAE/sideshow/internal/ledger"
+	"github.com/ArcavenAE/sideshow/internal/preserve"
+)
+
+// MigrateUserScope moves a machine-wide (user-scope) enable of the
+// foreign channel to per-repo enables, then removes the machine-wide
+// entry (aae-orc-d3nq.22 clause b).
+//
+// Adopt refuses to run against a user-scope enable, because a
+// per-repo-required pack activating in every repo on the machine is
+// itself the containment defect, and adopting one repo would leave the
+// rest of the machine in it. This is the consented path out: pin the
+// foreign channel in each repo that currently depends on the
+// machine-wide enable, drop the machine-wide entry, and prove per repo
+// that dropping it changed nothing. Afterwards the target repo is an
+// ordinary per-repo adoption.
+//
+// The invariant is that effective enablement is IDENTICAL in every
+// swept repo before and after. That is what makes the migration safe to
+// consent to, and it is verified against disk, not predicted.
+//
+// The honest limit, stated in the plan and in the report: sideshow
+// cannot enumerate every repo on the machine. Repos outside the sweep
+// set that relied on the machine-wide enable lose the foreign channel.
+// Only the operator can complete that list, so the sweep sources are
+// disclosed and extensible rather than guessed at.
+type MigrateOptions struct {
+	// RepoDir is the repo the operator intends to adopt next. It joins
+	// the sweep set like any other candidate.
+	RepoDir    string
+	Pack       string
+	ConfigDir  string
+	LedgerPath string
+	// Scope is where per-repo enables are written: local (default,
+	// untracked) or project (committed, and gated on CommitConsent).
+	Scope string
+	// CommitConsent is required for project scope: the write lands in a
+	// tracked file every clone of that repo inherits.
+	CommitConsent bool
+	// AlsoRepos are operator-named repos to include in the sweep.
+	AlsoRepos []string
+	// SweepRoots are directories to scan for git checkouts (depth 3,
+	// not descending into a checkout once found).
+	SweepRoots []string
+	// OverrideStaleLock accepts expired factory locks across the sweep,
+	// matching enable's flag. Unexpired locks never yield.
+	OverrideStaleLock bool
+	// DryRun prints the plan and writes nothing.
+	DryRun bool
+	// Consented records that the operator approved the printed plan.
+	// Without it the real run refuses after printing.
+	Consented bool
+	Now       time.Time
+}
+
+// RepoPlan is one swept repo's part in the migration.
+type RepoPlan struct {
+	Dir string
+	// Source records how the repo entered the sweep, so the operator can
+	// judge the set's completeness.
+	Source string
+	// Enabled are the pack's foreign identities this repo loads today.
+	Enabled []string
+	// Pin are the identities that would STOP loading here if the
+	// machine-wide entry were removed, so they get a per-repo enable.
+	Pin []string
+	// SettingsPath is the file a pin writes, empty when Pin is empty.
+	SettingsPath string
+}
+
+// MigrationOutcome reports the plan and, for a real run, the result.
+type MigrationOutcome struct {
+	Identities []string
+	Repos      []RepoPlan
+	// Blockers are reasons the real run refuses. A dry run prints them
+	// and returns them as an error; a real run never starts with any.
+	Blockers []string
+	Applied  bool
+	// Pinned counts the per-repo enables written.
+	Pinned int
+}
+
+func (o *MigrateOptions) normalize() error {
+	if o.ConfigDir == "" {
+		o.ConfigDir = foreign.ConfigDir()
+	}
+	if o.LedgerPath == "" {
+		o.LedgerPath = ledger.Path()
+	}
+	if o.Scope == "" {
+		o.Scope = foreign.ScopeLocal
+	}
+	if o.Scope != foreign.ScopeLocal && o.Scope != foreign.ScopeProject {
+		return fmt.Errorf("per-repo enables go to local or project scope, not %q; user scope is what this migration removes", o.Scope)
+	}
+	if o.Scope == foreign.ScopeProject && !o.CommitConsent {
+		return fmt.Errorf("project scope writes .claude/settings.json, a tracked file every clone of the repo inherits; re-run with --commit-consent to accept that, or use the default local scope")
+	}
+	if o.Now.IsZero() {
+		o.Now = time.Now().UTC()
+	}
+	abs, err := filepath.Abs(o.RepoDir)
+	if err != nil {
+		return fmt.Errorf("resolve repo dir: %w", err)
+	}
+	o.RepoDir = abs
+	return nil
+}
+
+// MigrateUserScope runs the migration (or, with DryRun, prints the plan
+// it would run).
+func MigrateUserScope(opts MigrateOptions) (*MigrationOutcome, error) {
+	if err := opts.normalize(); err != nil {
+		return nil, err
+	}
+
+	census, err := foreign.TakeCensus(opts.ConfigDir, opts.Pack)
+	if err != nil {
+		return nil, err
+	}
+	identities := census.UserEnabledIdentities()
+	if len(identities) == 0 {
+		return nil, fmt.Errorf("no user-scope enable of %s found in %s; there is no machine-wide posture to migrate (run 'sideshow coexist %s' to see the current one)", opts.Pack, filepath.Join(opts.ConfigDir, "settings.json"), opts.Pack)
+	}
+
+	out := &MigrationOutcome{Identities: identities}
+
+	// The counterfactual census: the machine as it would be with the
+	// user-scope entries gone. Resolving a repo against both censuses is
+	// what identifies the repos that depend on the machine-wide enable,
+	// rather than guessing from install records.
+	after := census.WithoutUserEnables(identities)
+
+	candidates, sweepNotes := collectCandidates(opts)
+	out.Blockers = append(out.Blockers, sweepNotes...)
+
+	for _, cand := range candidates {
+		plan := RepoPlan{Dir: cand.dir, Source: cand.source}
+		before, err := census.ResolveRepo(cand.dir)
+		if err != nil {
+			out.Blockers = append(out.Blockers, fmt.Sprintf("%s: %v", cand.dir, err))
+			continue
+		}
+		lost, err := after.ResolveRepo(cand.dir)
+		if err != nil {
+			out.Blockers = append(out.Blockers, fmt.Sprintf("%s: %v", cand.dir, err))
+			continue
+		}
+		plan.Enabled = before.EffectivelyEnabled
+		plan.Pin = missing(before.EffectivelyEnabled, lost.EffectivelyEnabled)
+		if len(plan.Pin) > 0 {
+			path, err := foreign.SettingsPath(cand.dir, opts.ConfigDir, opts.Scope)
+			if err != nil {
+				return nil, err
+			}
+			if protected, component, reason := preserve.IsProtected(path); protected {
+				out.Blockers = append(out.Blockers, fmt.Sprintf("%s sits under protected state (%s: %s); sideshow does not write settings there", path, component, reason))
+				continue
+			}
+			plan.SettingsPath = path
+		}
+		out.Repos = append(out.Repos, plan)
+	}
+
+	// The session and lock sweep covers EVERY swept repo, not just the
+	// target: a machine-scoped flip changes what dispatches in all of
+	// them, so a wave in flight anywhere is a reason to wait.
+	for _, plan := range out.Repos {
+		v := factoryguard.CheckRepo(plan.Dir, opts.Now)
+		switch {
+		case v.HardRefusal():
+			out.Blockers = append(out.Blockers, fmt.Sprintf("%s has a factory run in flight: %s", plan.Dir, oneLine(v.Refusal())))
+		case v.InFlight() && !opts.OverrideStaleLock:
+			out.Blockers = append(out.Blockers, fmt.Sprintf("%s shows factory activity: %s (pass --override-stale-lock to accept an expired lock)", plan.Dir, oneLine(v.Refusal())))
+		}
+	}
+
+	// Validate every write the plan names, so a dry run reports the
+	// failure the real run would hit instead of promising success
+	// (finding-099 F099-a).
+	userSettings := filepath.Join(opts.ConfigDir, "settings.json")
+	if err := foreign.CanWriteSettings(userSettings); err != nil {
+		out.Blockers = append(out.Blockers, fmt.Sprintf("cannot update the machine-wide entry: %v", err))
+	}
+	for _, plan := range out.Repos {
+		if plan.SettingsPath == "" {
+			continue
+		}
+		if err := foreign.CanWriteSettings(plan.SettingsPath); err != nil {
+			out.Blockers = append(out.Blockers, fmt.Sprintf("cannot pin %s: %v", plan.Dir, err))
+		}
+		out.Pinned += len(plan.Pin)
+	}
+
+	printMigrationPlan(opts, out)
+
+	if len(out.Blockers) > 0 {
+		return out, fmt.Errorf("migration refused: %d blocker(s) reported above", len(out.Blockers))
+	}
+	if opts.DryRun {
+		fmt.Println("every step of the plan above resolves: the real run would proceed")
+		return out, nil
+	}
+	if !opts.Consented {
+		return out, fmt.Errorf("this changes machine-wide harness posture and needs consent; re-run with --yes after reading the plan above")
+	}
+
+	if err := applyMigration(opts, out, identities, census); err != nil {
+		return out, err
+	}
+	out.Applied = true
+
+	fmt.Printf("migrated: %s no longer carries a machine-wide enable of %s; %d per-repo enable(s) written at %s scope\n",
+		userSettings, strings.Join(identities, ", "), out.Pinned, opts.Scope)
+	fmt.Printf("Adopt the target repo now: sideshow adopt %s --repo %s\n", opts.Pack, opts.RepoDir)
+	fmt.Println("Reverse: remove the per-repo enables listed above and restore the machine-wide entry (this is the posture the containment mandate grades an ERROR, so reversing brings the defect back).")
+	return out, nil
+}
+
+// applyMigration writes the pins, drops the machine-wide entries, and
+// verifies against disk that effective enablement is unchanged in every
+// swept repo. Any mismatch rolls the whole migration back.
+func applyMigration(opts MigrateOptions, out *MigrationOutcome, identities []string, before *foreign.Census) error {
+	pre := map[string][]string{}
+	for _, plan := range out.Repos {
+		pre[plan.Dir] = plan.Enabled
+	}
+
+	var undo undoLog
+	// Pins first: no repo may lose the channel even momentarily.
+	for _, plan := range out.Repos {
+		for _, id := range plan.Pin {
+			prior, err := foreign.ReadEnable(plan.SettingsPath, id)
+			if err != nil {
+				undo.run()
+				return fmt.Errorf("read %s before pinning: %w", plan.SettingsPath, err)
+			}
+			created, err := foreign.SetEnable(plan.SettingsPath, id, true)
+			if err != nil {
+				undo.run()
+				return fmt.Errorf("pin %s in %s: %w", id, plan.Dir, err)
+			}
+			undo.add(plan.SettingsPath, id, prior, created)
+		}
+	}
+	for _, id := range identities {
+		path := before.UserEnablePath(id)
+		if path == "" {
+			path = filepath.Join(opts.ConfigDir, "settings.json")
+		}
+		prior, err := foreign.ReadEnable(path, id)
+		if err != nil {
+			undo.run()
+			return fmt.Errorf("read %s before removing the machine-wide entry: %w", path, err)
+		}
+		if _, err := foreign.DeleteEnable(path, id); err != nil {
+			undo.run()
+			return fmt.Errorf("remove the machine-wide enable of %s: %w", id, err)
+		}
+		undo.add(path, id, prior, false)
+	}
+
+	// Verify against disk. This is the "user-scope disable verified a
+	// no-op per repo" clause, and it is the reason the migration is
+	// consentable: it either held everywhere or it is reverted.
+	fresh, err := foreign.TakeCensus(opts.ConfigDir, opts.Pack)
+	if err != nil {
+		undo.run()
+		return fmt.Errorf("re-read the census to verify the migration: %w", err)
+	}
+	if ids := fresh.UserEnabledIdentities(); len(ids) > 0 {
+		undo.run()
+		return fmt.Errorf("the machine-wide enable of %s survived removal; migration rolled back", strings.Join(ids, ", "))
+	}
+	for _, plan := range out.Repos {
+		view, err := fresh.ResolveRepo(plan.Dir)
+		if err != nil {
+			undo.run()
+			return fmt.Errorf("verify %s: %w; migration rolled back", plan.Dir, err)
+		}
+		if !sameSet(pre[plan.Dir], view.EffectivelyEnabled) {
+			undo.run()
+			return fmt.Errorf("removing the machine-wide entry was NOT a no-op in %s (was [%s], now [%s]); migration rolled back",
+				plan.Dir, strings.Join(pre[plan.Dir], " "), strings.Join(view.EffectivelyEnabled, " "))
+		}
+	}
+	return nil
+}
+
+// undoLog reverses settings writes in the order that restores the
+// starting state: last write first, prior values restored exactly, and
+// a file sideshow created removed only when its removal passes the
+// preserve floor and it is empty again.
+type undoLog struct {
+	entries []undoEntry
+	created map[string]bool
+}
+
+type undoEntry struct {
+	path     string
+	identity string
+	prior    foreign.EnableEntry
+}
+
+func (u *undoLog) add(path, identity string, prior foreign.EnableEntry, created bool) {
+	if created {
+		if u.created == nil {
+			u.created = map[string]bool{}
+		}
+		u.created[path] = true
+	}
+	u.entries = append(u.entries, undoEntry{path: path, identity: identity, prior: prior})
+}
+
+func (u *undoLog) run() {
+	for i := len(u.entries) - 1; i >= 0; i-- {
+		e := u.entries[i]
+		var err error
+		if e.prior.Present {
+			_, err = foreign.SetEnable(e.path, e.identity, e.prior.Value)
+		} else {
+			_, err = foreign.DeleteEnable(e.path, e.identity)
+		}
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: could not restore %s in %s: %v\n", e.identity, e.path, err)
+		}
+	}
+	for path := range u.created {
+		if err := preserve.Check(path); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: leaving %s in place: %v\n", path, err)
+			continue
+		}
+		if !settingsFileIsEmpty(path) {
+			continue
+		}
+		if err := os.Remove(path); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: could not remove the settings file sideshow created at %s: %v\n", path, err)
+		}
+	}
+}
+
+// settingsFileIsEmpty reports whether the file holds an empty JSON
+// object, which is the state a rolled-back pin leaves behind in a file
+// sideshow created. Anything else is content sideshow did not write.
+func settingsFileIsEmpty(path string) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(data)) == "{}"
+}
+
+type candidate struct {
+	dir    string
+	source string
+}
+
+// collectCandidates builds the sweep set from disclosed sources, in
+// precedence order (first source to name a repo owns the label), and
+// returns notes for anything it could not use.
+func collectCandidates(opts MigrateOptions) ([]candidate, []string) {
+	var notes []string
+	seen := map[string]bool{}
+	var out []candidate
+
+	add := func(dir, source string) {
+		abs, err := filepath.Abs(dir)
+		if err != nil {
+			notes = append(notes, fmt.Sprintf("cannot resolve %s (%s): %v", dir, source, err))
+			return
+		}
+		if seen[abs] {
+			return
+		}
+		info, err := os.Stat(abs)
+		if err != nil || !info.IsDir() {
+			// A ledger row for a deleted checkout is stale bookkeeping,
+			// not a blocker. A path the operator typed is a typo, and
+			// silently sweeping one repo fewer than they asked for is the
+			// worst outcome here: the entry still goes.
+			if source == sourceOperator || source == sourceTarget {
+				notes = append(notes, fmt.Sprintf("%s: %s is not a directory", source, dir))
+			}
+			return
+		}
+		seen[abs] = true
+		out = append(out, candidate{dir: abs, source: source})
+	}
+
+	add(opts.RepoDir, sourceTarget)
+	for _, dir := range opts.AlsoRepos {
+		add(dir, sourceOperator)
+	}
+	if led, err := ledger.Load(opts.LedgerPath); err == nil {
+		dirs := led.RepoDirs()
+		sort.Strings(dirs)
+		for _, dir := range dirs {
+			add(dir, "sideshow ledger")
+		}
+	} else {
+		notes = append(notes, fmt.Sprintf("cannot read the repo-bindings ledger: %v", err))
+	}
+	if census, err := foreign.TakeCensus(opts.ConfigDir, opts.Pack); err == nil {
+		for _, in := range census.Installs {
+			if in.ProjectPath != "" {
+				add(in.ProjectPath, "harness project-scope install")
+			}
+		}
+	}
+	for _, root := range opts.SweepRoots {
+		found, err := findGitCheckouts(root, 3)
+		if err != nil {
+			notes = append(notes, fmt.Sprintf("--sweep-root %s: %v", root, err))
+			continue
+		}
+		for _, dir := range found {
+			add(dir, "sweep "+root)
+		}
+	}
+	return out, notes
+}
+
+const (
+	sourceTarget   = "adoption target"
+	sourceOperator = "operator (--also-repo)"
+)
+
+// findGitCheckouts lists directories containing .git under root, to
+// maxDepth levels, without descending into a checkout once found.
+// Hidden directories are skipped: a sweep is for working repos, and
+// caches full of vendored checkouts are noise at best.
+func findGitCheckouts(root string, maxDepth int) ([]string, error) {
+	abs, err := filepath.Abs(root)
+	if err != nil {
+		return nil, err
+	}
+	if info, err := os.Stat(abs); err != nil || !info.IsDir() {
+		return nil, fmt.Errorf("not a directory")
+	}
+	var found []string
+	var walk func(dir string, depth int)
+	walk = func(dir string, depth int) {
+		if _, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
+			found = append(found, dir)
+			return
+		}
+		if depth >= maxDepth {
+			return
+		}
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			return
+		}
+		for _, e := range entries {
+			if !e.IsDir() || strings.HasPrefix(e.Name(), ".") {
+				continue
+			}
+			walk(filepath.Join(dir, e.Name()), depth+1)
+		}
+	}
+	walk(abs, 0)
+	sort.Strings(found)
+	return found, nil
+}
+
+func printMigrationPlan(opts MigrateOptions, out *MigrationOutcome) {
+	verb := "migration plan"
+	if opts.DryRun {
+		verb = "migration plan (dry run, nothing written)"
+	}
+	fmt.Printf("%s for %s: move the machine-wide enable of %s to per-repo enables at %s scope\n",
+		verb, opts.Pack, strings.Join(out.Identities, ", "), opts.Scope)
+
+	fmt.Printf("  swept %d repo(s):\n", len(out.Repos))
+	for _, plan := range out.Repos {
+		switch {
+		case len(plan.Pin) > 0:
+			fmt.Printf("    PIN  %s [%s]: enable %s in %s\n", plan.Dir, plan.Source, strings.Join(plan.Pin, ", "), plan.SettingsPath)
+		case len(plan.Enabled) > 0:
+			fmt.Printf("    keep %s [%s]: already enabled independently of user scope; no write\n", plan.Dir, plan.Source)
+		default:
+			fmt.Printf("    skip %s [%s]: the foreign channel does not dispatch here; no write\n", plan.Dir, plan.Source)
+		}
+	}
+	fmt.Printf("  then remove the %s entries for %s from %s\n",
+		foreign.EnableKey, strings.Join(out.Identities, ", "), filepath.Join(opts.ConfigDir, "settings.json"))
+	fmt.Println("  then verify per repo, against disk, that the removal changed nothing; any mismatch rolls the whole migration back")
+
+	fmt.Println("LIMIT: sideshow cannot enumerate every repo on this machine. Any repo NOT listed above that")
+	fmt.Println("  relied on the machine-wide enable stops loading the foreign channel. Add repos with")
+	fmt.Println("  --also-repo <path> or --sweep-root <dir>, or re-add the entry per repo afterwards.")
+
+	for _, b := range out.Blockers {
+		fmt.Printf("  BLOCKER: %s\n", b)
+	}
+}
+
+// missing returns the elements of a that are absent from b.
+func missing(a, b []string) []string {
+	have := make(map[string]bool, len(b))
+	for _, v := range b {
+		have[v] = true
+	}
+	var out []string
+	for _, v := range a {
+		if !have[v] {
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
+func sameSet(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	x := append([]string(nil), a...)
+	y := append([]string(nil), b...)
+	sort.Strings(x)
+	sort.Strings(y)
+	for i := range x {
+		if x[i] != y[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func oneLine(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}

--- a/internal/adopt/migrate_test.go
+++ b/internal/adopt/migrate_test.go
@@ -1,0 +1,478 @@
+package adopt
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ArcavenAE/sideshow/internal/foreign"
+	"github.com/ArcavenAE/sideshow/internal/ledger"
+)
+
+var migrateNow = time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+
+// migrateScene stands up a machine with a user-scope (machine-wide)
+// enable of the foreign channel and four repos around it:
+//
+//	target:      depends on the machine-wide enable; the adoption target
+//	dependent:   depends on it too, and is in the sideshow ledger
+//	independent: carries its own project-scope enable
+//	suppressed:  overrides the machine-wide enable to false
+//
+// The migration must pin exactly the first two and leave the other two
+// alone, because those two are the only ones whose effective enablement
+// would change when the machine-wide entry goes.
+type migrateScene struct {
+	opts        MigrateOptions
+	configDir   string
+	target      string
+	dependent   string
+	independent string
+	suppressed  string
+}
+
+func newMigrateScene(t *testing.T) *migrateScene {
+	t.Helper()
+	configDir := t.TempDir()
+	cache := filepath.Join(t.TempDir(), "cache", "vsdd-factory")
+	writeTree(t, cache, platform(t))
+	mustWrite(t, configDir, "plugins/installed_plugins.json", `{"version": 2, "plugins": {"vsdd-factory@claude-mp": [
+	  {"scope": "user", "installPath": "`+cache+`", "version": "1.0.0-rc.23"}
+	]}}`, 0o644)
+	mustWrite(t, configDir, "settings.json", `{"enabledPlugins": {"vsdd-factory@claude-mp": true}}`, 0o644)
+
+	s := &migrateScene{
+		configDir:   configDir,
+		target:      t.TempDir(),
+		dependent:   t.TempDir(),
+		independent: t.TempDir(),
+		suppressed:  t.TempDir(),
+	}
+	mustWrite(t, s.independent, ".claude/settings.json",
+		`{"enabledPlugins": {"vsdd-factory@claude-mp": true}}`, 0o644)
+	mustWrite(t, s.suppressed, ".claude/settings.local.json",
+		`{"enabledPlugins": {"vsdd-factory@claude-mp": false}}`, 0o644)
+
+	// The ledger names the dependent repo; the others arrive by flag.
+	ledgerPath := filepath.Join(t.TempDir(), "repo-bindings.yaml")
+	led := &ledger.Ledger{}
+	if err := led.SetRow(s.dependent, "other-pack", ledger.Row{Version: "1.0.0", Channel: "sideshow-native"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := led.Save(ledgerPath); err != nil {
+		t.Fatal(err)
+	}
+
+	s.opts = MigrateOptions{
+		RepoDir:    s.target,
+		Pack:       "vsdd-factory",
+		ConfigDir:  configDir,
+		LedgerPath: ledgerPath,
+		AlsoRepos:  []string{s.independent, s.suppressed},
+		Now:        migrateNow,
+	}
+	return s
+}
+
+// effective reports the pack identities a session in repo would load.
+func (s *migrateScene) effective(t *testing.T, repo string) []string {
+	t.Helper()
+	census, err := foreign.TakeCensus(s.configDir, "vsdd-factory")
+	if err != nil {
+		t.Fatal(err)
+	}
+	view, err := census.ResolveRepo(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return view.EffectivelyEnabled
+}
+
+func (s *migrateScene) planFor(t *testing.T, out *MigrationOutcome, repo string) RepoPlan {
+	t.Helper()
+	for _, p := range out.Repos {
+		if p.Dir == repo {
+			return p
+		}
+	}
+	t.Fatalf("%s is not in the sweep set: %+v", repo, out.Repos)
+	return RepoPlan{}
+}
+
+func TestMigrateUserScope_PinsOnlyDependentRepos(t *testing.T) {
+	t.Parallel()
+	s := newMigrateScene(t)
+
+	pre := map[string][]string{}
+	for _, repo := range []string{s.target, s.dependent, s.independent, s.suppressed} {
+		pre[repo] = s.effective(t, repo)
+	}
+
+	s.opts.Consented = true
+	out, err := MigrateUserScope(s.opts)
+	if err != nil {
+		t.Fatalf("MigrateUserScope: %v", err)
+	}
+	if !out.Applied {
+		t.Fatal("migration reported not applied")
+	}
+	if out.Pinned != 2 {
+		t.Errorf("pinned %d repos, want 2 (target + dependent)", out.Pinned)
+	}
+
+	tests := []struct {
+		name    string
+		repo    string
+		wantPin bool
+	}{
+		{"adoption target", s.target, true},
+		{"ledger repo on the machine-wide enable", s.dependent, true},
+		{"repo enabled at project scope", s.independent, false},
+		{"repo that suppresses the identity", s.suppressed, false},
+	}
+	for _, tc := range tests {
+		plan := s.planFor(t, out, tc.repo)
+		if got := len(plan.Pin) > 0; got != tc.wantPin {
+			t.Errorf("%s: pinned = %v, want %v (plan %+v)", tc.name, got, tc.wantPin, plan)
+		}
+		if got := s.effective(t, tc.repo); strings.Join(got, ",") != strings.Join(pre[tc.repo], ",") {
+			t.Errorf("%s: effective enablement changed from %v to %v", tc.name, pre[tc.repo], got)
+		}
+	}
+
+	// The machine-wide entry is gone, and nothing else in the file is.
+	census, err := foreign.TakeCensus(s.configDir, "vsdd-factory")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ids := census.UserEnabledIdentities(); len(ids) != 0 {
+		t.Errorf("machine-wide enable survived: %v", ids)
+	}
+}
+
+// TestMigrateUserScope_TargetIsAdoptableAfterwards is the clause the
+// migration exists for: adopt refuses against a user-scope enable, and
+// this is what makes the refusal answerable.
+func TestMigrateUserScope_TargetIsAdoptableAfterwards(t *testing.T) {
+	t.Parallel()
+	s := newMigrateScene(t)
+
+	adoptOpts := Options{
+		RepoDir: s.target, Pack: "vsdd-factory",
+		LedgerPath: filepath.Join(t.TempDir(), "repo-bindings.yaml"),
+		ConfigDir:  s.configDir,
+		StoreRoot:  storeTree(t),
+		Prefix:     "vsdd",
+		BoundDir:   filepath.Join(t.TempDir(), "bound"),
+		Now:        migrateNow,
+	}
+	if _, err := Adopt(adoptOpts); err == nil || !strings.Contains(err.Error(), "USER scope") {
+		t.Fatalf("Adopt before migration = %v, want the user-scope refusal", err)
+	}
+
+	s.opts.Consented = true
+	if _, err := MigrateUserScope(s.opts); err != nil {
+		t.Fatalf("MigrateUserScope: %v", err)
+	}
+
+	out, err := Adopt(adoptOpts)
+	if err != nil {
+		t.Fatalf("Adopt after migration: %v", err)
+	}
+	if !out.Suppressed {
+		t.Error("adoption did not suppress the foreign identity")
+	}
+	if len(out.FootprintDrift) != 0 {
+		t.Errorf("adoption changed machine-level state: %v", out.FootprintDrift)
+	}
+}
+
+func TestMigrateUserScope_DryRunWritesNothing(t *testing.T) {
+	t.Parallel()
+	s := newMigrateScene(t)
+	s.opts.DryRun = true
+
+	before := map[string]map[string]string{}
+	for _, dir := range []string{s.configDir, s.target, s.dependent, s.independent, s.suppressed} {
+		before[dir] = snapshotDir(t, dir)
+	}
+
+	out, err := MigrateUserScope(s.opts)
+	if err != nil {
+		t.Fatalf("dry run: %v", err)
+	}
+	if out.Applied {
+		t.Error("dry run reported the migration applied")
+	}
+	if out.Pinned != 2 {
+		t.Errorf("dry run planned %d pins, want 2", out.Pinned)
+	}
+	for dir, snap := range before {
+		if diff := diffSnapshots(snap, snapshotDir(t, dir)); len(diff) != 0 {
+			t.Errorf("dry run wrote into %s: %v", dir, diff)
+		}
+	}
+}
+
+func TestMigrateUserScope_RefusesWithoutConsent(t *testing.T) {
+	t.Parallel()
+	s := newMigrateScene(t)
+	before := snapshotDir(t, s.target)
+
+	_, err := MigrateUserScope(s.opts)
+	if err == nil || !strings.Contains(err.Error(), "needs consent") {
+		t.Fatalf("MigrateUserScope = %v, want a consent refusal", err)
+	}
+	if diff := diffSnapshots(before, snapshotDir(t, s.target)); len(diff) != 0 {
+		t.Errorf("unconsented run wrote into the repo: %v", diff)
+	}
+}
+
+func TestMigrateUserScope_Refusals(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		mutate  func(t *testing.T, s *migrateScene)
+		wantErr string
+	}{
+		{
+			name: "no machine-wide enable to migrate",
+			mutate: func(t *testing.T, s *migrateScene) {
+				mustWrite(t, s.configDir, "settings.json", `{"enabledPlugins": {}}`, 0o644)
+			},
+			wantErr: "no user-scope enable",
+		},
+		{
+			name:    "project scope without commit consent",
+			mutate:  func(t *testing.T, s *migrateScene) { s.opts.Scope = foreign.ScopeProject },
+			wantErr: "--commit-consent",
+		},
+		{
+			name: "unknown scope",
+			mutate: func(t *testing.T, s *migrateScene) {
+				s.opts.Scope = foreign.ScopeUser
+			},
+			wantErr: "not \"user\"",
+		},
+		{
+			name: "a factory run in flight anywhere in the sweep",
+			mutate: func(t *testing.T, s *migrateScene) {
+				// The lock is in a swept repo that is NOT the target, so
+				// this also pins that the sweep reaches past the target.
+				mustWrite(t, s.dependent, ".factory/STATE.md",
+					"---\nfactory_lock:\n  holder: dev@example.com\n  locked_at: "+
+						migrateNow.Add(-10*time.Minute).Format(time.RFC3339)+
+						"\n  expires_at: "+migrateNow.Add(30*time.Minute).Format(time.RFC3339)+
+						"\n---\n\n# Factory State\n", 0o644)
+			},
+			wantErr: "blocker",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			s := newMigrateScene(t)
+			s.opts.Consented = true
+			tc.mutate(t, s)
+			before := snapshotDir(t, s.configDir)
+
+			_, err := MigrateUserScope(s.opts)
+			if err == nil {
+				t.Fatalf("MigrateUserScope succeeded, want a refusal naming %q", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("MigrateUserScope = %v, want it to name %q", err, tc.wantErr)
+			}
+			if diff := diffSnapshots(before, snapshotDir(t, s.configDir)); len(diff) != 0 {
+				t.Errorf("refusal changed machine state: %v", diff)
+			}
+		})
+	}
+}
+
+// TestMigrateUserScope_DryRunPredictsAnUnwritableSettingsFile is the
+// F099-a lesson applied to this verb: a dry run validates every step of
+// the plan it prints, so an unwritable settings file is reported before
+// the operator consents rather than discovered halfway through.
+func TestMigrateUserScope_DryRunPredictsAnUnwritableSettingsFile(t *testing.T) {
+	t.Parallel()
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores the write bit")
+	}
+	s := newMigrateScene(t)
+	s.opts.DryRun = true
+
+	// The dependent repo gets a settings file nobody can write.
+	mustWrite(t, s.dependent, ".claude/settings.local.json", `{}`, 0o400)
+	t.Cleanup(func() {
+		_ = os.Chmod(filepath.Join(s.dependent, ".claude", "settings.local.json"), 0o644)
+	})
+
+	out, err := MigrateUserScope(s.opts)
+	if err == nil {
+		t.Fatal("dry run promised success for a plan whose pin cannot be written")
+	}
+	if !strings.Contains(err.Error(), "blocker") {
+		t.Errorf("dry run error = %v, want it to report blockers", err)
+	}
+	var found bool
+	for _, b := range out.Blockers {
+		if strings.Contains(b, s.dependent) && strings.Contains(b, "not writable") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("blockers do not name the unwritable pin: %v", out.Blockers)
+	}
+}
+
+func TestMigrateUserScope_ProjectScopeWritesTheTrackedFile(t *testing.T) {
+	t.Parallel()
+	s := newMigrateScene(t)
+	s.opts.Scope = foreign.ScopeProject
+	s.opts.CommitConsent = true
+	s.opts.Consented = true
+
+	if _, err := MigrateUserScope(s.opts); err != nil {
+		t.Fatalf("MigrateUserScope: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(s.target, ".claude", "settings.json"))
+	if err != nil {
+		t.Fatalf("project-scope pin not written: %v", err)
+	}
+	var settings map[string]any
+	if err := json.Unmarshal(data, &settings); err != nil {
+		t.Fatal(err)
+	}
+	enables, _ := settings["enabledPlugins"].(map[string]any)
+	if v, ok := enables["vsdd-factory@claude-mp"].(bool); !ok || !v {
+		t.Errorf("project-scope pin = %v, want true", enables)
+	}
+	if _, err := os.Stat(filepath.Join(s.target, ".claude", "settings.local.json")); !os.IsNotExist(err) {
+		t.Error("project scope also wrote the local settings file")
+	}
+}
+
+func TestUndoLog_RestoresPriorState(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	existing := filepath.Join(dir, "existing.json")
+	if err := os.WriteFile(existing, []byte(`{"enabledPlugins": {"a@mp": true}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	fresh := filepath.Join(dir, "fresh", "settings.local.json")
+
+	prior, err := foreign.ReadEnable(existing, "a@mp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := foreign.SetEnable(existing, "a@mp", false); err != nil {
+		t.Fatal(err)
+	}
+	created, err := foreign.SetEnable(fresh, "b@mp", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var undo undoLog
+	undo.add(existing, "a@mp", prior, false)
+	undo.add(fresh, "b@mp", foreign.EnableEntry{Path: fresh}, created)
+	undo.run()
+
+	restored, err := foreign.ReadEnable(existing, "a@mp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !restored.Present || !restored.Value {
+		t.Errorf("prior value not restored: %+v", restored)
+	}
+	if _, err := os.Stat(fresh); !os.IsNotExist(err) {
+		t.Errorf("file sideshow created was not removed: %v", err)
+	}
+}
+
+func TestFindGitCheckouts(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	for _, rel := range []string{
+		"orc/repo-a/.git/HEAD",
+		"orc/repo-b/.git/HEAD",
+		"orc/repo-b/nested/.git/HEAD", // not descended into
+		"orc/notarepo/README.md",
+		".hidden/repo-c/.git/HEAD", // hidden roots are skipped
+	} {
+		mustWrite(t, root, rel, "ref: refs/heads/main\n", 0o644)
+	}
+
+	found, err := findGitCheckouts(root, 3)
+	if err != nil {
+		t.Fatalf("findGitCheckouts: %v", err)
+	}
+	want := []string{filepath.Join(root, "orc", "repo-a"), filepath.Join(root, "orc", "repo-b")}
+	if strings.Join(found, ",") != strings.Join(want, ",") {
+		t.Errorf("findGitCheckouts = %v, want %v", found, want)
+	}
+
+	if _, err := findGitCheckouts(filepath.Join(root, "orc", "notarepo", "README.md"), 3); err == nil {
+		t.Error("findGitCheckouts accepted a file as a sweep root")
+	}
+}
+
+func TestReportMarketplaces(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		registry string
+		want     string
+		notWant  string
+	}{
+		{
+			name:     "sole plugin: removal is decided safe",
+			registry: `{"version": 2, "plugins": {"vsdd-factory@claude-mp": [{"scope": "user"}]}}`,
+			want:     "removal is safe",
+			notWant:  "KEEP",
+		},
+		{
+			name: "shared marketplace: keep it, and say what would break",
+			registry: `{"version": 2, "plugins": {
+			  "vsdd-factory@claude-mp": [{"scope": "user"}],
+			  "other-pack@claude-mp": [{"scope": "user"}]
+			}}`,
+			want:    "KEEP",
+			notWant: "removal is safe",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			configDir := t.TempDir()
+			mustWrite(t, configDir, "plugins/installed_plugins.json", tc.registry, 0o644)
+			census, err := foreign.TakeCensus(configDir, "vsdd-factory")
+			if err != nil {
+				t.Fatal(err)
+			}
+			var buf bytes.Buffer
+			reportMarketplaces(&buf, census)
+			if !strings.Contains(buf.String(), tc.want) {
+				t.Errorf("report missing %q:\n%s", tc.want, buf.String())
+			}
+			if strings.Contains(buf.String(), tc.notWant) {
+				t.Errorf("report contains %q it should not:\n%s", tc.notWant, buf.String())
+			}
+		})
+	}
+}
+
+// storeTree lays down a sideshow store version dir matching the foreign
+// cache tree, so an adoption run after a migration has something to
+// enable.
+func storeTree(t *testing.T) string {
+	t.Helper()
+	store := filepath.Join(t.TempDir(), "1.0.0-rc.23")
+	writeTree(t, store, platform(t))
+	return store
+}

--- a/internal/foreign/census.go
+++ b/internal/foreign/census.go
@@ -3,10 +3,18 @@
 // delivers by repo bindings. It is the conversion-side surface behind
 // the coexistence guard (aae-orc-paqn), coexist-check, and adopt.
 //
-// Everything in this package is READ-ONLY. Sideshow never
-// auto-retires, auto-disables, or auto-uninstalls a foreign install;
-// mutations of foreign state happen only through documented claude
-// verbs with explicit consent, outside this package.
+// The census, resolution, and diagnosis surfaces are READ-ONLY.
+// Sideshow never auto-retires or auto-uninstalls a foreign install:
+// removing a plugin, purging its cache, and retiring its marketplace
+// happen only through documented claude verbs the operator runs.
+//
+// Two consented WRITE surfaces exist, both narrow and both reachable
+// only from a verb that asked first: the repo-side suppression override
+// (suppress.go, adopt step 1) and the scope-general enabledPlugins
+// writers (enables.go) the user-scope migration uses to move a
+// machine-wide enable per repo. Both touch enabledPlugins entries in
+// settings files and nothing else, which is the class-3 allowlist from
+// the preserve taxonomy. Neither touches an install tree.
 //
 // Ground truth for every parsed shape: aae-orc finding-091 addendum 3
 // (executed trials, Claude Code 2.1.220) and
@@ -77,6 +85,11 @@ type Census struct {
 	Installs    []Install
 	userEnables map[string]enableEntry // identity -> user-scope entry
 	installed   map[string]bool        // identity -> has install record
+	// marketplaces maps marketplace name -> every plugin name it serves
+	// on this machine, the census pack included. Retiring a marketplace
+	// turns on what ELSE it serves, so this one field looks past the
+	// pack filter the rest of the census applies.
+	marketplaces map[string][]string
 }
 
 // legacyMarketplaces are marketplace names whose identities predate
@@ -156,10 +169,11 @@ func treeVersion(installPath string) string {
 // detection rule), plus the user-scope enable entries.
 func TakeCensus(configDir, pack string) (*Census, error) {
 	c := &Census{
-		Pack:        pack,
-		ConfigDir:   configDir,
-		userEnables: map[string]enableEntry{},
-		installed:   map[string]bool{},
+		Pack:         pack,
+		ConfigDir:    configDir,
+		userEnables:  map[string]enableEntry{},
+		installed:    map[string]bool{},
+		marketplaces: map[string][]string{},
 	}
 
 	regPath := filepath.Join(configDir, "plugins", "installed_plugins.json")
@@ -176,6 +190,9 @@ func TakeCensus(configDir, pack string) (*Census, error) {
 		}
 		for identity, entries := range reg.Plugins {
 			plugin, mp := splitIdentity(identity)
+			if mp != "" {
+				c.marketplaces[mp] = append(c.marketplaces[mp], plugin)
+			}
 			if plugin != pack {
 				continue
 			}

--- a/internal/foreign/enables.go
+++ b/internal/foreign/enables.go
@@ -1,0 +1,238 @@
+package foreign
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// Scope names a settings file in the harness precedence chain.
+const (
+	ScopeLocal   = "local"
+	ScopeProject = "project"
+	ScopeUser    = "user"
+)
+
+// EnableKey is the settings key carrying per-identity plugin
+// enablement. Exported so operator-facing text elsewhere can name the
+// key it is about to change without spelling the literal: the policy
+// guard in cmd/sideshow confines plugin-delivery strings to this
+// package, and a message that says "some entries" is worse than no
+// message.
+const EnableKey = "enabledPlugins"
+
+// SettingsPath returns the settings file for a scope. repoDir is
+// ignored for user scope, configDir for the two repo scopes.
+func SettingsPath(repoDir, configDir, scope string) (string, error) {
+	switch scope {
+	case ScopeLocal:
+		return filepath.Join(repoDir, ".claude", "settings.local.json"), nil
+	case ScopeProject:
+		return filepath.Join(repoDir, ".claude", "settings.json"), nil
+	case ScopeUser:
+		return filepath.Join(configDir, "settings.json"), nil
+	default:
+		return "", fmt.Errorf("unknown settings scope %q (want local, project, or user)", scope)
+	}
+}
+
+// EnableEntry is one settings file's verdict for an identity, with the
+// file that carries it. A caller restoring a prior posture needs both.
+type EnableEntry struct {
+	Present bool
+	Value   bool
+	Path    string
+}
+
+// ReadEnable reports the identity's explicit entry in one settings
+// file. A missing file or a missing key is Present=false.
+func ReadEnable(path, identity string) (EnableEntry, error) {
+	entries, err := readEnables(path)
+	if err != nil {
+		return EnableEntry{}, err
+	}
+	e, ok := entries[identity]
+	if !ok {
+		return EnableEntry{Path: path}, nil
+	}
+	return EnableEntry{Present: true, Value: e.value, Path: path}, nil
+}
+
+// SetEnable writes enabledPlugins[identity] = value into one settings
+// file, preserving every other key, and reports whether the file had
+// to be created.
+//
+// This is a consented write: callers reach it only from a verb that
+// asked (adopt's suppression, the user-scope migration). Nothing here
+// touches a foreign install, its cache, or its marketplace.
+func SetEnable(path, identity string, value bool) (created bool, err error) {
+	settings, existed, err := readSettingsObject(path)
+	if err != nil {
+		return false, err
+	}
+	enables, err := enabledPluginsObject(settings, path)
+	if err != nil {
+		return false, err
+	}
+	enables[identity] = value
+	settings["enabledPlugins"] = enables
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return false, fmt.Errorf("create settings dir for %s: %w", path, err)
+	}
+	return !existed, writeSettingsObject(path, settings)
+}
+
+// DeleteEnable removes the identity's entry from one settings file
+// whatever its value, pruning an emptied enabledPlugins object. Use it
+// to reverse SetEnable; UnsuppressInRepo is the narrower form that
+// refuses to touch a true the user chose.
+//
+// Removing the last key never removes the FILE: deciding a settings
+// file has no reason to exist belongs to the caller that created it,
+// which is the only party that knows.
+func DeleteEnable(path, identity string) (removed bool, err error) {
+	settings, existed, err := readSettingsObject(path)
+	if err != nil {
+		return false, err
+	}
+	if !existed {
+		return false, nil
+	}
+	enables, err := enabledPluginsObject(settings, path)
+	if err != nil {
+		return false, err
+	}
+	if _, ok := enables[identity]; !ok {
+		return false, nil
+	}
+	delete(enables, identity)
+	if len(enables) == 0 {
+		delete(settings, "enabledPlugins")
+	} else {
+		settings["enabledPlugins"] = enables
+	}
+	return true, writeSettingsObject(path, settings)
+}
+
+// CanWriteSettings reports why SetEnable would fail against path,
+// without writing anything at all: an unparseable file, an
+// enabledPlugins key of the wrong shape, a file that cannot be opened
+// for writing, or a directory the write would have to be created under
+// that refuses new entries. A dry run calls it so it validates the step
+// it prints rather than only the step before it.
+//
+// It creates nothing, not even the parent directory SetEnable would
+// make, because a dry run that leaves a new .claude/ behind has already
+// written. For a path whose parents do not exist yet, that costs
+// exactness: the nearest existing ancestor is checked by mode bit
+// rather than by attempting a write, so an ACL or an ownership quirk
+// that a real write would trip can still get past here.
+func CanWriteSettings(path string) error {
+	settings, existed, err := readSettingsObject(path)
+	if err != nil {
+		return err
+	}
+	if _, err := enabledPluginsObject(settings, path); err != nil {
+		return err
+	}
+	if existed {
+		f, err := os.OpenFile(path, os.O_WRONLY, 0o644)
+		if err != nil {
+			return fmt.Errorf("settings %s is not writable: %w", path, err)
+		}
+		if err := f.Close(); err != nil {
+			return fmt.Errorf("close %s after the write check: %w", path, err)
+		}
+		return nil
+	}
+
+	dir := filepath.Dir(path)
+	for {
+		info, statErr := os.Stat(dir)
+		switch {
+		case statErr == nil && !info.IsDir():
+			return fmt.Errorf("settings %s cannot be written: %s is not a directory", path, dir)
+		case statErr == nil && info.Mode().Perm()&0o200 == 0:
+			return fmt.Errorf("settings %s cannot be written: %s is not writable (mode %s)", path, dir, info.Mode().Perm())
+		case statErr == nil:
+			return nil
+		case !os.IsNotExist(statErr):
+			return fmt.Errorf("stat %s on the way to %s: %w", dir, path, statErr)
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return fmt.Errorf("settings %s cannot be written: no existing directory above it", path)
+		}
+		dir = parent
+	}
+}
+
+// UserEnabledIdentities returns the census pack's identities carrying a
+// user-scope enable set to true, sorted. This is the machine-wide
+// posture a per-repo-required pack must not be left in.
+func (c *Census) UserEnabledIdentities() []string {
+	var out []string
+	for id, e := range c.userEnables {
+		if plugin, _ := splitIdentity(id); plugin == c.Pack && e.value {
+			out = append(out, id)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// UserEnablePath returns the settings file carrying the identity's
+// user-scope entry, empty when there is none.
+func (c *Census) UserEnablePath(identity string) string {
+	return c.userEnables[identity].path
+}
+
+// WithoutUserEnables returns a census identical to c but with the named
+// identities' user-scope entries dropped. Resolving a repo against it
+// answers the question the migration turns on: would this repo still
+// load the foreign channel if the machine-wide enable were gone?
+//
+// Install records are shared, not copied. Nothing mutates them.
+func (c *Census) WithoutUserEnables(identities []string) *Census {
+	drop := make(map[string]bool, len(identities))
+	for _, id := range identities {
+		drop[id] = true
+	}
+	clone := &Census{
+		Pack:        c.Pack,
+		ConfigDir:   c.ConfigDir,
+		Installs:    c.Installs,
+		userEnables: make(map[string]enableEntry, len(c.userEnables)),
+		installed:   c.installed,
+	}
+	for id, e := range c.userEnables {
+		if !drop[id] {
+			clone.userEnables[id] = e
+		}
+	}
+	return clone
+}
+
+// MarketplaceSiblings returns the OTHER plugin names the marketplace
+// serves on this machine, sorted. Empty means the marketplace serves
+// only the census pack, which is the condition under which removing it
+// is safe (aae-orc-d3nq.22 clause e).
+//
+// Read from the install registry rather than the marketplace metadata:
+// what matters is what would break, and that is what is installed.
+func (c *Census) MarketplaceSiblings(marketplace string) []string {
+	seen := map[string]bool{}
+	for _, plugin := range c.marketplaces[marketplace] {
+		if plugin == c.Pack || seen[plugin] {
+			continue
+		}
+		seen[plugin] = true
+	}
+	out := make([]string, 0, len(seen))
+	for plugin := range seen {
+		out = append(out, plugin)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/foreign/enables_test.go
+++ b/internal/foreign/enables_test.go
@@ -1,0 +1,333 @@
+package foreign
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSettingsPath(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		scope   string
+		want    string
+		wantErr bool
+	}{
+		{ScopeLocal, filepath.Join("repo", ".claude", "settings.local.json"), false},
+		{ScopeProject, filepath.Join("repo", ".claude", "settings.json"), false},
+		{ScopeUser, filepath.Join("config", "settings.json"), false},
+		{"machine", "", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.scope, func(t *testing.T) {
+			t.Parallel()
+			got, err := SettingsPath("repo", "config", tc.scope)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("SettingsPath(%q) error = %v, wantErr %v", tc.scope, err, tc.wantErr)
+			}
+			if got != tc.want {
+				t.Errorf("SettingsPath(%q) = %q, want %q", tc.scope, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSetEnable_RoundTripPreservesSiblings(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), ".claude", "settings.local.json")
+
+	created, err := SetEnable(path, "vsdd-factory@claude-mp", true)
+	if err != nil {
+		t.Fatalf("SetEnable: %v", err)
+	}
+	if !created {
+		t.Error("created=false for a file that did not exist")
+	}
+	entry, err := ReadEnable(path, "vsdd-factory@claude-mp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !entry.Present || !entry.Value || entry.Path != path {
+		t.Errorf("ReadEnable = %+v, want present true at %s", entry, path)
+	}
+
+	// A second identity and an unrelated key must both survive a delete.
+	if _, err := SetEnable(path, "other@mp", false); err != nil {
+		t.Fatal(err)
+	}
+	settings, _, err := readSettingsObject(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	settings["env"] = map[string]any{"KEPT": "yes"}
+	if err := writeSettingsObject(path, settings); err != nil {
+		t.Fatal(err)
+	}
+
+	removed, err := DeleteEnable(path, "vsdd-factory@claude-mp")
+	if err != nil || !removed {
+		t.Fatalf("DeleteEnable = %v, %v", removed, err)
+	}
+	after, _, err := readSettingsObject(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := after["env"]; !ok {
+		t.Errorf("unrelated key dropped: %v", after)
+	}
+	enables, _ := after["enabledPlugins"].(map[string]any)
+	if _, still := enables["vsdd-factory@claude-mp"]; still {
+		t.Errorf("entry survived deletion: %v", enables)
+	}
+	if _, sibling := enables["other@mp"]; !sibling {
+		t.Errorf("sibling identity dropped: %v", enables)
+	}
+}
+
+func TestDeleteEnable_PrunesEmptiedObjectButKeepsTheFile(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), ".claude", "settings.local.json")
+	if _, err := SetEnable(path, "vsdd-factory@claude-mp", true); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := DeleteEnable(path, "vsdd-factory@claude-mp"); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("file removed by DeleteEnable: %v", err)
+	}
+	var settings map[string]any
+	if err := json.Unmarshal(data, &settings); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := settings["enabledPlugins"]; ok {
+		t.Errorf("emptied object not pruned: %s", data)
+	}
+}
+
+func TestDeleteEnable_MissingFileAndMissingKey(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	removed, err := DeleteEnable(filepath.Join(dir, "absent.json"), "vsdd-factory@claude-mp")
+	if err != nil || removed {
+		t.Errorf("DeleteEnable on a missing file = %v, %v; want false, nil", removed, err)
+	}
+
+	path := filepath.Join(dir, "settings.json")
+	if err := os.WriteFile(path, []byte(`{"enabledPlugins": {"other@mp": true}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	removed, err = DeleteEnable(path, "vsdd-factory@claude-mp")
+	if err != nil || removed {
+		t.Errorf("DeleteEnable on a missing key = %v, %v; want false, nil", removed, err)
+	}
+}
+
+func TestCanWriteSettings(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		setup   func(t *testing.T, dir string) string
+		wantErr string
+	}{
+		{
+			name: "absent file in a writable dir",
+			setup: func(t *testing.T, dir string) string {
+				return filepath.Join(dir, ".claude", "settings.local.json")
+			},
+		},
+		{
+			name: "existing writable file",
+			setup: func(t *testing.T, dir string) string {
+				path := filepath.Join(dir, "settings.json")
+				if err := os.WriteFile(path, []byte(`{}`), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				return path
+			},
+		},
+		{
+			name: "unparseable file",
+			setup: func(t *testing.T, dir string) string {
+				path := filepath.Join(dir, "settings.json")
+				if err := os.WriteFile(path, []byte(`{not json`), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				return path
+			},
+			wantErr: "refusing to merge",
+		},
+		{
+			name: "enabledPlugins of the wrong shape",
+			setup: func(t *testing.T, dir string) string {
+				path := filepath.Join(dir, "settings.json")
+				if err := os.WriteFile(path, []byte(`{"enabledPlugins": ["a"]}`), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				return path
+			},
+			wantErr: "not an object",
+		},
+		{
+			name: "read-only file",
+			setup: func(t *testing.T, dir string) string {
+				if os.Geteuid() == 0 {
+					t.Skip("root ignores the write bit")
+				}
+				path := filepath.Join(dir, "settings.json")
+				if err := os.WriteFile(path, []byte(`{}`), 0o400); err != nil {
+					t.Fatal(err)
+				}
+				return path
+			},
+			wantErr: "not writable",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			path := tc.setup(t, t.TempDir())
+			err := CanWriteSettings(path)
+			switch {
+			case tc.wantErr == "" && err != nil:
+				t.Fatalf("CanWriteSettings = %v, want nil", err)
+			case tc.wantErr != "" && err == nil:
+				t.Fatalf("CanWriteSettings = nil, want %q", tc.wantErr)
+			case tc.wantErr != "" && !strings.Contains(err.Error(), tc.wantErr):
+				t.Errorf("CanWriteSettings = %v, want it to name %q", err, tc.wantErr)
+			}
+			// Validation must not write, and that includes the parent
+			// directory SetEnable would create: a dry run that leaves a
+			// new .claude/ behind has already written.
+			if tc.name == "absent file in a writable dir" {
+				for _, absent := range []string{path, filepath.Dir(path)} {
+					if _, statErr := os.Stat(absent); !os.IsNotExist(statErr) {
+						t.Errorf("validation created %s", absent)
+					}
+				}
+			}
+		})
+	}
+}
+
+// censusFixture writes a harness config dir with the given install
+// registry and user settings, and returns a census for pack.
+func censusFixture(t *testing.T, pack, registry, userSettings string) *Census {
+	t.Helper()
+	dir := t.TempDir()
+	if registry != "" {
+		if err := os.MkdirAll(filepath.Join(dir, "plugins"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "plugins", "installed_plugins.json"), []byte(registry), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if userSettings != "" {
+		if err := os.WriteFile(filepath.Join(dir, "settings.json"), []byte(userSettings), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	c, err := TakeCensus(dir, pack)
+	if err != nil {
+		t.Fatalf("TakeCensus: %v", err)
+	}
+	return c
+}
+
+func TestCensus_UserEnabledIdentities(t *testing.T) {
+	t.Parallel()
+	c := censusFixture(t, "vsdd-factory", "", `{"enabledPlugins": {
+	  "vsdd-factory@claude-mp": true,
+	  "vsdd-factory@vsdd-factory": false,
+	  "other@claude-mp": true
+	}}`)
+	got := c.UserEnabledIdentities()
+	if len(got) != 1 || got[0] != "vsdd-factory@claude-mp" {
+		t.Errorf("UserEnabledIdentities = %v, want only the pack's true entry", got)
+	}
+	if path := c.UserEnablePath("vsdd-factory@claude-mp"); !strings.HasSuffix(path, "settings.json") {
+		t.Errorf("UserEnablePath = %q, want the user settings file", path)
+	}
+}
+
+// TestCensus_WithoutUserEnables covers the counterfactual the migration
+// turns on: with the machine-wide entry gone, does this repo still load
+// the foreign channel?
+func TestCensus_WithoutUserEnables(t *testing.T) {
+	t.Parallel()
+	reg := `{"version": 2, "plugins": {"vsdd-factory@claude-mp": [{"scope": "user", "installPath": "/tmp/x", "version": "1.0.0"}]}}`
+	c := censusFixture(t, "vsdd-factory", reg, `{"enabledPlugins": {"vsdd-factory@claude-mp": true}}`)
+
+	dependent := t.TempDir()
+	independent := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(independent, ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(independent, ".claude", "settings.json"),
+		[]byte(`{"enabledPlugins": {"vsdd-factory@claude-mp": true}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	after := c.WithoutUserEnables([]string{"vsdd-factory@claude-mp"})
+	if ids := after.UserEnabledIdentities(); len(ids) != 0 {
+		t.Errorf("clone still carries user enables: %v", ids)
+	}
+	if ids := c.UserEnabledIdentities(); len(ids) != 1 {
+		t.Errorf("original census mutated: %v", ids)
+	}
+
+	for _, tc := range []struct {
+		name        string
+		repo        string
+		wantEnabled bool
+	}{
+		{"depends on the machine-wide enable", dependent, false},
+		{"enabled independently at project scope", independent, true},
+	} {
+		view, err := after.ResolveRepo(tc.repo)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := len(view.EffectivelyEnabled) > 0; got != tc.wantEnabled {
+			t.Errorf("%s: enabled without user scope = %v, want %v", tc.name, got, tc.wantEnabled)
+		}
+	}
+}
+
+func TestCensus_MarketplaceSiblings(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		registry string
+		want     []string
+	}{
+		{
+			name:     "sole plugin",
+			registry: `{"version": 2, "plugins": {"vsdd-factory@claude-mp": [{"scope": "user"}]}}`,
+			want:     nil,
+		},
+		{
+			name: "shares the marketplace",
+			registry: `{"version": 2, "plugins": {
+			  "vsdd-factory@claude-mp": [{"scope": "user"}],
+			  "other-pack@claude-mp": [{"scope": "user"}],
+			  "elsewhere@another-mp": [{"scope": "user"}]
+			}}`,
+			want: []string{"other-pack"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			c := censusFixture(t, "vsdd-factory", tc.registry, "")
+			got := c.MarketplaceSiblings("claude-mp")
+			if strings.Join(got, ",") != strings.Join(tc.want, ",") {
+				t.Errorf("MarketplaceSiblings = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/foreign/suppress.go
+++ b/internal/foreign/suppress.go
@@ -7,37 +7,25 @@ import (
 	"path/filepath"
 )
 
-// SuppressInRepo and UnsuppressInRepo are the ONE consented write in
-// this otherwise read-only package: they set (or remove) a repo-side
+// SuppressInRepo and UnsuppressInRepo set (or remove) a repo-side
 // enabledPlugins override in the CONSUMER repo's
 // .claude/settings.local.json. This is exactly option 2 of the
 // refusal menu (RefusalOptions) and the T10 trial mechanism: a
 // project/local false beats a user-scope true, so the foreign
 // identity stops dispatching in THIS repo only. Nothing here touches
-// harness state, the foreign install, its cache, or any other repo —
-// paqn clause (d) holds: sideshow never auto-disables or
-// auto-uninstalls a foreign install; these run only inside explicit,
-// consented verbs (adopt).
+// the foreign install, its cache, or any other repo. Paqn clause (d)
+// holds: sideshow never auto-disables or auto-uninstalls a foreign
+// install; these run only inside explicit, consented verbs (adopt).
+//
+// The scope-general writers live in enables.go; these two are the
+// narrow repo-suppression pair, kept separate because Unsuppress
+// deliberately refuses to touch a true value the user chose.
 
 // SuppressInRepo writes enabledPlugins[identity] = false into the
 // repo's settings.local.json, preserving every other key. Reports
 // whether the file was created.
 func SuppressInRepo(repoDir, identity string) (created bool, err error) {
-	path := localSettingsPath(repoDir)
-	settings, existed, err := readSettingsObject(path)
-	if err != nil {
-		return false, err
-	}
-	enables, err := enabledPluginsObject(settings, path)
-	if err != nil {
-		return false, err
-	}
-	enables[identity] = false
-	settings["enabledPlugins"] = enables
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return false, fmt.Errorf("create settings dir: %w", err)
-	}
-	return !existed, writeSettingsObject(path, settings)
+	return SetEnable(localSettingsPath(repoDir), identity, false)
 }
 
 // UnsuppressInRepo removes the identity's override only when it is


### PR DESCRIPTION
A consumer whose vsdd-factory plugin is enabled machine-wide currently cannot adopt any repo: adopt refuses the user-scope enable (correctly, since converting one repo would leave every other repo on the machine in the posture the containment mandate grades an error), and the refusal pointed at hand-editing settings files with nothing checking the result. This closes the last gap in the conversion toolkit for that consumer, and fixes a rollback defect that shape exposes.

## What changed

`sideshow adopt <pack> --migrate-user-scope` moves the machine-wide enable to per-repo enables:

1. Pin the foreign channel in each swept repo that DEPENDS on the machine-wide enable. A repo enabled independently gets no write; a repo that suppresses the identity gets no write. The dependency is computed against a counterfactual census (the machine with the entry gone), not inferred from install records.
2. Remove the machine-wide entry.
3. Verify against disk, per repo, that removing it changed nothing. Any mismatch, or a factory run in flight in any swept repo, rolls the whole migration back through an undo log that restores prior values exactly.

The sweep set is disclosed rather than guessed: adoption target, sideshow ledger repos, harness-recorded project-scope installs, plus `--also-repo <path>` and `--sweep-root <dir>`. The plan prints the limit plainly, because sideshow cannot enumerate every repo on a machine and only the operator can finish that list. Consent is `--yes` after a printed plan, never an unanswered prompt (sideshow#94). Per-repo enables land in `settings.local.json`; `--scope project` writes the tracked file and also requires `--commit-consent`.

**Rollback fix.** A repo already carrying a per-repo enable has a `true` in the very key adopt's suppression overwrites, and rollback deleted the key instead of restoring the value, switching the foreign channel off in a repo nobody converted. That shape predates this branch (any hand-written local enable had it) and the migration produces it by design, so it is fixed here. The created-file removal path now also calls the preserve floor.

Two smaller pieces: `adopt --finish` decides the marketplace-removal question from the install registry ("serves only vsdd-factory, so removal is safe" with the command, or "KEEP" naming what else it serves) instead of deferring it, and the dry-run write validator creates nothing, not even the parent directory a real write would make.

The executing half of `--finish` (uninstall per scope, cache purge, marketplace removal) stays print-only: it is gated behind `aae-orc-d3nq.20`, and no removal path for a store version exists yet.

## Tests

`go test ./...` green, `golangci-lint run ./...` reports 0 issues, gofmt clean. Test functions 270 to 289; cases including subtests 329 to 365.

The rollback regression test was verified failing against the pre-fix code (`repo not restored after rollback: [.claude/settings.local.json]`, `prior local enable not restored: map[]`) before the fix landed. The dry-run test caught a real bug during development: the write validator was creating `.claude/` directories, so a dry run wrote. Coverage includes the pin/no-pin decision across all four repo shapes, adopt succeeding on the target after migration, dry run writing nothing anywhere, four refusals (no machine-wide enable, project scope without commit consent, bad scope, factory lock in a swept repo that is not the target), the unwritable-settings prediction, project-scope pinning, the undo log, the sweep-root scanner, and the marketplace verdict both ways.

## Cost of merge

Additive. The one behavior change to an existing path is the rollback restoring a prior enable instead of deleting it, which is strictly closer to "repo exactly as found."