### PR TITLE
fix(weave): resolve symlinks on write targets; refuse escapes from the repo root

### DIFF
--- a/internal/weave/ops_csv.go
+++ b/internal/weave/ops_csv.go
@@ -3,7 +3,6 @@ package weave
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 )
 
@@ -26,7 +25,13 @@ func applyCSVInjections(d *Declaration, repoRoot string, opts Options) []Action 
 
 	for _, inj := range d.CSVInjections {
 		a := Action{Type: "csv", Name: inj.Name, Path: inj.Target}
-		abs := filepath.Join(repoRoot, inj.Target)
+		abs, err := resolveWriteTarget(repoRoot, inj.Target)
+		if err != nil {
+			a.Outcome = Failed
+			a.Detail = err.Error()
+			actions = append(actions, a)
+			continue
+		}
 
 		content, err := os.ReadFile(abs)
 		if err != nil {

--- a/internal/weave/ops_shim.go
+++ b/internal/weave/ops_shim.go
@@ -30,7 +30,13 @@ func applySlashCommands(d *Declaration, repoRoot string, opts Options) []Action 
 
 	for _, cmd := range d.SlashCommands {
 		a := Action{Type: "shim", Name: cmd.ID, Path: cmd.Target}
-		abs := filepath.Join(repoRoot, cmd.Target)
+		abs, err := resolveWriteTarget(repoRoot, cmd.Target)
+		if err != nil {
+			a.Outcome = Failed
+			a.Detail = err.Error()
+			actions = append(actions, a)
+			continue
+		}
 
 		onExists := cmd.OnExists
 		if onExists == "" {

--- a/internal/weave/ops_yaml.go
+++ b/internal/weave/ops_yaml.go
@@ -27,7 +27,13 @@ func applyMemoryInjections(d *Declaration, repoRoot string, opts Options) []Acti
 
 		for _, target := range inj.Targets {
 			a := Action{Type: "memory", Name: filepath.Base(target), Path: target}
-			abs := filepath.Join(repoRoot, target)
+			abs, err := resolveWriteTarget(repoRoot, target)
+			if err != nil {
+				a.Outcome = Failed
+				a.Detail = err.Error()
+				actions = append(actions, a)
+				continue
+			}
 
 			content, err := os.ReadFile(abs)
 			if err != nil {

--- a/internal/weave/target.go
+++ b/internal/weave/target.go
@@ -1,0 +1,64 @@
+package weave
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// resolveWriteTarget joins rel onto repoRoot and resolves symlinks before
+// returning the absolute path a weave operation may write to. A target whose
+// resolved location falls outside the resolved repo root is refused:
+// pack.yaml runtime_links symlink store content into the repo (for example
+// _bmad/_config pointing at the frozen store version), so a prefix check on
+// the unresolved path would let a declaration write through the link and
+// corrupt producer-validated store content (aae-orc-a3v6). The check is by
+// resolution, never by path spelling: legacy repos carrying a real _bmad/
+// tree resolve inside the root and pass unchanged.
+func resolveWriteTarget(repoRoot, rel string) (string, error) {
+	absRoot, err := filepath.Abs(repoRoot)
+	if err != nil {
+		return "", fmt.Errorf("resolve repo root: %w", err)
+	}
+	root, err := filepath.EvalSymlinks(absRoot)
+	if err != nil {
+		return "", fmt.Errorf("resolve repo root: %w", err)
+	}
+
+	resolved, err := resolveExisting(filepath.Join(absRoot, rel))
+	if err != nil {
+		return "", err
+	}
+
+	if resolved != root && !strings.HasPrefix(resolved, root+string(filepath.Separator)) {
+		return "", fmt.Errorf(
+			"target %s resolves to %s, outside the repo; refusing to write through a runtime link",
+			rel, resolved)
+	}
+	return resolved, nil
+}
+
+// resolveExisting resolves symlinks in abs. The final path elements may not
+// exist yet (shim files and their directories are created on apply), so the
+// deepest existing ancestor is resolved and the missing remainder re-joined
+// onto the resolution.
+func resolveExisting(abs string) (string, error) {
+	var tail []string
+	p := abs
+	for {
+		resolved, err := filepath.EvalSymlinks(p)
+		if err == nil {
+			return filepath.Join(append([]string{resolved}, tail...)...), nil
+		}
+		if !os.IsNotExist(err) {
+			return "", fmt.Errorf("resolve %s: %w", abs, err)
+		}
+		parent := filepath.Dir(p)
+		if parent == p {
+			return "", fmt.Errorf("resolve %s: no existing ancestor", abs)
+		}
+		tail = append([]string{filepath.Base(p)}, tail...)
+		p = parent
+	}
+}

--- a/internal/weave/target_test.go
+++ b/internal/weave/target_test.go
@@ -1,0 +1,189 @@
+package weave
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// storeLinkedRepo builds the aae-orc-a3v6 repro shape: a repo whose
+// _bmad/_config is a runtime_links symlink into a store directory outside
+// the repo, carrying a manifest the weave must never write through to.
+func storeLinkedRepo(t *testing.T) (repoRoot, storeManifest string) {
+	t.Helper()
+	base := t.TempDir()
+	repoRoot = filepath.Join(base, "repo")
+	storeConfig := filepath.Join(base, "store", "packs", "bmad", "6.10.0", "_config")
+	storeManifest = filepath.Join(storeConfig, "manifest.csv")
+	write(t, storeManifest, "header\n")
+	if err := os.MkdirAll(filepath.Join(repoRoot, "_bmad"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(storeConfig, filepath.Join(repoRoot, "_bmad", "_config")); err != nil {
+		t.Fatal(err)
+	}
+	return repoRoot, storeManifest
+}
+
+func TestCSVRefusesWriteThroughRuntimeLink(t *testing.T) {
+	root, storeManifest := storeLinkedRepo(t)
+
+	d := loadFrom(t, `schema_version: 0.1.0
+pack: bmad
+csv_injections:
+  - name: m
+    target: _bmad/_config/manifest.csv
+    rows:
+      - '"pe","Sam"'
+`)
+	res, err := Apply(d, root, Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Actions[0].Outcome != Failed {
+		t.Fatalf("outcome = %v (%s), want Failed", res.Actions[0].Outcome, res.Actions[0].Detail)
+	}
+	if !strings.Contains(res.Actions[0].Detail, "outside the repo") {
+		t.Fatalf("detail = %q, want refusal naming the escape", res.Actions[0].Detail)
+	}
+	if got := read(t, storeManifest); got != "header\n" {
+		t.Fatalf("store manifest mutated: %q", got)
+	}
+}
+
+func TestMemoryRefusesWriteThroughRuntimeLink(t *testing.T) {
+	root, storeManifest := storeLinkedRepo(t)
+
+	d := loadFrom(t, `schema_version: 0.1.0
+pack: bmad
+memory_injections:
+  - targets: [_bmad/_config/manifest.csv]
+    anchor: "memories:"
+    memories: [remember this]
+`)
+	res, err := Apply(d, root, Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Actions[0].Outcome != Failed {
+		t.Fatalf("outcome = %v (%s), want Failed", res.Actions[0].Outcome, res.Actions[0].Detail)
+	}
+	if !strings.Contains(res.Actions[0].Detail, "outside the repo") {
+		t.Fatalf("detail = %q, want refusal naming the escape", res.Actions[0].Detail)
+	}
+	if got := read(t, storeManifest); got != "header\n" {
+		t.Fatalf("store manifest mutated: %q", got)
+	}
+}
+
+func TestShimRefusesWriteThroughRuntimeLink(t *testing.T) {
+	root, _ := storeLinkedRepo(t)
+
+	d := loadFrom(t, `schema_version: 0.1.0
+pack: bmad
+slash_commands:
+  - id: rogue
+    target: _bmad/_config/commands/rogue.md
+    body: "hi"
+`)
+	res, err := Apply(d, root, Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Actions[0].Outcome != Failed {
+		t.Fatalf("outcome = %v (%s), want Failed", res.Actions[0].Outcome, res.Actions[0].Detail)
+	}
+	if !strings.Contains(res.Actions[0].Detail, "outside the repo") {
+		t.Fatalf("detail = %q, want refusal naming the escape", res.Actions[0].Detail)
+	}
+	// Nothing may be created on the store side of the link.
+	if _, err := os.Stat(filepath.Join(root, "_bmad", "_config", "commands")); !os.IsNotExist(err) {
+		t.Fatalf("commands dir created through the link (stat err = %v)", err)
+	}
+}
+
+func TestLegacyRealTreeStillWeaves(t *testing.T) {
+	// Repos carrying a real per-project _bmad/ tree (aae-orc-vaqh) are where
+	// weave works as designed; resolution keeps them inside the root.
+	root := t.TempDir()
+	target := filepath.Join(root, "_bmad", "_config", "manifest.csv")
+	write(t, target, "header\n")
+
+	d := loadFrom(t, `schema_version: 0.1.0
+pack: bmad
+csv_injections:
+  - name: m
+    target: _bmad/_config/manifest.csv
+    rows:
+      - '"pe","Sam"'
+`)
+	res, err := Apply(d, root, Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Actions[0].Outcome != Applied {
+		t.Fatalf("outcome = %v (%s), want Applied", res.Actions[0].Outcome, res.Actions[0].Detail)
+	}
+	if got := read(t, target); got != "header\n\"pe\",\"Sam\"\n" {
+		t.Fatalf("content = %q", got)
+	}
+}
+
+func TestResolveWriteTarget(t *testing.T) {
+	t.Parallel()
+
+	t.Run("symlink inside repo is allowed", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		write(t, filepath.Join(root, "real", "f.csv"), "x\n")
+		if err := os.Symlink(filepath.Join(root, "real"), filepath.Join(root, "alias")); err != nil {
+			t.Fatal(err)
+		}
+		got, err := resolveWriteTarget(root, "alias/f.csv")
+		if err != nil {
+			t.Fatalf("resolveWriteTarget: %v", err)
+		}
+		want, err := filepath.EvalSymlinks(filepath.Join(root, "real", "f.csv"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != want {
+			t.Errorf("resolved = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("missing tail resolves through existing ancestors", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		got, err := resolveWriteTarget(root, "new/dir/file.md")
+		if err != nil {
+			t.Fatalf("resolveWriteTarget: %v", err)
+		}
+		if !strings.HasSuffix(got, filepath.Join("new", "dir", "file.md")) {
+			t.Errorf("resolved = %q, want suffix new/dir/file.md", got)
+		}
+	})
+
+	t.Run("dot-dot traversal is refused", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		if _, err := resolveWriteTarget(root, "../escape.csv"); err == nil {
+			t.Error("expected refusal for ../ traversal")
+		}
+	})
+
+	t.Run("symlinked repo root compares like for like", func(t *testing.T) {
+		t.Parallel()
+		base := t.TempDir()
+		real := filepath.Join(base, "real-repo")
+		write(t, filepath.Join(real, "f.csv"), "x\n")
+		linkRoot := filepath.Join(base, "link-repo")
+		if err := os.Symlink(real, linkRoot); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := resolveWriteTarget(linkRoot, "f.csv"); err != nil {
+			t.Errorf("repo root behind a symlink must still weave: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
A weave declaration targeting a path under a runtime_links symlink (e.g. `_bmad/_config/...`) wrote straight through the link into the frozen store, corrupting producer-validated content shared by every repo on the machine. Verified live in a shimmed repo (bd aae-orc-a3v6); since the store freeze (#106) it fails loudly, before it it was silent.

The fix adds `resolveWriteTarget`: resolve the deepest existing ancestor of the target and the repo root the same way, refuse any target whose resolution lands outside the root, and surface the refusal as a Failed action naming the resolved destination (weave's existing error model). The check is by resolution, not path spelling, so legacy repos with a real `_bmad/` tree (aae-orc-vaqh) weave exactly as before; `../` traversal is covered for free. Verify ops deliberately keep reading through links since checking what the repo resolves to is their job.

Applied to all three write ops (csv, memory, shim; patch is a stub). Tests: three write-through refusals against the live repro shape, legacy real-tree pass-through, resolver units (in-repo symlink allowed, missing tail, dot-dot, symlinked repo root). Additive guard; no behavior change for in-repo targets.