### PR TITLE
fix(pack): freeze installed store versions read-only; reinstall unlocks first

### DIFF
--- a/internal/pack/activate_test.go
+++ b/internal/pack/activate_test.go
@@ -18,7 +18,7 @@ func writePackYAML(t *testing.T, dir, version string) {
 }
 
 func TestActivateAndInstalledVersions(t *testing.T) {
-	t.Setenv("SIDESHOW_HOME", t.TempDir())
+	freezeSafeHome(t)
 
 	// Two installed versions, current pointing at 2.0.0.
 	for _, v := range []string{"1.0.0", "2.0.0"} {
@@ -76,7 +76,7 @@ func TestActivateAndInstalledVersions(t *testing.T) {
 }
 
 func TestInstallFromLocal_NoActivateKeepsCurrent(t *testing.T) {
-	t.Setenv("SIDESHOW_HOME", t.TempDir())
+	freezeSafeHome(t)
 
 	src1 := t.TempDir()
 	writePackYAML(t, src1, "1.0.0")

--- a/internal/pack/activation_test.go
+++ b/internal/pack/activation_test.go
@@ -122,8 +122,7 @@ func captureStdout(t *testing.T, fn func()) string {
 }
 
 func TestInstallFromLocal_PluginClassNoticeReplacesSyncHint(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("SIDESHOW_HOME", home)
+	freezeSafeHome(t)
 	src := t.TempDir()
 	packYAML := "name: vsdd-factory\nversion: \"1.0.0-rc.23\"\n" +
 		"activation:\n  default_scope: per-repo\n  per_repo_required: true\n" +
@@ -157,8 +156,7 @@ func TestInstallFromLocal_PluginClassNoticeReplacesSyncHint(t *testing.T) {
 }
 
 func TestInstallFromLocal_UnknownMechanismWarns(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("SIDESHOW_HOME", home)
+	freezeSafeHome(t)
 	src := t.TempDir()
 	packYAML := "name: mystery\nversion: \"1.0.0\"\n" +
 		"activation:\n  mechanism: quantum-entangle\n"

--- a/internal/pack/pack.go
+++ b/internal/pack/pack.go
@@ -394,7 +394,11 @@ func InstalledVersions(name string) (versions []string, active string, err error
 }
 
 // InstallFromLocal copies a pack from a local path to the sideshow directory.
-func InstallFromLocal(name, sourcePath string, activate bool) error {
+// The installed version tree is frozen read-only (aae-orc-dihj); a
+// reinstall over an existing frozen version unlocks it first, and the
+// tree refreezes on every exit, including failure, so a partial
+// install fails frozen rather than writable.
+func InstallFromLocal(name, sourcePath string, activate bool) (retErr error) {
 	// Expand ~ in source path
 	if strings.HasPrefix(sourcePath, "~/") {
 		home, _ := os.UserHomeDir()
@@ -440,6 +444,19 @@ func InstallFromLocal(name, sourcePath string, activate bool) error {
 	if err := os.MkdirAll(destDir, 0o755); err != nil {
 		return fmt.Errorf("create pack dir: %w", err)
 	}
+
+	// Unlock-write-refreeze envelope (aae-orc-dihj). A reinstall over a
+	// frozen version would otherwise EACCES on the first overwrite; the
+	// deferred freeze runs on every return path so the store is never
+	// left writable, including after a failed install.
+	if err := UnfreezeTree(destDir); err != nil {
+		return fmt.Errorf("unlock existing store version %s: %w", destDir, err)
+	}
+	defer func() {
+		if ferr := FreezeTree(destDir); ferr != nil && retErr == nil {
+			retErr = fmt.Errorf("freeze store %s: %w", destDir, ferr)
+		}
+	}()
 
 	// Copy content
 	count := 0
@@ -488,8 +505,10 @@ func InstallFromLocal(name, sourcePath string, activate bool) error {
 		}
 		// WriteFile applies perm only at create time (and subject to
 		// umask); force the exact source mode so exec bits survive
-		// reinstalls over an existing tree. Read-only store freeze
-		// (aae-orc-dihj) must map 0755 -> 0555 here, never 0444.
+		// reinstalls over an existing tree. The deferred FreezeTree
+		// strips write bits afterward, mapping 0755 -> 0555 and never
+		// 0444, because the freeze is a mask and this chmod is what
+		// preserves the exec bit it masks against.
 		if err := os.Chmod(destPath, perm); err != nil {
 			return fmt.Errorf("chmod %s: %w", destPath, err)
 		}
@@ -614,4 +633,63 @@ func List() ([]InstalledPack, error) {
 		return nil, err
 	}
 	return reg.Packs, nil
+}
+
+// FreezeTree strips every write bit under root: 0755 becomes 0555,
+// 0644 becomes 0444 — never 0444 for executables, because the mask
+// only removes write bits and leaves read and exec intact
+// (aae-orc-dihj). The store freezes WHOLE: no exemption, no
+// derived-layer chain, no integrity special case (finding-094 round
+// 3). The file mode is the only thing preventing an unauthorized
+// pack write today (finding-002 F8: no doctor verb, no content
+// hashing anywhere near pack content), so a write from a runtime
+// skill or a weave op fails loudly here instead of corrupting the
+// active version silently (finding-074).
+//
+// Symlinks are skipped: Chmod follows them, and a bridge link inside
+// the tree may point at user-owned content outside the store that
+// must not be frozen.
+func FreezeTree(root string) error {
+	return chmodTree(root, func(perm os.FileMode) os.FileMode {
+		return perm &^ 0o222
+	})
+}
+
+// UnfreezeTree restores owner write under root so install may replace
+// a frozen version and a future removal path may drop one. Any writer
+// of a declared-mutable store path must use the full
+// unlock-write-refreeze envelope: UnfreezeTree, write, then FreezeTree
+// in a defer so the tree refreezes even when the write fails
+// (aae-orc-dihj; consumers: reinstall here, uninstall aae-orc-d3nq.20,
+// weave runtime_links writes aae-orc-a3v6).
+func UnfreezeTree(root string) error {
+	return chmodTree(root, func(perm os.FileMode) os.FileMode {
+		return perm | 0o200
+	})
+}
+
+func chmodTree(root string, transform func(os.FileMode) os.FileMode) error {
+	return filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		// DirEntry.Info does not follow symlinks; skip them so the
+		// chmod (which does follow) cannot reach outside the tree.
+		if info.Mode()&os.ModeSymlink != 0 {
+			return nil
+		}
+		perm := info.Mode().Perm()
+		next := transform(perm)
+		if next == perm {
+			return nil
+		}
+		if err := os.Chmod(path, next); err != nil {
+			return fmt.Errorf("chmod %s: %w", path, err)
+		}
+		return nil
+	})
 }

--- a/internal/pack/pack_test.go
+++ b/internal/pack/pack_test.go
@@ -1,6 +1,7 @@
 package pack
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -34,7 +35,7 @@ func TestPacksDir(t *testing.T) {
 }
 
 func TestLoadRegistry_Empty(t *testing.T) {
-	t.Setenv("SIDESHOW_HOME", t.TempDir())
+	freezeSafeHome(t)
 	reg, err := LoadRegistry()
 	if err != nil {
 		t.Fatalf("LoadRegistry() error: %v", err)
@@ -45,7 +46,7 @@ func TestLoadRegistry_Empty(t *testing.T) {
 }
 
 func TestRegistrySaveAndLoad(t *testing.T) {
-	t.Setenv("SIDESHOW_HOME", t.TempDir())
+	freezeSafeHome(t)
 
 	reg := &Registry{
 		Packs: []InstalledPack{
@@ -241,9 +242,20 @@ func TestDetectVersion_MalformedJSON(t *testing.T) {
 	}
 }
 
-func TestInstallFromLocal(t *testing.T) {
+// freezeSafeHome sets SIDESHOW_HOME to a fresh temp dir and registers
+// a cleanup that unfreezes any frozen store trees first, so TempDir's
+// RemoveAll can delete them. Cleanups run LIFO: this one is registered
+// after TempDir's, so it runs before it.
+func freezeSafeHome(t *testing.T) string {
+	t.Helper()
 	home := t.TempDir()
 	t.Setenv("SIDESHOW_HOME", home)
+	t.Cleanup(func() { _ = UnfreezeTree(home) })
+	return home
+}
+
+func TestInstallFromLocal(t *testing.T) {
+	home := freezeSafeHome(t)
 
 	// Create a source pack with a manifest
 	src := t.TempDir()
@@ -374,7 +386,7 @@ func TestValidateShape_RejectsUnknownLayout(t *testing.T) {
 }
 
 func TestInstallFromLocal_RejectsSourceTarballShape(t *testing.T) {
-	t.Setenv("SIDESHOW_HOME", t.TempDir())
+	freezeSafeHome(t)
 
 	source := t.TempDir()
 	if err := os.WriteFile(filepath.Join(source, "package.json"), []byte(`{"version":"6.5.0"}`), 0o644); err != nil {
@@ -456,7 +468,7 @@ func TestHasInstallerSiblingLayout_AlreadyUnified(t *testing.T) {
 }
 
 func TestInstallFromLocal_UnifiesInstallerSiblingLayout(t *testing.T) {
-	t.Setenv("SIDESHOW_HOME", t.TempDir())
+	freezeSafeHome(t)
 
 	source := t.TempDir()
 	// Build a realistic upstream installer output: _bmad/_config/manifest.yaml
@@ -519,7 +531,7 @@ func TestInstallFromLocal_UnifiesInstallerSiblingLayout(t *testing.T) {
 }
 
 func TestInstallFromLocal_AlreadyUnifiedPassesThrough(t *testing.T) {
-	t.Setenv("SIDESHOW_HOME", t.TempDir())
+	freezeSafeHome(t)
 
 	source := t.TempDir()
 	// Pack root with _config/ at top level (no _bmad/ prefix at all).
@@ -570,9 +582,11 @@ func makeModeFixture(t *testing.T) string {
 	return src
 }
 
+// The mode contract after the store freeze (aae-orc-dihj): read and
+// exec bits survive the copy, write bits are stripped. 0755 becomes
+// 0555 and never 0444; 0644 becomes 0444.
 func TestInstallFromLocal_PreservesFileModes(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("SIDESHOW_HOME", home)
+	home := freezeSafeHome(t)
 	src := makeModeFixture(t)
 
 	if err := InstallFromLocal("modes", src, true); err != nil {
@@ -584,8 +598,8 @@ func TestInstallFromLocal_PreservesFileModes(t *testing.T) {
 		rel  string
 		want os.FileMode
 	}{
-		{filepath.Join("bin", "tool.sh"), 0o755},
-		{"doc.md", 0o644},
+		{filepath.Join("bin", "tool.sh"), 0o555},
+		{"doc.md", 0o444},
 	}
 	for _, tt := range tests {
 		info, err := os.Stat(filepath.Join(packRoot, tt.rel))
@@ -599,8 +613,7 @@ func TestInstallFromLocal_PreservesFileModes(t *testing.T) {
 }
 
 func TestInstallFromLocal_ExecManifestVerified(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("SIDESHOW_HOME", home)
+	freezeSafeHome(t)
 	src := makeModeFixture(t)
 	if err := os.WriteFile(filepath.Join(src, "exec-manifest.txt"), []byte("bin/tool.sh\n"), 0o644); err != nil {
 		t.Fatal(err)
@@ -612,8 +625,7 @@ func TestInstallFromLocal_ExecManifestVerified(t *testing.T) {
 }
 
 func TestInstallFromLocal_ExecManifestDriftFailsLoudly(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("SIDESHOW_HOME", home)
+	freezeSafeHome(t)
 	src := makeModeFixture(t)
 	// Census references an entry the source does not satisfy: the listed
 	// path exists but is not executable, plus one missing path.
@@ -632,5 +644,175 @@ func TestInstallFromLocal_ExecManifestDriftFailsLoudly(t *testing.T) {
 		if !strings.Contains(err.Error(), want) {
 			t.Errorf("error %q missing %q", err.Error(), want)
 		}
+	}
+}
+
+// walkPerms collects perm bits for every non-symlink entry under root.
+func walkPerms(t *testing.T, root string) map[string]os.FileMode {
+	t.Helper()
+	perms := map[string]os.FileMode{}
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		perms[rel] = info.Mode().Perm()
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return perms
+}
+
+// The store freezes WHOLE (finding-094 round 3): every file and every
+// directory in the installed tree, no exemptions.
+func TestInstallFromLocal_FreezesStoreWhole(t *testing.T) {
+	home := freezeSafeHome(t)
+	src := makeModeFixture(t)
+
+	if err := InstallFromLocal("modes", src, true); err != nil {
+		t.Fatalf("InstallFromLocal: %v", err)
+	}
+
+	for rel, perm := range walkPerms(t, filepath.Join(home, "packs", "modes", "1.0.0")) {
+		if perm&0o222 != 0 {
+			t.Errorf("%s carries write bits: %o", rel, perm)
+		}
+	}
+}
+
+// A write into the frozen store fails loudly instead of corrupting the
+// active version silently (the finding-074 class).
+func TestInstallFromLocal_StoreWriteFailsLoudly(t *testing.T) {
+	home := freezeSafeHome(t)
+	src := makeModeFixture(t)
+
+	if err := InstallFromLocal("modes", src, true); err != nil {
+		t.Fatalf("InstallFromLocal: %v", err)
+	}
+
+	packRoot := filepath.Join(home, "packs", "modes", "1.0.0")
+	if err := os.WriteFile(filepath.Join(packRoot, "doc.md"), []byte("mutated"), 0o644); err == nil {
+		t.Error("overwrite of a frozen store file succeeded")
+	}
+	if err := os.WriteFile(filepath.Join(packRoot, "bin", "new.sh"), []byte("#!/bin/sh\n"), 0o755); err == nil {
+		t.Error("creating a file inside a frozen store dir succeeded")
+	}
+	if err := os.Remove(filepath.Join(packRoot, "doc.md")); err == nil {
+		t.Error("deleting a file from a frozen store dir succeeded")
+	}
+}
+
+// Reinstalling over a frozen version is the unlock half of the
+// envelope: before the fix this EACCESed on the first overwrite, which
+// is the state every manually frozen store has been in since the
+// 2026-07-12 chmod (finding-074 interim).
+func TestInstallFromLocal_ReinstallOverFrozenTree(t *testing.T) {
+	home := freezeSafeHome(t)
+	src := makeModeFixture(t)
+
+	if err := InstallFromLocal("modes", src, true); err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "doc.md"), []byte("updated"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := InstallFromLocal("modes", src, true); err != nil {
+		t.Fatalf("reinstall over frozen tree: %v", err)
+	}
+
+	packRoot := filepath.Join(home, "packs", "modes", "1.0.0")
+	data, err := os.ReadFile(filepath.Join(packRoot, "doc.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "updated" {
+		t.Errorf("reinstall did not replace content: %q", data)
+	}
+	for rel, perm := range walkPerms(t, packRoot) {
+		if perm&0o222 != 0 {
+			t.Errorf("%s writable after reinstall: %o", rel, perm)
+		}
+	}
+}
+
+// A failed install leaves the tree frozen, not writable: the deferred
+// freeze runs on every exit (fail frozen).
+func TestInstallFromLocal_FreezesEvenOnFailure(t *testing.T) {
+	home := freezeSafeHome(t)
+	src := makeModeFixture(t)
+	// Exec-manifest drift makes the install fail after the copy.
+	if err := os.Chmod(filepath.Join(src, "bin", "tool.sh"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "exec-manifest.txt"), []byte("bin/tool.sh\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := InstallFromLocal("modes", src, true); err == nil {
+		t.Fatal("install succeeded despite exec-manifest drift")
+	}
+	for rel, perm := range walkPerms(t, filepath.Join(home, "packs", "modes", "1.0.0")) {
+		if perm&0o222 != 0 {
+			t.Errorf("failed install left %s writable: %o", rel, perm)
+		}
+	}
+}
+
+// Chmod follows symlinks; the freeze must not. A bridge link inside
+// the tree may point at user-owned content outside the store.
+func TestFreezeTree_SkipsSymlinks(t *testing.T) {
+	t.Parallel()
+	tree := t.TempDir()
+	t.Cleanup(func() { _ = UnfreezeTree(tree) })
+	outside := filepath.Join(t.TempDir(), "user-owned.md")
+	if err := os.WriteFile(outside, []byte("mine"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(tree, "bridge")); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := FreezeTree(tree); err != nil {
+		t.Fatalf("FreezeTree: %v", err)
+	}
+	info, err := os.Stat(outside)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o644 {
+		t.Errorf("freeze reached through the symlink: outside target mode = %o, want 644", info.Mode().Perm())
+	}
+}
+
+func TestUnfreezeTree_RestoresOwnerWrite(t *testing.T) {
+	t.Parallel()
+	tree := t.TempDir()
+	sub := filepath.Join(tree, "sub")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sub, "f.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := FreezeTree(tree); err != nil {
+		t.Fatal(err)
+	}
+	if err := UnfreezeTree(tree); err != nil {
+		t.Fatalf("UnfreezeTree: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sub, "f.txt"), []byte("y"), 0o644); err != nil {
+		t.Errorf("write after unfreeze failed: %v", err)
 	}
 }


### PR DESCRIPTION
The file mode is the only thing standing between a runtime skill and the active store version, and until now it was applied by hand. finding-074 recorded a helper skill corrupting the active bmad version through fallback-resolution substitution; the interim fix was a manual `chmod -R a-w` on 2026-07-12, which made the protection a human habit and quietly broke every reinstall over those trees (EACCES on the first overwrite). finding-002 F8 confirmed the exposure: no doctor verb, no content hashing anywhere near pack content, and a second write route already found (weave `csv_injections` through `runtime_links`, `aae-orc-a3v6`).

Closes the code half of `aae-orc-dihj`.

## What changed

`InstallFromLocal` now carries the unlock-write-refreeze envelope: unlock an existing version tree on entry, copy, refreeze on every exit including failure, so a partial install fails frozen rather than writable. Per finding-094 round 3 the store freezes whole: no exemption, no derived-layer chain, no integrity special case.

`FreezeTree` strips write bits only, so 0755 becomes 0555 and never 0444; the exec-manifest property survives the last hop. Symlinks are skipped, because `Chmod` follows them and a bridge link inside the tree may point at user-owned content outside the store.

Both primitives are exported for the consumers that come next, and the envelope requirement (refreeze even on failure) is documented on them: uninstall (`aae-orc-d3nq.20`) and declared-mutable weave writes (`aae-orc-a3v6`).

## The residual gate, run against the real artifact

The ticket gated landing on trialing `lint-registry-async-invariant.wasm` (`:1311`, `on_error=block`) under 0555. Executed end to end on this machine: rc.23 downloaded from the signed release, sha256-verified, installed through this branch's binary (1191 files, zero write bits afterward, exec dirs at `dr-xr-xr-x`), enabled into a scratch repo, and a matcher-shaped `PostToolUse` fired through the dispatcher.

Result: the dispatcher loads all 73 plugins from the frozen store, and the wasm behaves **byte-identically frozen vs unfrozen** (differential run both ways). The gate's question is answered: the freeze changes nothing for store reads.

One pre-existing observation, freeze-independent: the wasm reports timeout at `elapsed_ms=1` against a 5000ms budget and blocks fail-closed, in both modes. Recorded in the ticket; not filed upstream, because a single synthetic invocation may not match the harness's event shape.

## Tests

Freeze-whole walk over the installed tree; loud failure on overwrite, create, and delete inside the frozen store; reinstall-over-frozen (the exact state every manually frozen store is in today); fail-frozen on exec-manifest drift; symlink skip proving the freeze cannot reach through a bridge link; unfreeze round trip; and the mode-contract test updated to the frozen expectation (0555/0444, exec preserved).

All four install-path guards were run against the unwired code (HEAD plus primitives, no envelope) and fail there. Test homes register an unfreeze cleanup ahead of `TempDir`'s so the suite can delete what the freeze protects.

`gofmt`, `go vet`, `golangci-lint` clean; full suite passes.

## Cost of merge

The install contract changes: installed trees are read-only from now on, which is the defect being fixed, not a regression. Reinstall handles the unlock itself. Anything else that writes into a store version was already corrupting it silently and now fails loudly with a permission error.