### PR TITLE
feat(doctor): read-only five-layer health surface (spec + first implementation)

### DIFF
--- a/cmd/sideshow/doctor.go
+++ b/cmd/sideshow/doctor.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/ArcavenAE/sideshow/internal/doctor"
+)
+
+// exitCodeError carries a non-message exit code out of a command.
+// main's error handler exits with the code without printing an
+// "error:" line: the report already said everything.
+type exitCodeError struct{ code int }
+
+func (e exitCodeError) Error() string { return fmt.Sprintf("exit %d", e.code) }
+
+// runDoctor is the read-only health surface:
+//
+//	sideshow doctor [<pack>] [--layer <n[,n...]>] [--repo <path>]
+//	                [--json] [--strict]
+//
+// Spec: docs/doctor-spec.md. Exit 0 unless a structural failure is
+// present (exit 2); --strict promotes structural warns. Advisory and
+// unavailable findings never affect the exit code.
+func runDoctor(args []string) error {
+	var opts doctor.Options
+	if len(args) > 0 && len(args[0]) > 0 && args[0][0] != '-' {
+		opts.Pack = args[0]
+		args = args[1:]
+	}
+	var asJSON bool
+	if wd, err := os.Getwd(); err == nil {
+		opts.RepoDir = wd
+	}
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--layer":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--layer requires a comma list from 1,3,4,5")
+			}
+			i++
+			for _, part := range strings.Split(args[i], ",") {
+				n, err := strconv.Atoi(strings.TrimSpace(part))
+				if err != nil {
+					return fmt.Errorf("--layer: %q is not a layer number", part)
+				}
+				opts.Layers = append(opts.Layers, n)
+			}
+		case "--repo":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--repo requires a path")
+			}
+			i++
+			opts.RepoDir = args[i]
+		case "--json":
+			asJSON = true
+		case "--strict":
+			opts.Strict = true
+		default:
+			return fmt.Errorf("unknown flag for doctor: %s (see 'sideshow --help')", args[i])
+		}
+	}
+
+	report, layers, err := doctor.Run(opts)
+	if err != nil {
+		return err
+	}
+	if asJSON {
+		if err := report.WriteJSON(os.Stdout); err != nil {
+			return err
+		}
+	} else {
+		report.WriteText(os.Stdout, layers)
+	}
+	if report.Summary.ExitCode != 0 {
+		return exitCodeError{code: report.Summary.ExitCode}
+	}
+	return nil
+}

--- a/cmd/sideshow/main.go
+++ b/cmd/sideshow/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -47,6 +48,9 @@ Usage:
   sideshow activate <pack> [--repo <path>] [--agent <name>]  Consented persona flip (repo default agent)
   sideshow deactivate <pack> [--repo <path>]  Remove the persona flip only (prefix-guarded)
   sideshow coexist-check <pack> [--repo <path>]  Read-only enable/adopt preflight (ten checks)
+  sideshow doctor [<pack>] [--layer <n,...>] [--repo <path>] [--json] [--strict]
+                                          Read-only health report over store, receipts,
+                                          and ledger (layers 1,3,4,5; docs/doctor-spec.md)
   sideshow adopt <pack> [--repo <path>] [--rewrite-agent] [--dry-run]  Convert a repo from the foreign (claude-mp) channel
   sideshow adopt <pack> --finish          Report remaining foreign residue (print-only)
   sideshow adopt <pack> --migrate-user-scope [--also-repo <path>] [--sweep-root <dir>] [--yes]
@@ -143,6 +147,8 @@ func main() {
 		err = runDisable(os.Args[2:])
 	case "coexist-check":
 		err = runCoexistCheck(os.Args[2:])
+	case "doctor":
+		err = runDoctor(os.Args[2:])
 	case "adopt":
 		err = runAdopt(os.Args[2:])
 	case "coexist":
@@ -158,6 +164,12 @@ func main() {
 	}
 
 	if err != nil {
+		var ec exitCodeError
+		if errors.As(err, &ec) {
+			// The command already printed its report; the code is
+			// the whole message.
+			os.Exit(ec.code)
+		}
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}

--- a/docs/doctor-spec.md
+++ b/docs/doctor-spec.md
@@ -1,0 +1,179 @@
+# sideshow doctor
+
+Read-only health surface over the state sideshow itself has written:
+the pack store, the registry receipts, the sync manifest, and the
+repo-bindings ledger. Every check is the mechanical verification of a
+promise some receipt, ledger row, marker, or doc sentence already
+makes. Doctor proposes; it never mutates (orc ADR-007, automation
+boundary).
+
+Ticket: bd `aae-orc-xteh`. Layer vocabulary is fixed by orc charter
+F24: layers 1, 3, 4, 5. Layer 2 (pack-declared validation) is excluded
+and deferred to the weave engine (`aae-orc-a44c`); doctor prints one
+line saying so, so the numbering gap reads as a decision rather than a
+bug.
+
+## Command
+
+```
+sideshow doctor [<pack>] [--layer <n[,n...]>] [--repo <path>]
+                [--json] [--strict]
+```
+
+- `<pack>` narrows every layer to one pack (positional, matching
+  coexist-check, enable, disable, adopt).
+- `--layer` limits to a comma list drawn from 1,3,4,5. `2` is rejected
+  with a pointer to the deferral.
+- `--repo` sets the layer-3 subject directory. Default: cwd.
+- `--json` emits the machine report (schema_version carried) on
+  stdout and suppresses the text report.
+- `--strict` promotes structural WARN findings to the failing exit.
+  Advisory findings are never promoted, by invariant.
+
+Layer 4 resolves fleet repos through what the receipts already
+record: each installation's root and repos manifest, plus the
+repo-bindings ledger. There is no separate `--manifest` flag; when
+the lockfile ships (`aae-orc-333y`), pin comparison keys off the orc
+root the same way.
+
+## Result model
+
+Every check produces findings with two orthogonal fields:
+
+- **Status**: `ok`, `warn`, `fail`, `unavailable`.
+- **Class**: `structural` (sideshow's own records disagree with disk;
+  well-formedness) or `advisory` (health signals: drift a human may
+  have intended, staleness, in-flight activity).
+
+Exit policy, which is the orc `diagnostic-not-gate` rule expressed as
+code rather than etiquette:
+
+| Condition | Exit |
+|---|---|
+| no structural `fail` | 0 |
+| any structural `fail` | 2 |
+| structural `warn` under `--strict` | 2 |
+| advisory findings, any status, any flags | never affects exit |
+| `unavailable`, any flags | never affects exit |
+| doctor itself cannot run (bad flag, etc.) | 1 |
+
+Structural validity may gate CI; health may not. Wiring
+`sideshow doctor --strict` into CI is legitimate; nothing advisory can
+ever turn that gate red.
+
+Two invariants are enforced by the runner and by tests, not by
+convention:
+
+1. Every non-`ok` finding carries a `next:` line naming the command to
+   run, the doc to read, or the bd ticket that supplies the missing
+   input.
+2. Layer 3 findings are clamped to advisory and to `warn` or below
+   (ratified warn-only decision). A layer-3 check that returns `fail`
+   is a programming error the clamp corrects and reports.
+
+## Absent-input discipline
+
+Same rule as the pack consumer side (sideshow-packs
+docs/release-url-format.md): an absent input makes a check
+`unavailable` with a named reason, never a failure and never a silent
+skip. Silence must not read as cleanliness. Concretely:
+
+- no `sideshow.lock` at the orc root: layer 4 pin comparison is
+  `unavailable`, reason names `aae-orc-333y`; version skew against the
+  installed store is reported instead as the honest partial answer.
+- no known-defects feed: layer 5 is `unavailable`, reason names
+  `aae-orc-ztg5` (feed) and `aae-orc-10vq` (overlay artifacts).
+- a pack whose store copy ships no `_config/files-manifest.csv`
+  (vsdd-factory does not; bmad does): content census is `unavailable`,
+  reason names `aae-orc-wk92` (release-asset manifests are not
+  retained on install today).
+- a malformed ledger or registry: dependent checks are `unavailable`
+  carrying the parse error verbatim, never reported as "no repos
+  bound" (the lie `internal/ledger/ledger.go` warns about).
+
+## Check inventory
+
+Availability legend: **today** ships in this PR; **d3nq.9**,
+**receipt-change**, **lockfile (333y)**, **feed (ztg5)** are the
+follow-on tickets that light the check up.
+
+### Layer 1: sideshow-native integrity
+
+| ID | Verifies | Class/Status on hit | Availability |
+|---|---|---|---|
+| `registry-parse` | registry.yaml loads | structural fail | today |
+| `store-coherence` | registry version, `current` symlink target, and version dir agree; `current` not dangling | structural fail | today |
+| `store-shape` | installed version looks like installer output, not a source tree (closes `aae-orc-xbkl`) | structural warn | today |
+| `store-freeze` | no write bits under a version dir (PR #106 invariant). Wording names the two benign causes (pre-freeze install; interrupted unlock-write-refreeze); never "tampered" | advisory warn | today |
+| `store-content-census` | per-file sha256 of the store tree against the census the pack ships (`_config/files-manifest.csv`) | structural fail | today where shipped; unavailable otherwise |
+| `sync-manifest` | every sync-manifest entry path exists; entry version matches the active store version (entries recording `custom` are project content and exempt from currency) | structural warn | today |
+| `receipt-markers` | receipted claude_md sections have paired begin/end markers (a lone begin silently duplicates the section on the next distribute); receipted rules files keep their managed-by first line | structural fail / warn | today |
+| `receipt-symlinks` | receipted symlink artifacts exist, are symlinks, and point at their recorded target | structural fail | today |
+| `store-exec-census` | exec-manifest census against the installed tree | structural fail | receipt-change (census is a release asset, not retained; `aae-orc-wk92`) |
+| `sync-content` | content hashes of synced bindings | unavailable | receipt-change (sync manifest records paths only) |
+
+### Layer 1, plugin-class check set (mechanism-keyed seam)
+
+Packs whose `activation.mechanism` declares a plugin class get an
+extra check set, dispatched from the same activation contract that
+`status` and `bindings.Sync` already branch on. This PR ships one
+check to prove the seam by use:
+
+| ID | Verifies | Class/Status on hit | Availability |
+|---|---|---|---|
+| `ledger-row-coherence` | ledger row's store path exists and is a version dir (never `current`); row version matches the dir; repo dir still exists | structural fail; missing repo dir is advisory warn (a distinct condition, not a failure) | today |
+| env-shim, hook-chain, dispatcher exec, local-scope symlinks, replay preflight, dangling foreign registrations | the per-repo bind battery | mixed | d3nq.9 |
+
+### Layer 3: cwd discoverability (warn-only, advisory by invariant)
+
+| ID | Verifies | Availability |
+|---|---|---|
+| `cwd-known` | whether sideshow has any record of this directory (ledger row, receipt repo, installation root) | today |
+| `cwd-coexistence` | the coexist-check battery per installed pack, ERROR grades clamped to warn with the original grade named; a battery error becomes unavailable, never a crash | today |
+| `cwd-factory-guard` | unexpired factory lock with holder and age (TTL-based, so the observation time is printed) | today |
+
+### Layer 4: fleet drift
+
+| ID | Verifies | Class/Status on hit | Availability |
+|---|---|---|---|
+| `receipt-drift` | re-hash every receipted `files` and `rules` artifact against its recorded checksum (the sideshow#92 signal). Missing receipted file is structural (the receipt claims ownership); a changed one is advisory (a user edit is a deliberate act) | structural warn / advisory warn | today |
+| `receipt-coverage` | dead installation roots and empty receipt sets, reported as skipped-with-reason so "no findings" cannot read as "no drift". Names the two under-coverage causes: RecordResults drops receipts for files a partial run skipped, and `project init` writes no receipts | advisory | today |
+| `version-skew` | ledger row versions and receipt versions against the active store version | advisory warn | today |
+| `lock-pins` | declared pins vs installed and receipted versions | unavailable | lockfile (333y) |
+
+### Layer 5: known defects
+
+| ID | Verifies | Availability |
+|---|---|---|
+| `known-defects` | installed pack versions against the publisher defects feed | feed (ztg5) |
+| `unapplied-overlays` | overlays applying to an installed base, not yet applied | feed (ztg5) + overlay spec (10vq) |
+
+A future stopgap may read the sideshow-packs pack-support registers
+(wrinkle brackets) with an operator-supplied path; those rows are
+"upstream packaging wrinkles", not known defects, and must be labeled
+as such. Deliberately not in this PR: doctor is offline here, no
+network call anywhere.
+
+## Receipt fidelity (separate PR)
+
+Two write-path changes are deliberately not in the doctor PR, so
+doctor stays read-only and reviewable:
+
+1. `distributeFile` observes drift (path, on-disk hash, receipted
+   hash) and throws the observation away (sideshow#92,
+   `internal/distribute/distribute.go`). Keeping it turns "drift
+   exists" into "drift first seen at T".
+2. `RecordResults` replaces the artifact list wholesale, so a run
+   that wrote one file and skipped another drops the skipped file's
+   receipt, converting a sideshow-written file into "user-authored"
+   forever. Doctor's `receipt-coverage` check names this ambiguity in
+   its output until the fix lands.
+
+## JSON output
+
+`--json` emits one object: `schema_version` (0.1.0), `generated_at`
+(UTC), `findings[]` (layer, id, pack, subject, status, class, detail,
+next), and `summary` (counts per status, exit code). Consumers follow
+the absent-field discipline: unknown fields are ignored, absent fields
+mean the field's documented default, and `schema_version` gates shape
+expectations.

--- a/internal/bindings/manifest.go
+++ b/internal/bindings/manifest.go
@@ -39,6 +39,13 @@ func manifestPath() string {
 
 // loadManifest reads the previous sync manifest. A missing file returns
 // an empty manifest, not an error.
+// LoadManifest exposes the sync-manifest receipt for read-only
+// consumers (doctor). A missing file is an empty manifest, not an
+// error; a malformed one is an error.
+func LoadManifest() (*SyncManifest, error) {
+	return loadManifest()
+}
+
 func loadManifest() (*SyncManifest, error) {
 	data, err := os.ReadFile(manifestPath())
 	if err != nil {

--- a/internal/distribute/distribute.go
+++ b/internal/distribute/distribute.go
@@ -17,6 +17,18 @@ import (
 // markerPrefix is used to identify sideshow-managed files and sections.
 const markerPrefix = "<!-- managed by sideshow"
 
+// MarkerPrefix exposes the managed-file marker prefix for read-only
+// verification (doctor checks receipted rules files kept it).
+const MarkerPrefix = markerPrefix
+
+// SectionBegin and SectionEnd expose the CLAUDE.md section markers
+// for read-only verification (doctor checks receipted sections stay
+// paired).
+func SectionBegin(id string) string { return sectionBegin(id) }
+
+// SectionEnd is SectionBegin's closing pair.
+func SectionEnd(id string) string { return sectionEnd(id) }
+
 // sectionBegin returns the begin marker for a CLAUDE.md section.
 func sectionBegin(id string) string {
 	return fmt.Sprintf("<!-- sideshow:%s:begin -->", id)

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -1,0 +1,163 @@
+package doctor
+
+import (
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/ArcavenAE/sideshow/internal/bindings"
+	"github.com/ArcavenAE/sideshow/internal/ledger"
+	"github.com/ArcavenAE/sideshow/internal/pack"
+)
+
+// Options configures a run.
+type Options struct {
+	// Pack narrows every layer to one pack. Empty means all installed.
+	Pack string
+	// Layers limits the run. Empty means all of 1, 3, 4, 5.
+	Layers []int
+	// RepoDir is the layer-3 subject. Empty means the caller's cwd
+	// was unavailable and layer 3 reports that.
+	RepoDir string
+	// Now is injected for testable TTL and timestamp rendering.
+	Now time.Time
+	// Strict promotes structural warns into the failing exit.
+	Strict bool
+}
+
+// AllLayers is the fixed layer vocabulary (orc charter F24). Layer 2
+// is excluded by decision, not omission; see docs/doctor-spec.md.
+var AllLayers = []int{1, 3, 4, 5}
+
+// Context is the preloaded, read-only input set shared by every
+// check. Inputs that failed to load carry their error so dependent
+// checks report unavailable with the parse error verbatim instead of
+// treating absence as cleanliness.
+type Context struct {
+	Registry    *pack.Registry
+	RegistryErr error
+	Ledger      *ledger.Ledger
+	LedgerErr   error
+	Manifest    *bindings.SyncManifest
+	ManifestErr error
+	// Packs is the installed set after the Options.Pack filter.
+	Packs []pack.InstalledPack
+	// PackFilter carries Options.Pack for checks that walk inputs
+	// keyed by pack name (ledger rows, receipts, sync entries).
+	PackFilter string
+	// RepoDir is the layer-3 subject directory.
+	RepoDir string
+	Now     time.Time
+}
+
+// Check is one doctor probe: read-only, returning zero or more
+// findings. Checks never mutate anything.
+type Check struct {
+	ID    string
+	Layer int
+	Run   func(ctx *Context) []Finding
+}
+
+// checkSets returns the registered checks. Plugin-class packs get an
+// extra set dispatched from the activation contract; new check sets
+// (aae-orc-d3nq.9) register here without touching Run, the output
+// layout, or the exit policy.
+func checkSets() []Check {
+	var checks []Check
+	checks = append(checks, layer1Checks()...)
+	checks = append(checks, pluginClassChecks()...)
+	checks = append(checks, layer3Checks()...)
+	checks = append(checks, layer4Checks()...)
+	checks = append(checks, layer5Checks()...)
+	return checks
+}
+
+// Run executes the doctor and returns the assembled report plus the
+// layer list actually run (for the text renderer's grouping).
+func Run(opts Options) (Report, []int, error) {
+	layers := opts.Layers
+	if len(layers) == 0 {
+		layers = AllLayers
+	}
+	sort.Ints(layers)
+	for _, l := range layers {
+		switch l {
+		case 1, 3, 4, 5:
+		case 2:
+			return Report{}, nil, fmt.Errorf("layer 2 (pack-declared validation) is deferred to the weave engine; see aae-orc-a44c and docs/doctor-spec.md")
+		default:
+			return Report{}, nil, fmt.Errorf("unknown layer %d (valid: 1,3,4,5)", l)
+		}
+	}
+	want := make(map[int]bool, len(layers))
+	for _, l := range layers {
+		want[l] = true
+	}
+
+	now := opts.Now
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+
+	ctx := loadContext(opts, now)
+
+	var findings []Finding
+	for _, c := range checkSets() {
+		if !want[c.Layer] {
+			continue
+		}
+		fs := c.Run(ctx)
+		if c.Layer == 3 {
+			fs = clampAdvisory(fs)
+		}
+		findings = append(findings, fs...)
+	}
+	findings = sweepInvariants(findings)
+
+	return NewReport(findings, opts.Strict, now), layers, nil
+}
+
+// loadContext preloads every shared input once, capturing load errors
+// per input.
+func loadContext(opts Options, now time.Time) *Context {
+	ctx := &Context{Now: now, PackFilter: opts.Pack, RepoDir: opts.RepoDir}
+	ctx.Registry, ctx.RegistryErr = pack.LoadRegistry()
+	ctx.Ledger, ctx.LedgerErr = ledger.Load(ledger.Path())
+	ctx.Manifest, ctx.ManifestErr = bindings.LoadManifest()
+
+	if ctx.Registry != nil {
+		for _, p := range ctx.Registry.Packs {
+			if opts.Pack == "" || p.Name == opts.Pack {
+				ctx.Packs = append(ctx.Packs, p)
+			}
+		}
+	}
+	return ctx
+}
+
+// clampAdvisory enforces the ratified layer-3 decision in code: every
+// finding is advisory, and nothing exceeds warn. A check that returns
+// fail is a programming error the clamp corrects and names.
+func clampAdvisory(fs []Finding) []Finding {
+	for i := range fs {
+		fs[i].Class = Advisory
+		if fs[i].Status == Fail {
+			fs[i].Status = Warn
+			fs[i].Detail += " (graded fail by the check; clamped to warn: layer 3 is warn-only by decision)"
+		}
+	}
+	return fs
+}
+
+// sweepInvariants enforces the next-line invariant: every non-ok
+// finding names its next step. A finding without one gets an explicit
+// marker so the omission is visible in output and caught by tests,
+// never silently rendered as a dead end.
+func sweepInvariants(fs []Finding) []Finding {
+	for i := range fs {
+		if fs[i].Status != OK && fs[i].Next == "" {
+			fs[i].Next = "(no next step recorded; report this as a sideshow doctor bug)"
+		}
+	}
+	return fs
+}

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -1,0 +1,713 @@
+package doctor
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakeHome points SIDESHOW_HOME at a fresh temp dir and returns it.
+func fakeHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("SIDESHOW_HOME", home)
+	return home
+}
+
+func write(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// installVersion lays down one store version dir with optional
+// current symlink, without going through InstallFromLocal (tests
+// exercise doctor's reading, not install's writing).
+func installVersion(t *testing.T, home, name, version string, current bool) string {
+	t.Helper()
+	dir := filepath.Join(home, "packs", name, version)
+	write(t, filepath.Join(dir, "pack.yaml"), "name: "+name+"\nversion: \""+version+"\"\n")
+	if current {
+		link := filepath.Join(home, "packs", name, "current")
+		_ = os.Remove(link)
+		if err := os.Symlink(version, link); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+func registryYAML(t *testing.T, home, content string) {
+	t.Helper()
+	write(t, filepath.Join(home, "registry.yaml"), content)
+}
+
+func findBy(fs []Finding, id string) []Finding {
+	var out []Finding
+	for _, f := range fs {
+		if f.ID == id {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// --- exit policy: the diagnostic-not-gate rule as code ---
+
+func TestExitCode(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		findings []Finding
+		strict   bool
+		want     int
+	}{
+		{"clean", []Finding{{Status: OK, Class: Structural}}, false, 0},
+		{"structural fail", []Finding{{Status: Fail, Class: Structural}}, false, 2},
+		{"advisory fail never gates", []Finding{{Status: Fail, Class: Advisory}}, false, 0},
+		{"advisory fail never gates even strict", []Finding{{Status: Fail, Class: Advisory}}, true, 0},
+		{"structural warn lenient", []Finding{{Status: Warn, Class: Structural}}, false, 0},
+		{"structural warn strict", []Finding{{Status: Warn, Class: Structural}}, true, 2},
+		{"advisory warn strict never gates", []Finding{{Status: Warn, Class: Advisory}}, true, 0},
+		{"unavailable never gates", []Finding{{Status: Unavailable, Class: Structural}}, true, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := ExitCode(tt.findings, tt.strict); got != tt.want {
+				t.Errorf("ExitCode = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClampAdvisoryForcesWarnOnly(t *testing.T) {
+	t.Parallel()
+	fs := clampAdvisory([]Finding{
+		{Status: Fail, Class: Structural, Detail: "x"},
+		{Status: OK, Class: Structural},
+	})
+	if fs[0].Status != Warn || fs[0].Class != Advisory {
+		t.Errorf("fail not clamped: %+v", fs[0])
+	}
+	if !strings.Contains(fs[0].Detail, "clamped") {
+		t.Errorf("clamp must name itself: %q", fs[0].Detail)
+	}
+	if fs[1].Class != Advisory {
+		t.Errorf("layer-3 ok finding must still be advisory: %+v", fs[1])
+	}
+}
+
+func TestSweepInvariantsNamesMissingNext(t *testing.T) {
+	t.Parallel()
+	fs := sweepInvariants([]Finding{{Status: Warn, Class: Advisory}})
+	if fs[0].Next == "" || !strings.Contains(fs[0].Next, "doctor bug") {
+		t.Errorf("missing next must be visible, got %q", fs[0].Next)
+	}
+}
+
+// --- layer 1: store ---
+
+func TestStoreCoherence(t *testing.T) {
+	home := fakeHome(t)
+	installVersion(t, home, "alpha", "1.0.0", true)
+	installVersion(t, home, "skewed", "1.0.0", true)
+	dangDir := installVersion(t, home, "dangling", "1.0.0", true)
+	if err := os.RemoveAll(dangDir); err != nil {
+		t.Fatal(err)
+	}
+	registryYAML(t, home, `packs:
+  - name: alpha
+    version: 1.0.0
+    path: `+filepath.Join(home, "packs", "alpha", "current")+`
+  - name: skewed
+    version: 2.0.0
+    path: `+filepath.Join(home, "packs", "skewed", "current")+`
+  - name: dangling
+    version: 1.0.0
+    path: `+filepath.Join(home, "packs", "dangling", "current")+`
+`)
+	report, _, err := Run(Options{Layers: []int{1}, Now: time.Unix(0, 0)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := map[string]Status{}
+	for _, f := range findBy(report.Findings, "store-coherence") {
+		got[f.Pack] = f.Status
+	}
+	if got["alpha"] != OK {
+		t.Errorf("alpha = %v, want ok", got["alpha"])
+	}
+	if got["skewed"] != Fail {
+		t.Errorf("skewed = %v, want fail (registry 2.0.0 vs symlink 1.0.0)", got["skewed"])
+	}
+	if got["dangling"] != Fail {
+		t.Errorf("dangling = %v, want fail", got["dangling"])
+	}
+}
+
+func TestStoreFreeze(t *testing.T) {
+	home := fakeHome(t)
+	dir := installVersion(t, home, "alpha", "1.0.0", true)
+	registryYAML(t, home, `packs:
+  - name: alpha
+    version: 1.0.0
+    path: `+filepath.Join(home, "packs", "alpha", "current")+`
+`)
+	// Writable tree: expect the advisory warn naming benign causes.
+	report, _, err := Run(Options{Layers: []int{1}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs := findBy(report.Findings, "store-freeze")
+	if len(fs) != 1 || fs[0].Status != Warn || fs[0].Class != Advisory {
+		t.Fatalf("writable store: %+v", fs)
+	}
+	if !strings.Contains(fs[0].Detail, "cause not recorded") {
+		t.Errorf("must name benign causes: %q", fs[0].Detail)
+	}
+
+	// Freeze it: expect ok.
+	if err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		return os.Chmod(path, info.Mode().Perm()&^0o222)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return nil
+			}
+			return os.Chmod(path, info.Mode().Perm()|0o200)
+		})
+	})
+	report, _, err = Run(Options{Layers: []int{1}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs = findBy(report.Findings, "store-freeze")
+	if len(fs) != 1 || fs[0].Status != OK {
+		t.Fatalf("frozen store: %+v", fs)
+	}
+}
+
+func TestContentCensus(t *testing.T) {
+	home := fakeHome(t)
+	dir := installVersion(t, home, "alpha", "1.0.0", true)
+	installVersion(t, home, "nocensus", "1.0.0", true)
+	registryYAML(t, home, `packs:
+  - name: alpha
+    version: 1.0.0
+    path: `+filepath.Join(home, "packs", "alpha", "current")+`
+  - name: nocensus
+    version: 1.0.0
+    path: `+filepath.Join(home, "packs", "nocensus", "current")+`
+`)
+	// content "x\n" -> sha256
+	write(t, filepath.Join(dir, "agents", "a.md"), "x\n")
+	sum, err := sha256File(filepath.Join(dir, "agents", "a.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	write(t, filepath.Join(dir, "_config", "files-manifest.csv"),
+		"type,name,module,path,hash\n"+
+			`"md","a","agents","agents/a.md","`+sum+`"`+"\n"+
+			`"md","gone","agents","agents/gone.md","deadbeef"`+"\n")
+
+	report, _, err := Run(Options{Layers: []int{1}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	byPack := map[string]Finding{}
+	for _, f := range findBy(report.Findings, "store-content-census") {
+		byPack[f.Pack] = f
+	}
+	if byPack["alpha"].Status != OK {
+		t.Errorf("alpha census = %+v, want ok (unresolved paths are counted, not failed)", byPack["alpha"])
+	}
+	if byPack["nocensus"].Status != Unavailable || !strings.Contains(byPack["nocensus"].Next, "wk92") {
+		t.Errorf("no census must be unavailable naming wk92: %+v", byPack["nocensus"])
+	}
+
+	// Now corrupt the file: structural fail.
+	write(t, filepath.Join(dir, "agents", "a.md"), "tampered\n")
+	report, _, err = Run(Options{Layers: []int{1}, Pack: "alpha"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs := findBy(report.Findings, "store-content-census")
+	if len(fs) != 1 || fs[0].Status != Fail || fs[0].Class != Structural {
+		t.Fatalf("mismatch must fail structurally: %+v", fs)
+	}
+}
+
+func TestSyncManifest(t *testing.T) {
+	home := fakeHome(t)
+	installVersion(t, home, "alpha", "2.0.0", true)
+	registryYAML(t, home, `packs:
+  - name: alpha
+    version: 2.0.0
+    path: `+filepath.Join(home, "packs", "alpha", "current")+`
+`)
+	present := filepath.Join(home, "bind-present.md")
+	write(t, present, "x")
+	write(t, filepath.Join(home, "sync-manifest.yaml"), `schema_version: 0.1.0
+entries:
+  - pack: alpha
+    version: 2.0.0
+    kind: command
+    path: `+present+`
+  - pack: alpha
+    version: 1.0.0
+    kind: command
+    path: `+present+`
+  - pack: alpha
+    version: 2.0.0
+    kind: command
+    path: `+filepath.Join(home, "gone.md")+`
+  - pack: alpha
+    version: custom
+    kind: skill-dir
+    path: `+present+`
+`)
+	report, _, err := Run(Options{Layers: []int{1}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs := findBy(report.Findings, "sync-manifest")
+	var stale, missing int
+	for _, f := range fs {
+		if f.Status != Warn {
+			continue
+		}
+		if strings.Contains(f.Detail, "synced from 1.0.0") {
+			stale++
+		}
+		if strings.Contains(f.Detail, "file is gone") {
+			missing++
+		}
+		if f.Next != "sideshow commands sync" {
+			t.Errorf("next must name the command: %+v", f)
+		}
+	}
+	if stale != 1 || missing != 1 {
+		t.Errorf("stale=%d missing=%d, want 1 and 1: %+v", stale, missing, fs)
+	}
+	// The custom-source entry (version "custom") is project content;
+	// currency does not apply and it must not have warned.
+	for _, f := range fs {
+		if strings.Contains(f.Detail, "synced from custom") {
+			t.Errorf("custom-source entry warned on currency: %+v", f)
+		}
+	}
+}
+
+// --- layer 1: receipts ---
+
+// receiptFixture builds a project root with a repos.yaml, one
+// consumer repo, and a registry receipt naming the given artifacts.
+func receiptFixture(t *testing.T, home string, artifactsYAML string) (root, repo string) {
+	t.Helper()
+	root = t.TempDir()
+	repo = filepath.Join(root, "consumer")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	write(t, filepath.Join(root, "repos.yaml"), `repos:
+  consumer:
+    path: consumer
+`)
+	installVersion(t, home, "alpha", "1.0.0", true)
+	registryYAML(t, home, `packs:
+  - name: alpha
+    version: 1.0.0
+    path: `+filepath.Join(home, "packs", "alpha", "current")+`
+projects:
+  - id: proj-1
+    installations:
+      - root: `+root+`
+        manifest: `+filepath.Join(root, "repos.yaml")+`
+        repos:
+          - name: consumer
+            packs:
+              - pack: alpha
+                version: 1.0.0
+                scope: project
+                artifacts:
+`+artifactsYAML)
+	return root, repo
+}
+
+func TestReceiptMarkers(t *testing.T) {
+	home := fakeHome(t)
+	_, repo := receiptFixture(t, home, `                  - type: claude_md
+                    section_id: alpha-rules
+                  - type: rules
+                    path: .claude/rules/alpha.md
+                    checksum: sha256:ignored
+`)
+	// Lone begin marker: the silent-duplication hazard.
+	write(t, filepath.Join(repo, "CLAUDE.md"), "# repo\n<!-- sideshow:alpha-rules:begin -->\ncontent\n")
+	// Rules file that lost its managed-by first line.
+	write(t, filepath.Join(repo, ".claude", "rules", "alpha.md"), "no marker here\n")
+
+	report, _, err := Run(Options{Layers: []int{1}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs := findBy(report.Findings, "receipt-markers")
+	var unpaired, unmarked bool
+	for _, f := range fs {
+		if f.Status == Fail && strings.Contains(f.Detail, "unpaired") {
+			unpaired = true
+		}
+		if f.Status == Warn && strings.Contains(f.Detail, "managed-by marker") {
+			unmarked = true
+		}
+	}
+	if !unpaired || !unmarked {
+		t.Errorf("unpaired=%v unmarked=%v: %+v", unpaired, unmarked, fs)
+	}
+}
+
+func TestReceiptSymlinks(t *testing.T) {
+	home := fakeHome(t)
+	_, repo := receiptFixture(t, home, `                  - type: symlink
+                    path: _alpha/custom
+                    target: ../_alpha-custom
+`)
+	// Points at the wrong target.
+	if err := os.MkdirAll(filepath.Join(repo, "_alpha"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("../elsewhere", filepath.Join(repo, "_alpha", "custom")); err != nil {
+		t.Fatal(err)
+	}
+	report, _, err := Run(Options{Layers: []int{1}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs := findBy(report.Findings, "receipt-symlinks")
+	if len(fs) != 1 || fs[0].Status != Fail || !strings.Contains(fs[0].Detail, "receipt records") {
+		t.Fatalf("wrong target must fail naming both paths: %+v", fs)
+	}
+}
+
+// --- layer 1: plugin-class seam ---
+
+func TestLedgerRowCoherence(t *testing.T) {
+	home := fakeHome(t)
+	good := installVersion(t, home, "plug", "1.0.0", true)
+	registryYAML(t, home, `packs:
+  - name: plug
+    version: 1.0.0
+    path: `+filepath.Join(home, "packs", "plug", "current")+`
+`)
+	repoGood := t.TempDir()
+	repoCurrent := t.TempDir()
+	write(t, filepath.Join(home, "repo-bindings.yaml"), `schema_version: 0.1.0
+repos:
+  `+repoGood+`:
+    plug:
+      version: 1.0.0
+      store_path: `+good+`
+      channel: sideshow-native
+  `+repoCurrent+`:
+    plug:
+      version: 1.0.0
+      store_path: `+filepath.Join(home, "packs", "plug", "current")+`
+      channel: sideshow-native
+  /nonexistent-repo-dir:
+    plug:
+      version: 1.0.0
+      store_path: `+good+`
+      channel: sideshow-native
+`)
+	report, _, err := Run(Options{Layers: []int{1}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs := findBy(report.Findings, "ledger-row-coherence")
+	got := map[string]Finding{}
+	for _, f := range fs {
+		got[f.Subject] = f
+	}
+	if got[repoGood].Status != OK {
+		t.Errorf("good row: %+v", got[repoGood])
+	}
+	if f := got[repoCurrent]; f.Status != Fail || !strings.Contains(f.Detail, "current") {
+		t.Errorf("current pin must fail: %+v", f)
+	}
+	if f := got["/nonexistent-repo-dir"]; f.Status != Warn || f.Class != Advisory {
+		t.Errorf("dead repo dir is advisory, not failure: %+v", f)
+	}
+}
+
+// --- layer 4 ---
+
+func TestReceiptDrift(t *testing.T) {
+	home := fakeHome(t)
+	_, repo := receiptFixture(t, home, "") // artifacts appended below
+	// Rebuild registry with checksummed artifacts.
+	current := filepath.Join(repo, "current.md")
+	write(t, current, "kept\n")
+	sum, err := sha256File(current)
+	if err != nil {
+		t.Fatal(err)
+	}
+	drifting := filepath.Join(repo, "drifting.md")
+	write(t, drifting, "edited by hand\n")
+	root := filepath.Dir(repo)
+	registryYAML(t, home, `packs:
+  - name: alpha
+    version: 1.0.0
+    path: `+filepath.Join(home, "packs", "alpha", "current")+`
+projects:
+  - id: proj-1
+    installations:
+      - root: `+root+`
+        manifest: `+filepath.Join(root, "repos.yaml")+`
+        repos:
+          - name: consumer
+            packs:
+              - pack: alpha
+                version: 1.0.0
+                artifacts:
+                  - type: files
+                    path: current.md
+                    checksum: sha256:`+sum+`
+                  - type: files
+                    path: drifting.md
+                    checksum: sha256:0000000000000000000000000000000000000000000000000000000000000000
+                  - type: files
+                    path: missing.md
+                    checksum: sha256:1111111111111111111111111111111111111111111111111111111111111111
+`)
+	report, _, err := Run(Options{Layers: []int{4}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs := findBy(report.Findings, "receipt-drift")
+	var driftedAdvisory, missingStructural, summary bool
+	for _, f := range fs {
+		if f.Status == Warn && f.Class == Advisory && strings.Contains(f.Subject, "drifting.md") {
+			driftedAdvisory = true
+		}
+		if f.Status == Warn && f.Class == Structural && strings.Contains(f.Subject, "missing.md") {
+			missingStructural = true
+		}
+		if f.Status == OK && strings.Contains(f.Detail, "1 current, 1 drifted") {
+			summary = true
+		}
+	}
+	if !driftedAdvisory || !missingStructural || !summary {
+		t.Errorf("drifted=%v missing=%v summary=%v: %+v", driftedAdvisory, missingStructural, summary, fs)
+	}
+}
+
+func TestReceiptDriftNoReceiptsIsUnavailable(t *testing.T) {
+	home := fakeHome(t)
+	installVersion(t, home, "alpha", "1.0.0", true)
+	registryYAML(t, home, `packs:
+  - name: alpha
+    version: 1.0.0
+    path: `+filepath.Join(home, "packs", "alpha", "current")+`
+`)
+	report, _, err := Run(Options{Layers: []int{4}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs := findBy(report.Findings, "receipt-drift")
+	if len(fs) != 1 || fs[0].Status != Unavailable {
+		t.Fatalf("no receipts must be unavailable, not clean: %+v", fs)
+	}
+	if !strings.Contains(fs[0].Detail, "not the same as no drift") {
+		t.Errorf("must say silence is not cleanliness: %q", fs[0].Detail)
+	}
+}
+
+func TestVersionSkew(t *testing.T) {
+	home := fakeHome(t)
+	old := installVersion(t, home, "alpha", "1.0.0", false)
+	installVersion(t, home, "alpha", "2.0.0", true)
+	repo := t.TempDir()
+	registryYAML(t, home, `packs:
+  - name: alpha
+    version: 2.0.0
+    path: `+filepath.Join(home, "packs", "alpha", "current")+`
+`)
+	write(t, filepath.Join(home, "repo-bindings.yaml"), `schema_version: 0.1.0
+repos:
+  `+repo+`:
+    alpha:
+      version: 1.0.0
+      store_path: `+old+`
+      channel: sideshow-native
+`)
+	report, _, err := Run(Options{Layers: []int{4}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs := findBy(report.Findings, "version-skew")
+	if len(fs) != 1 || fs[0].Status != Warn || fs[0].Class != Advisory {
+		t.Fatalf("skewed enable must warn advisory: %+v", fs)
+	}
+}
+
+// --- absent inputs and layer plumbing ---
+
+func TestAbsentInputsReportUnavailable(t *testing.T) {
+	home := fakeHome(t)
+	installVersion(t, home, "alpha", "1.0.0", true)
+	registryYAML(t, home, `packs:
+  - name: alpha
+    version: 1.0.0
+    path: `+filepath.Join(home, "packs", "alpha", "current")+`
+`)
+	report, _, err := Run(Options{Layers: []int{4, 5}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantTickets := map[string]string{
+		"lock-pins":          "aae-orc-333y",
+		"known-defects":      "aae-orc-ztg5",
+		"unapplied-overlays": "aae-orc-10vq",
+	}
+	for id, ticket := range wantTickets {
+		fs := findBy(report.Findings, id)
+		if len(fs) != 1 || fs[0].Status != Unavailable {
+			t.Errorf("%s: %+v, want unavailable", id, fs)
+			continue
+		}
+		if !strings.Contains(fs[0].Next, ticket) {
+			t.Errorf("%s next must name %s: %q", id, ticket, fs[0].Next)
+		}
+	}
+}
+
+func TestLayerTwoIsRejectedWithPointer(t *testing.T) {
+	fakeHome(t)
+	_, _, err := Run(Options{Layers: []int{2}})
+	if err == nil || !strings.Contains(err.Error(), "aae-orc-a44c") {
+		t.Fatalf("layer 2 must be rejected naming the deferral: %v", err)
+	}
+}
+
+func TestLayer3IsAdvisoryByConstruction(t *testing.T) {
+	home := fakeHome(t)
+	installVersion(t, home, "alpha", "1.0.0", true)
+	registryYAML(t, home, `packs:
+  - name: alpha
+    version: 1.0.0
+    path: `+filepath.Join(home, "packs", "alpha", "current")+`
+`)
+	report, _, err := Run(Options{Layers: []int{3}, RepoDir: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(report.Findings) == 0 {
+		t.Fatal("layer 3 must produce findings")
+	}
+	for _, f := range report.Findings {
+		if f.Class != Advisory {
+			t.Errorf("layer-3 finding not advisory: %+v", f)
+		}
+		if f.Status == Fail {
+			t.Errorf("layer-3 finding graded fail: %+v", f)
+		}
+	}
+	if report.Summary.ExitCode != 0 {
+		t.Errorf("layer 3 alone must never move the exit code, got %d", report.Summary.ExitCode)
+	}
+}
+
+func TestEveryNonOKFindingCarriesNext(t *testing.T) {
+	home := fakeHome(t)
+	installVersion(t, home, "alpha", "1.0.0", true)
+	registryYAML(t, home, `packs:
+  - name: alpha
+    version: 2.0.0
+    path: `+filepath.Join(home, "packs", "alpha", "current")+`
+`)
+	report, _, err := Run(Options{RepoDir: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range report.Findings {
+		if f.Status != OK && f.Next == "" {
+			t.Errorf("non-ok finding without next: %+v", f)
+		}
+	}
+}
+
+func TestReportJSONAndText(t *testing.T) {
+	home := fakeHome(t)
+	installVersion(t, home, "alpha", "1.0.0", true)
+	registryYAML(t, home, `packs:
+  - name: alpha
+    version: 1.0.0
+    path: `+filepath.Join(home, "packs", "alpha", "current")+`
+`)
+	report, layers, err := Run(Options{Now: time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	if err := report.WriteJSON(&buf); err != nil {
+		t.Fatal(err)
+	}
+	var decoded Report
+	if err := json.Unmarshal(buf.Bytes(), &decoded); err != nil {
+		t.Fatalf("json round-trip: %v", err)
+	}
+	if decoded.SchemaVersion != "0.1.0" {
+		t.Errorf("schema_version = %q", decoded.SchemaVersion)
+	}
+
+	buf.Reset()
+	report.WriteText(&buf, layers)
+	text := buf.String()
+	if !strings.Contains(text, "layer 2, pack-declared validation, is deferred") {
+		t.Errorf("text must explain the layer-2 gap:\n%s", text)
+	}
+	for _, l := range []string{"layer 1:", "layer 3:", "layer 4:", "layer 5:"} {
+		if !strings.Contains(text, l) {
+			t.Errorf("text missing %q:\n%s", l, text)
+		}
+	}
+}
+
+func TestPackFilterNarrowsEveryLayer(t *testing.T) {
+	home := fakeHome(t)
+	installVersion(t, home, "alpha", "1.0.0", true)
+	installVersion(t, home, "beta", "1.0.0", true)
+	registryYAML(t, home, `packs:
+  - name: alpha
+    version: 1.0.0
+    path: `+filepath.Join(home, "packs", "alpha", "current")+`
+  - name: beta
+    version: 1.0.0
+    path: `+filepath.Join(home, "packs", "beta", "current")+`
+`)
+	report, _, err := Run(Options{Layers: []int{1}, Pack: "alpha"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range report.Findings {
+		if f.Pack == "beta" {
+			t.Errorf("beta finding leaked through the filter: %+v", f)
+		}
+	}
+}

--- a/internal/doctor/layer1.go
+++ b/internal/doctor/layer1.go
@@ -1,0 +1,458 @@
+package doctor
+
+import (
+	"bufio"
+	"crypto/sha256"
+	"encoding/csv"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/ArcavenAE/sideshow/internal/distribute"
+	"github.com/ArcavenAE/sideshow/internal/pack"
+)
+
+// layer1Checks is the sideshow-native integrity set: the store, the
+// sync manifest, and the receipts sideshow wrote, verified against
+// disk.
+func layer1Checks() []Check {
+	return []Check{
+		{ID: "registry-parse", Layer: 1, Run: checkRegistryParse},
+		{ID: "store-coherence", Layer: 1, Run: checkStoreCoherence},
+		{ID: "store-shape", Layer: 1, Run: checkStoreShape},
+		{ID: "store-freeze", Layer: 1, Run: checkStoreFreeze},
+		{ID: "store-content-census", Layer: 1, Run: checkContentCensus},
+		{ID: "sync-manifest", Layer: 1, Run: checkSyncManifest},
+		{ID: "receipt-markers", Layer: 1, Run: checkReceiptMarkers},
+		{ID: "receipt-symlinks", Layer: 1, Run: checkReceiptSymlinks},
+	}
+}
+
+func registryPath() string {
+	return filepath.Join(filepath.Dir(pack.PacksDir()), "registry.yaml")
+}
+
+func checkRegistryParse(ctx *Context) []Finding {
+	if ctx.RegistryErr != nil {
+		return []Finding{{
+			Layer: 1, ID: "registry-parse", Status: Fail, Class: Structural,
+			Detail: fmt.Sprintf("registry does not load: %v", ctx.RegistryErr),
+			Next:   fmt.Sprintf("inspect %s; a store we cannot read is not a health signal", registryPath()),
+		}}
+	}
+	return []Finding{{
+		Layer: 1, ID: "registry-parse", Status: OK, Class: Structural,
+		Detail: fmt.Sprintf("registry loads (%d installed packs)", len(ctx.Registry.Packs)),
+	}}
+}
+
+// checkStoreCoherence verifies that the three records of "which
+// version is active" agree: the registry row, the current symlink,
+// and the version directory on disk.
+func checkStoreCoherence(ctx *Context) []Finding {
+	var out []Finding
+	for _, p := range ctx.Packs {
+		link := filepath.Join(pack.PacksDir(), p.Name, "current")
+		target, err := os.Readlink(link)
+		if err != nil {
+			out = append(out, Finding{
+				Layer: 1, ID: "store-coherence", Pack: p.Name, Status: Fail, Class: Structural,
+				Detail: fmt.Sprintf("registry records %s installed but the current symlink does not read: %v", p.Version, err),
+				Next:   fmt.Sprintf("sideshow use %s %s", p.Name, p.Version),
+			})
+			continue
+		}
+		if _, err := os.Stat(link); err != nil {
+			out = append(out, Finding{
+				Layer: 1, ID: "store-coherence", Pack: p.Name, Status: Fail, Class: Structural,
+				Detail: fmt.Sprintf("current symlink dangles: points at %q which does not exist", target),
+				Next:   fmt.Sprintf("sideshow install %s --from <artifact>, or sideshow use %s <installed-version>", p.Name, p.Name),
+			})
+			continue
+		}
+		if target != p.Version {
+			out = append(out, Finding{
+				Layer: 1, ID: "store-coherence", Pack: p.Name, Status: Fail, Class: Structural,
+				Detail: fmt.Sprintf("registry records version %s but current points at %s; two records of the active version disagree", p.Version, target),
+				Next:   fmt.Sprintf("sideshow use %s <version> to realign both records", p.Name),
+			})
+			continue
+		}
+		out = append(out, Finding{
+			Layer: 1, ID: "store-coherence", Pack: p.Name, Status: OK, Class: Structural,
+			Detail: fmt.Sprintf("registry, current symlink, and version dir agree on %s", p.Version),
+		})
+	}
+	return out
+}
+
+// checkStoreShape warns when an installed version looks like an
+// upstream source tree rather than installer output (aae-orc-xbkl:
+// install used to accept source tarballs silently).
+func checkStoreShape(ctx *Context) []Finding {
+	var out []Finding
+	for _, p := range ctx.Packs {
+		for _, version := range installedVersionDirs(p.Name) {
+			dir := filepath.Join(pack.PacksDir(), p.Name, version)
+			if err := pack.ValidateShape(dir); err != nil {
+				out = append(out, Finding{
+					Layer: 1, ID: "store-shape", Pack: p.Name, Subject: version, Status: Warn, Class: Structural,
+					Detail: fmt.Sprintf("installed tree does not look like installer output: %v", err),
+					Next:   fmt.Sprintf("reinstall %s %s from a release artifact (sideshow install %s --from <path>)", p.Name, version, p.Name),
+				})
+			}
+		}
+	}
+	if len(out) == 0 && len(ctx.Packs) > 0 {
+		out = append(out, Finding{
+			Layer: 1, ID: "store-shape", Status: OK, Class: Structural,
+			Detail: "every installed version looks like installer output",
+		})
+	}
+	return out
+}
+
+// checkStoreFreeze verifies the store-freeze invariant (installed
+// versions are read-only). Advisory: sideshow cannot distinguish a
+// pre-freeze install from an interrupted unlock-write-refreeze, so
+// the wording names both benign causes and never says "tampered".
+func checkStoreFreeze(ctx *Context) []Finding {
+	var out []Finding
+	for _, p := range ctx.Packs {
+		for _, version := range installedVersionDirs(p.Name) {
+			dir := filepath.Join(pack.PacksDir(), p.Name, version)
+			writable := 0
+			_ = filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+				if err != nil {
+					return nil
+				}
+				info, err := d.Info()
+				if err != nil || info.Mode()&os.ModeSymlink != 0 {
+					return nil
+				}
+				if info.Mode().Perm()&0o222 != 0 {
+					writable++
+				}
+				return nil
+			})
+			if writable > 0 {
+				out = append(out, Finding{
+					Layer: 1, ID: "store-freeze", Pack: p.Name, Subject: version, Status: Warn, Class: Advisory,
+					Detail: fmt.Sprintf("%d writable entries under the version dir; freeze invariant broken; cause not recorded (installed before the store freeze, or an unlock-write-refreeze was interrupted)", writable),
+					Next:   fmt.Sprintf("reinstall to refreeze: sideshow install %s --from <artifact>", p.Name),
+				})
+			}
+		}
+	}
+	if len(out) == 0 && len(ctx.Packs) > 0 {
+		out = append(out, Finding{
+			Layer: 1, ID: "store-freeze", Status: OK, Class: Advisory,
+			Detail: "every installed version is frozen read-only",
+		})
+	}
+	return out
+}
+
+// checkContentCensus re-hashes the store tree against the per-file
+// census the pack itself ships (_config/files-manifest.csv; bmad
+// does, vsdd-factory does not). Absent census is unavailable, not
+// clean: release-asset manifests are not retained on install today.
+func checkContentCensus(ctx *Context) []Finding {
+	var out []Finding
+	for _, p := range ctx.Packs {
+		for _, version := range installedVersionDirs(p.Name) {
+			dir := filepath.Join(pack.PacksDir(), p.Name, version)
+			census := filepath.Join(dir, "_config", "files-manifest.csv")
+			f, err := os.Open(census)
+			if err != nil {
+				out = append(out, Finding{
+					Layer: 1, ID: "store-content-census", Pack: p.Name, Subject: version, Status: Unavailable, Class: Structural,
+					Detail: "the pack ships no _config/files-manifest.csv and release-asset manifests are not retained on install; content integrity has no input here",
+					Next:   "aae-orc-wk92 (fetch/verify consumer retains release manifests)",
+				})
+				continue
+			}
+			verified, mismatched, unresolved, samples := censusCompare(f, dir)
+			_ = f.Close()
+			if mismatched > 0 {
+				out = append(out, Finding{
+					Layer: 1, ID: "store-content-census", Pack: p.Name, Subject: version, Status: Fail, Class: Structural,
+					Detail: fmt.Sprintf("%d of %d census entries differ from the store tree (first: %s); %d entries name paths not present in this layout", mismatched, verified+mismatched, strings.Join(samples, ", "), unresolved),
+					Next:   fmt.Sprintf("reinstall %s %s from its release artifact and re-run doctor", p.Name, version),
+				})
+			} else {
+				out = append(out, Finding{
+					Layer: 1, ID: "store-content-census", Pack: p.Name, Subject: version, Status: OK, Class: Structural,
+					Detail: fmt.Sprintf("%d census entries verified (%d name paths not present in this layout)", verified, unresolved),
+				})
+			}
+		}
+	}
+	return out
+}
+
+// censusCompare walks one files-manifest.csv (columns
+// type,name,module,path,hash) against root. Paths the census names
+// that are absent are counted, not failed: installer output layout
+// legitimately differs from some census rows.
+func censusCompare(r io.Reader, root string) (verified, mismatched, unresolved int, samples []string) {
+	cr := csv.NewReader(r)
+	cr.FieldsPerRecord = -1
+	first := true
+	for {
+		rec, err := cr.Read()
+		if err != nil {
+			break
+		}
+		if first {
+			first = false
+			continue // header
+		}
+		if len(rec) < 5 {
+			continue
+		}
+		rel, want := rec[3], rec[4]
+		got, err := sha256File(filepath.Join(root, rel))
+		if err != nil {
+			unresolved++
+			continue
+		}
+		if got == want {
+			verified++
+		} else {
+			mismatched++
+			if len(samples) < 3 {
+				samples = append(samples, rel)
+			}
+		}
+	}
+	return verified, mismatched, unresolved, samples
+}
+
+// checkSyncManifest verifies the commands-sync receipt: every entry
+// path still exists, and every entry's version matches the pack's
+// active store version. Presence and currency only: the manifest
+// records no content hashes (sync-content stays unavailable until a
+// receipt change adds them).
+func checkSyncManifest(ctx *Context) []Finding {
+	if ctx.ManifestErr != nil {
+		return []Finding{{
+			Layer: 1, ID: "sync-manifest", Status: Unavailable, Class: Structural,
+			Detail: fmt.Sprintf("sync manifest does not load: %v", ctx.ManifestErr),
+			Next:   "run 'sideshow commands sync' to regenerate it",
+		}}
+	}
+	active := map[string]string{}
+	for _, p := range ctx.Packs {
+		active[p.Name] = p.Version
+	}
+	var out []Finding
+	entries := 0
+	for _, e := range ctx.Manifest.Entries {
+		if ctx.PackFilter != "" && e.Pack != ctx.PackFilter {
+			continue
+		}
+		entries++
+		if _, err := os.Stat(e.Path); err != nil {
+			out = append(out, Finding{
+				Layer: 1, ID: "sync-manifest", Pack: e.Pack, Subject: e.Path, Status: Warn, Class: Structural,
+				Detail: "the sync manifest records this binding but the file is gone",
+				Next:   "sideshow commands sync",
+			})
+			continue
+		}
+		// Custom-skills sources record "custom": project content, not
+		// store content, so version currency does not apply to them.
+		if e.Version == "custom" {
+			continue
+		}
+		if v, ok := active[e.Pack]; ok && v != e.Version {
+			out = append(out, Finding{
+				Layer: 1, ID: "sync-manifest", Pack: e.Pack, Subject: e.Path, Status: Warn, Class: Structural,
+				Detail: fmt.Sprintf("binding synced from %s while the active store version is %s", e.Version, v),
+				Next:   "sideshow commands sync",
+			})
+		}
+	}
+	if len(out) == 0 {
+		out = append(out, Finding{
+			Layer: 1, ID: "sync-manifest", Status: OK, Class: Structural,
+			Detail: fmt.Sprintf("%d synced bindings exist and match their pack's active version (presence and currency only; the manifest records no content hashes)", entries),
+		})
+	}
+	return out
+}
+
+// checkReceiptMarkers verifies the managed-content markers the
+// receipts promise: claude_md sections keep paired begin/end markers
+// (a lone begin silently duplicates the section on the next
+// distribute run), and rules files keep their managed-by first line.
+func checkReceiptMarkers(ctx *Context) []Finding {
+	var out []Finding
+	forEachReceiptRepo(ctx, func(repoDir string, pd pack.PackDistribution) {
+		var sections []string
+		for _, a := range pd.Artifacts {
+			switch a.Type {
+			case "claude_md":
+				if a.SectionID != "" {
+					sections = append(sections, a.SectionID)
+				}
+			case "rules":
+				if a.Path == "" {
+					continue
+				}
+				path := filepath.Join(repoDir, a.Path)
+				line, err := firstLine(path)
+				if err != nil {
+					continue // absence is layer 4's receipt-drift subject
+				}
+				if !strings.HasPrefix(line, distribute.MarkerPrefix) {
+					out = append(out, Finding{
+						Layer: 1, ID: "receipt-markers", Pack: pd.Pack, Subject: path, Status: Warn, Class: Structural,
+						Detail: "receipted rules file lost its managed-by marker line; the next distribute run will treat it as unmanaged",
+						Next:   "restore the marker or re-run 'sideshow init' for this project",
+					})
+				}
+			}
+		}
+		if len(sections) == 0 {
+			return
+		}
+		claudeMD := filepath.Join(repoDir, "CLAUDE.md")
+		content, err := os.ReadFile(claudeMD)
+		if err != nil {
+			return // absence is layer 4's subject
+		}
+		text := string(content)
+		for _, id := range sections {
+			begin := strings.Count(text, distribute.SectionBegin(id))
+			end := strings.Count(text, distribute.SectionEnd(id))
+			switch {
+			case begin == 1 && end == 1:
+				// paired; ordering is implied by the writer refusing
+				// inverted markers
+			case begin == 0 && end == 0:
+				out = append(out, Finding{
+					Layer: 1, ID: "receipt-markers", Pack: pd.Pack, Subject: claudeMD, Status: Warn, Class: Structural,
+					Detail: fmt.Sprintf("receipted section %q is absent from CLAUDE.md", id),
+					Next:   "re-run 'sideshow init' for this project to restore it",
+				})
+			default:
+				out = append(out, Finding{
+					Layer: 1, ID: "receipt-markers", Pack: pd.Pack, Subject: claudeMD, Status: Fail, Class: Structural,
+					Detail: fmt.Sprintf("section %q markers are unpaired (%d begin, %d end); the next distribute run would silently append a duplicate section", id, begin, end),
+					Next:   "repair the marker pair by hand before the next 'sideshow init' run",
+				})
+			}
+		}
+	})
+	if len(out) == 0 {
+		out = append(out, Finding{
+			Layer: 1, ID: "receipt-markers", Status: OK, Class: Structural,
+			Detail: "every receipted marker is paired and present",
+		})
+	}
+	return out
+}
+
+// checkReceiptSymlinks verifies receipted symlink artifacts still
+// exist, are symlinks, and point at their recorded target (the
+// customization bridge and runtime links are receipted this way).
+func checkReceiptSymlinks(ctx *Context) []Finding {
+	var out []Finding
+	forEachReceiptRepo(ctx, func(repoDir string, pd pack.PackDistribution) {
+		for _, a := range pd.Artifacts {
+			if a.Type != "symlink" || a.Path == "" {
+				continue
+			}
+			path := filepath.Join(repoDir, a.Path)
+			fi, err := os.Lstat(path)
+			if err != nil {
+				out = append(out, Finding{
+					Layer: 1, ID: "receipt-symlinks", Pack: pd.Pack, Subject: path, Status: Warn, Class: Structural,
+					Detail: "receipted symlink is gone",
+					Next:   fmt.Sprintf("sideshow project init %s (recreates it)", pd.Pack),
+				})
+				continue
+			}
+			if fi.Mode()&os.ModeSymlink == 0 {
+				out = append(out, Finding{
+					Layer: 1, ID: "receipt-symlinks", Pack: pd.Pack, Subject: path, Status: Fail, Class: Structural,
+					Detail: "a real file or directory occupies a receipted symlink path",
+					Next:   "move the occupant aside, then sideshow project init " + pd.Pack,
+				})
+				continue
+			}
+			got, _ := os.Readlink(path)
+			if got != a.Target {
+				out = append(out, Finding{
+					Layer: 1, ID: "receipt-symlinks", Pack: pd.Pack, Subject: path, Status: Fail, Class: Structural,
+					Detail: fmt.Sprintf("symlink points at %q, receipt records %q", got, a.Target),
+					Next:   fmt.Sprintf("sideshow project init %s (recreates it)", pd.Pack),
+				})
+				continue
+			}
+			if _, err := os.Stat(path); err != nil {
+				out = append(out, Finding{
+					Layer: 1, ID: "receipt-symlinks", Pack: pd.Pack, Subject: path, Status: Fail, Class: Structural,
+					Detail: fmt.Sprintf("symlink dangles: target %q does not resolve", a.Target),
+					Next:   fmt.Sprintf("reinstall or 'sideshow use %s <version>' so the target exists, then re-run doctor", pd.Pack),
+				})
+			}
+		}
+	})
+	if len(out) == 0 {
+		out = append(out, Finding{
+			Layer: 1, ID: "receipt-symlinks", Status: OK, Class: Structural,
+			Detail: "every receipted symlink resolves to its recorded target",
+		})
+	}
+	return out
+}
+
+// installedVersionDirs lists the version dirs of one pack, ignoring
+// the current symlink. Errors surface through store-coherence.
+func installedVersionDirs(name string) []string {
+	entries, err := os.ReadDir(filepath.Join(pack.PacksDir(), name))
+	if err != nil {
+		return nil
+	}
+	var versions []string
+	for _, e := range entries {
+		if e.Name() == "current" || !e.IsDir() {
+			continue
+		}
+		versions = append(versions, e.Name())
+	}
+	return versions
+}
+
+func sha256File(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = f.Close() }() // read-only handle
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func firstLine(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = f.Close() }() // read-only handle
+	s := bufio.NewScanner(f)
+	if s.Scan() {
+		return s.Text(), nil
+	}
+	return "", s.Err()
+}

--- a/internal/doctor/layer3.go
+++ b/internal/doctor/layer3.go
@@ -1,0 +1,143 @@
+package doctor
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/ArcavenAE/sideshow/internal/coexistcheck"
+	"github.com/ArcavenAE/sideshow/internal/factoryguard"
+	"github.com/ArcavenAE/sideshow/internal/foreign"
+	"github.com/ArcavenAE/sideshow/internal/pack"
+)
+
+// layer3Checks is the cwd discoverability probe. Warn-only by
+// ratified decision; the runner clamps everything here to advisory
+// and to warn or below, so nothing in this layer can gate CI or
+// abort a run.
+func layer3Checks() []Check {
+	return []Check{
+		{ID: "cwd-known", Layer: 3, Run: checkCwdKnown},
+		{ID: "cwd-coexistence", Layer: 3, Run: checkCwdCoexistence},
+		{ID: "cwd-factory-guard", Layer: 3, Run: checkCwdFactoryGuard},
+	}
+}
+
+func checkCwdKnown(ctx *Context) []Finding {
+	if ctx.RepoDir == "" {
+		return []Finding{{
+			Layer: 3, ID: "cwd-known", Status: Unavailable, Class: Advisory,
+			Detail: "working directory could not be resolved",
+			Next:   "re-run with --repo <path>",
+		}}
+	}
+	var how []string
+	if ctx.Ledger != nil {
+		for _, dir := range ctx.Ledger.RepoDirs() {
+			if dir == ctx.RepoDir {
+				how = append(how, "repo-bindings ledger row")
+				break
+			}
+		}
+	}
+	if ctx.Registry != nil {
+		for _, proj := range ctx.Registry.Projects {
+			for _, inst := range proj.Installations {
+				if ctx.RepoDir == inst.Root || strings.HasPrefix(ctx.RepoDir, inst.Root+string(filepath.Separator)) {
+					how = append(how, "project installation root "+inst.Root)
+				}
+			}
+		}
+	}
+	if len(how) == 0 {
+		return []Finding{{
+			Layer: 3, ID: "cwd-known", Subject: ctx.RepoDir, Status: Warn, Class: Advisory,
+			Detail: "sideshow has no record of this directory; an agent started here finds no sideshow-managed content",
+			Next:   "sideshow enable <pack> --repo . (plugin-class) or sideshow init (project distribution)",
+		}}
+	}
+	return []Finding{{
+		Layer: 3, ID: "cwd-known", Subject: ctx.RepoDir, Status: OK, Class: Advisory,
+		Detail: "known via " + strings.Join(how, "; "),
+	}}
+}
+
+// checkCwdCoexistence runs the read-only coexist-check battery for
+// every installed pack against the subject directory. ERROR grades
+// are reported with their original grade named but land as warn:
+// this layer informs, it does not gate.
+func checkCwdCoexistence(ctx *Context) []Finding {
+	if ctx.RepoDir == "" {
+		return nil // cwd-known already reported the missing subject
+	}
+	var out []Finding
+	for _, p := range ctx.Packs {
+		opts := coexistcheck.Options{
+			RepoDir:         ctx.RepoDir,
+			Pack:            p.Name,
+			Prefix:          p.Name,
+			ConfigDir:       foreign.ConfigDir(),
+			PerRepoRequired: true,
+			Now:             ctx.Now,
+		}
+		if act, err := pack.LoadActivation(p.Path); err == nil && act != nil {
+			opts.Prefix = act.Prefix(p.Name)
+			opts.PerRepoRequired = act.PerRepoRequired
+		}
+		if resolved, err := filepath.EvalSymlinks(p.Path); err == nil {
+			opts.StoreRoot = resolved
+		}
+		report, err := coexistcheck.Run(opts)
+		if err != nil {
+			out = append(out, Finding{
+				Layer: 3, ID: "cwd-coexistence", Pack: p.Name, Status: Unavailable, Class: Advisory,
+				Detail: fmt.Sprintf("coexist-check did not run: %v", err),
+				Next:   fmt.Sprintf("sideshow coexist-check %s --repo %s", p.Name, ctx.RepoDir),
+			})
+			continue
+		}
+		clean := true
+		for _, res := range report.Results {
+			if res.Severity == foreign.Info {
+				continue
+			}
+			clean = false
+			detail := fmt.Sprintf("check %d (%s): %s", res.Check, res.Name, res.Detail)
+			if res.Severity == foreign.Error {
+				detail += " (graded ERROR by coexist-check; enable would refuse here)"
+			}
+			out = append(out, Finding{
+				Layer: 3, ID: "cwd-coexistence", Pack: p.Name, Subject: ctx.RepoDir, Status: Warn, Class: Advisory,
+				Detail: detail,
+				Next:   fmt.Sprintf("sideshow coexist-check %s --repo %s (full battery output)", p.Name, ctx.RepoDir),
+			})
+		}
+		if clean {
+			out = append(out, Finding{
+				Layer: 3, ID: "cwd-coexistence", Pack: p.Name, Subject: ctx.RepoDir, Status: OK, Class: Advisory,
+				Detail: "coexistence battery clean",
+			})
+		}
+	}
+	return out
+}
+
+// checkCwdFactoryGuard reports in-flight factory activity. The
+// signal is TTL-based, so the observation time is printed.
+func checkCwdFactoryGuard(ctx *Context) []Finding {
+	if ctx.RepoDir == "" {
+		return nil
+	}
+	v := factoryguard.CheckRepo(ctx.RepoDir, ctx.Now)
+	if v == nil || !v.InFlight() {
+		return []Finding{{
+			Layer: 3, ID: "cwd-factory-guard", Subject: ctx.RepoDir, Status: OK, Class: Advisory,
+			Detail: "no in-flight factory activity",
+		}}
+	}
+	return []Finding{{
+		Layer: 3, ID: "cwd-factory-guard", Subject: ctx.RepoDir, Status: Warn, Class: Advisory,
+		Detail: fmt.Sprintf("%s (observed at %s; the signal is TTL-based)", v.Refusal(), ctx.Now.Format("15:04:05 MST")),
+		Next:   "wait for the run to finish, or confirm the lock is stale before overriding anything",
+	}}
+}

--- a/internal/doctor/layer4.go
+++ b/internal/doctor/layer4.go
@@ -1,0 +1,150 @@
+package doctor
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/ArcavenAE/sideshow/internal/pack"
+)
+
+// layer4Checks is the fleet-drift set: what sideshow distributed
+// across repos, verified against its receipts. The pinned-version
+// comparison against sideshow.lock stays unavailable until the
+// lockfile ships (aae-orc-333y); receipt re-hashing and version skew
+// are the honest signals that need no new input.
+func layer4Checks() []Check {
+	return []Check{
+		{ID: "receipt-drift", Layer: 4, Run: checkReceiptDrift},
+		{ID: "version-skew", Layer: 4, Run: checkVersionSkew},
+		{ID: "lock-pins", Layer: 4, Run: checkLockPins},
+	}
+}
+
+// checkReceiptDrift re-hashes every receipted artifact that carries a
+// checksum against disk (the sideshow#92 signal). A missing receipted
+// file is structural: the receipt claims ownership of a path that is
+// gone. A changed one is advisory: a user edit is a deliberate act,
+// not malformed state. The skip census rides along so "no findings"
+// cannot read as "no drift".
+func checkReceiptDrift(ctx *Context) []Finding {
+	if ctx.RegistryErr != nil {
+		return []Finding{{
+			Layer: 4, ID: "receipt-drift", Status: Unavailable, Class: Structural,
+			Detail: fmt.Sprintf("registry does not load: %v", ctx.RegistryErr),
+			Next:   fmt.Sprintf("inspect %s", registryPath()),
+		}}
+	}
+	var out []Finding
+	receipts, current, drifted := 0, 0, 0
+	skips := forEachReceiptRepo(ctx, func(repoDir string, pd pack.PackDistribution) {
+		for _, a := range pd.Artifacts {
+			if a.Checksum == "" || a.Path == "" {
+				continue
+			}
+			receipts++
+			path := filepath.Join(repoDir, a.Path)
+			got, err := sha256File(path)
+			if err != nil {
+				out = append(out, Finding{
+					Layer: 4, ID: "receipt-drift", Pack: pd.Pack, Subject: path, Status: Warn, Class: Structural,
+					Detail: "receipted artifact is gone; the receipt claims sideshow placed it here",
+					Next:   "re-run 'sideshow init' for this project, or retire the receipt by redistributing",
+				})
+				continue
+			}
+			want := strings.TrimPrefix(a.Checksum, "sha256:")
+			if got != want {
+				drifted++
+				out = append(out, Finding{
+					Layer: 4, ID: "receipt-drift", Pack: pd.Pack, Subject: path, Status: Warn, Class: Advisory,
+					Detail: fmt.Sprintf("differs from the %s receipt (a user edit is a deliberate act; distribution preserves it)", pd.Version),
+					Next:   "diff against the pack copy if the divergence is unintended",
+				})
+				continue
+			}
+			current++
+		}
+	})
+
+	// Coverage: what the drift signal could not see, and why the
+	// receipt set under-covers even where repos are reachable.
+	for _, s := range skips {
+		out = append(out, Finding{
+			Layer: 4, ID: "receipt-drift", Subject: s.Subject, Status: Warn, Class: Advisory,
+			Detail: "skipped: " + s.Reason,
+			Next:   "remove dead registry entries by redistributing, or ignore if the checkout is expected to be absent",
+		})
+	}
+	if receipts == 0 {
+		out = append(out, Finding{
+			Layer: 4, ID: "receipt-drift", Status: Unavailable, Class: Structural,
+			Detail: "no checksummed receipts exist; there is no drift signal (which is not the same as no drift). Two known under-coverage causes: RecordResults keeps only wrote/merged actions and replaces artifact lists wholesale, and 'sideshow project init' writes no receipts",
+			Next:   "sideshow#92 tracks receipt fidelity; run 'sideshow init' distribution to create receipts",
+		})
+		return out
+	}
+	out = append(out, Finding{
+		Layer: 4, ID: "receipt-drift", Status: OK, Class: Structural,
+		Detail: fmt.Sprintf("%d checksummed receipts: %d current, %d drifted, %d skipped subtrees (coverage caveat: partial distribute runs drop receipts for files they skipped; sideshow#92)", receipts, current, drifted, len(skips)),
+	})
+	return out
+}
+
+// checkVersionSkew compares every receipt version and ledger row
+// version against the pack's active store version. Advisory: running
+// behind is a state to know about, not malformed state.
+func checkVersionSkew(ctx *Context) []Finding {
+	active := map[string]string{}
+	for _, p := range ctx.Packs {
+		active[p.Name] = p.Version
+	}
+	var out []Finding
+	forEachReceiptRepo(ctx, func(repoDir string, pd pack.PackDistribution) {
+		if v, ok := active[pd.Pack]; ok && v != pd.Version {
+			out = append(out, Finding{
+				Layer: 4, ID: "version-skew", Pack: pd.Pack, Subject: repoDir, Status: Warn, Class: Advisory,
+				Detail: fmt.Sprintf("distributed at %s; active store version is %s", pd.Version, v),
+				Next:   "re-run 'sideshow init' distribution to bring this repo current",
+			})
+		}
+	})
+	if ctx.Ledger != nil {
+		for repoDir, packs := range ctx.Ledger.Repos {
+			for packName, row := range packs {
+				if ctx.PackFilter != "" && packName != ctx.PackFilter {
+					continue
+				}
+				if _, err := os.Stat(repoDir); err != nil {
+					continue // ledger-row-coherence owns dead rows
+				}
+				if v, ok := active[packName]; ok && v != row.Version {
+					out = append(out, Finding{
+						Layer: 4, ID: "version-skew", Pack: packName, Subject: repoDir, Status: Warn, Class: Advisory,
+						Detail: fmt.Sprintf("enabled at %s; active store version is %s (enables pin deliberately; skew is information, not an error)", row.Version, v),
+						Next:   fmt.Sprintf("sideshow disable %s --repo %s && sideshow enable %s --repo %s to move the pin", packName, repoDir, packName, repoDir),
+					})
+				}
+			}
+		}
+	}
+	if len(out) == 0 {
+		out = append(out, Finding{
+			Layer: 4, ID: "version-skew", Status: OK, Class: Advisory,
+			Detail: "every receipt and ledger row matches its pack's active store version",
+		})
+	}
+	return out
+}
+
+// checkLockPins is the pinned-version comparison. No sideshow.lock
+// exists yet, so the check reports its missing input by name instead
+// of pretending the fleet is pinned.
+func checkLockPins(_ *Context) []Finding {
+	return []Finding{{
+		Layer: 4, ID: "lock-pins", Status: Unavailable, Class: Structural,
+		Detail: "sideshow.lock is not implemented; the pinned-version comparison has no input. Version skew against the installed store is reported instead",
+		Next:   "aae-orc-333y (lockfile spec and feature)",
+	}}
+}

--- a/internal/doctor/layer5.go
+++ b/internal/doctor/layer5.go
@@ -1,0 +1,29 @@
+package doctor
+
+// layer5Checks is the known-defects surface. Both inputs are
+// unshipped, so both checks report unavailable with the tickets that
+// supply them. Doctor is offline by design in this phase: no network
+// call anywhere, so a future feed lands as a cached file read, not a
+// fetch.
+func layer5Checks() []Check {
+	return []Check{
+		{ID: "known-defects", Layer: 5, Run: checkKnownDefects},
+		{ID: "unapplied-overlays", Layer: 5, Run: checkUnappliedOverlays},
+	}
+}
+
+func checkKnownDefects(_ *Context) []Finding {
+	return []Finding{{
+		Layer: 5, ID: "known-defects", Status: Unavailable, Class: Structural,
+		Detail: "no known-defects feed exists yet; installed versions cannot be cross-referenced against publisher advisories",
+		Next:   "aae-orc-ztg5 (publisher feed), then aae-orc-e1jj (this check's implementation)",
+	}}
+}
+
+func checkUnappliedOverlays(_ *Context) []Finding {
+	return []Finding{{
+		Layer: 5, ID: "unapplied-overlays", Status: Unavailable, Class: Structural,
+		Detail: "no overlay artifact has ever been published and no applied-overlay record exists; the check has no input at all",
+		Next:   "aae-orc-10vq (overlay artifact spec) and aae-orc-333y (applied-overlay record in the lockfile)",
+	}}
+}

--- a/internal/doctor/plugin_class.go
+++ b/internal/doctor/plugin_class.go
@@ -1,0 +1,87 @@
+package doctor
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// pluginClassChecks is the mechanism-keyed check set for packs that
+// activate per repo (repo-bindings channel). The seam for
+// aae-orc-d3nq.9: the per-repo bind battery (env shim, hook chain,
+// dispatcher exec, local-scope symlinks, replay preflight, dangling
+// foreign registrations) registers here as further checks without
+// touching Run, the output layout, or the exit policy. This PR ships
+// one check so the seam is proven by use.
+func pluginClassChecks() []Check {
+	return []Check{
+		{ID: "ledger-row-coherence", Layer: 1, Run: checkLedgerRows},
+	}
+}
+
+// checkLedgerRows verifies every repo-bindings ledger row against
+// disk: the pinned store path exists and is a version dir (the
+// ledger contract forbids `current`), the row's version matches the
+// dir, and the bound repo still exists.
+func checkLedgerRows(ctx *Context) []Finding {
+	if ctx.LedgerErr != nil {
+		return []Finding{{
+			Layer: 1, ID: "ledger-row-coherence", Status: Unavailable, Class: Structural,
+			Detail: fmt.Sprintf("ledger does not load: %v (readers fail closed rather than reporting a repo as unbound)", ctx.LedgerErr),
+			Next:   "inspect the repo-bindings ledger by hand; do not delete it",
+		}}
+	}
+	var out []Finding
+	rows := 0
+	for repoDir, packs := range ctx.Ledger.Repos {
+		for packName, row := range packs {
+			if ctx.PackFilter != "" && packName != ctx.PackFilter {
+				continue
+			}
+			rows++
+			if _, err := os.Stat(repoDir); err != nil {
+				out = append(out, Finding{
+					Layer: 1, ID: "ledger-row-coherence", Pack: packName, Subject: repoDir, Status: Warn, Class: Advisory,
+					Detail: "ledger row for a repo path that no longer exists (a distinct condition, not a failure)",
+					Next:   fmt.Sprintf("sideshow disable %s --repo %s to retire the row if the repo is gone for good", packName, repoDir),
+				})
+				continue
+			}
+			if filepath.Base(row.StorePath) == "current" {
+				out = append(out, Finding{
+					Layer: 1, ID: "ledger-row-coherence", Pack: packName, Subject: repoDir, Status: Fail, Class: Structural,
+					Detail: "ledger row pins `current` instead of a version dir; the ledger contract records the resolved version so version flips cannot silently retarget enabled repos",
+					Next:   fmt.Sprintf("sideshow disable %s --repo %s && sideshow enable %s --repo %s", packName, repoDir, packName, repoDir),
+				})
+				continue
+			}
+			if _, err := os.Stat(row.StorePath); err != nil {
+				out = append(out, Finding{
+					Layer: 1, ID: "ledger-row-coherence", Pack: packName, Subject: repoDir, Status: Fail, Class: Structural,
+					Detail: fmt.Sprintf("pinned store path %s is gone; every binding in this repo is dangling", row.StorePath),
+					Next:   fmt.Sprintf("reinstall %s %s, or disable and re-enable against an installed version", packName, row.Version),
+				})
+				continue
+			}
+			if filepath.Base(row.StorePath) != row.Version {
+				out = append(out, Finding{
+					Layer: 1, ID: "ledger-row-coherence", Pack: packName, Subject: repoDir, Status: Fail, Class: Structural,
+					Detail: fmt.Sprintf("row records version %s but pins store dir %s; two records of the bound version disagree", row.Version, row.StorePath),
+					Next:   fmt.Sprintf("sideshow disable %s --repo %s && sideshow enable %s --repo %s", packName, repoDir, packName, repoDir),
+				})
+				continue
+			}
+			out = append(out, Finding{
+				Layer: 1, ID: "ledger-row-coherence", Pack: packName, Subject: repoDir, Status: OK, Class: Structural,
+				Detail: fmt.Sprintf("row pins %s and disk agrees", row.Version),
+			})
+		}
+	}
+	if rows == 0 {
+		out = append(out, Finding{
+			Layer: 1, ID: "ledger-row-coherence", Status: OK, Class: Structural,
+			Detail: "no repo-bindings ledger rows to verify",
+		})
+	}
+	return out
+}

--- a/internal/doctor/receipts.go
+++ b/internal/doctor/receipts.go
@@ -1,0 +1,83 @@
+package doctor
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/ArcavenAE/sideshow/internal/pack"
+	"github.com/ArcavenAE/sideshow/internal/project"
+)
+
+// receiptSkip records one receipt subtree doctor could not walk, so
+// coverage reporting can say what was skipped and why instead of
+// letting "no findings" read as "no drift".
+type receiptSkip struct {
+	Subject string
+	Reason  string
+}
+
+// forEachReceiptRepo resolves every reachable receipted repo and
+// calls fn once per pack distribution, honoring the pack filter.
+// Repo paths resolve the way distribution wrote them: the recorded
+// repo path when present, else the installation's repos manifest
+// (RecordResults does not populate RepoDistribution.Path today).
+func forEachReceiptRepo(ctx *Context, fn func(repoDir string, pd pack.PackDistribution)) []receiptSkip {
+	var skips []receiptSkip
+	if ctx.Registry == nil {
+		return skips
+	}
+	for _, proj := range ctx.Registry.Projects {
+		for _, inst := range proj.Installations {
+			if _, err := os.Stat(inst.Root); err != nil {
+				skips = append(skips, receiptSkip{Subject: inst.Root, Reason: "installation root no longer exists"})
+				continue
+			}
+			paths := repoPathIndex(inst)
+			for _, rd := range inst.Repos {
+				repoDir := rd.Path
+				if repoDir == "" {
+					repoDir = paths[rd.Name]
+				}
+				if repoDir == "" {
+					skips = append(skips, receiptSkip{Subject: rd.Name, Reason: "repo path unresolvable (receipt records no path and the repos manifest does not list it)"})
+					continue
+				}
+				if _, err := os.Stat(repoDir); err != nil {
+					skips = append(skips, receiptSkip{Subject: repoDir, Reason: "receipted repo dir no longer exists"})
+					continue
+				}
+				for _, pd := range rd.Packs {
+					if ctx.PackFilter != "" && pd.Pack != ctx.PackFilter {
+						continue
+					}
+					fn(repoDir, pd)
+				}
+			}
+		}
+	}
+	return skips
+}
+
+// repoPathIndex maps receipt repo names to absolute paths via the
+// installation's recorded repos manifest.
+func repoPathIndex(inst pack.Installation) map[string]string {
+	idx := map[string]string{}
+	manifestPath := inst.Manifest
+	if manifestPath == "" {
+		manifestPath = project.FindReposManifest(inst.Root)
+	}
+	if manifestPath == "" {
+		return idx
+	}
+	if !filepath.IsAbs(manifestPath) {
+		manifestPath = filepath.Join(inst.Root, manifestPath)
+	}
+	m, err := project.LoadReposManifest(manifestPath)
+	if err != nil {
+		return idx
+	}
+	for _, sub := range project.ResolveSubrepos(inst.Root, m) {
+		idx[sub.Name] = sub.AbsPath
+	}
+	return idx
+}

--- a/internal/doctor/report.go
+++ b/internal/doctor/report.go
@@ -1,0 +1,174 @@
+// Package doctor is the read-only health surface over the state
+// sideshow itself has written: the pack store, the registry receipts,
+// the sync manifest, and the repo-bindings ledger. Every check
+// verifies a promise some receipt, ledger row, marker, or doc
+// sentence already makes. Doctor proposes; it never mutates.
+// Spec: docs/doctor-spec.md. Ticket: aae-orc-xteh.
+package doctor
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"time"
+)
+
+// Status is the outcome of one finding.
+type Status string
+
+const (
+	OK          Status = "ok"
+	Warn        Status = "warn"
+	Fail        Status = "fail"
+	Unavailable Status = "unavailable"
+)
+
+// Class separates well-formedness from health. Only structural
+// findings may move the exit code (orc rule diagnostic-not-gate):
+// structural means sideshow's own records disagree with disk;
+// advisory means a health signal a human may have intended.
+type Class string
+
+const (
+	Structural Class = "structural"
+	Advisory   Class = "advisory"
+)
+
+// Finding is one check observation.
+type Finding struct {
+	Layer   int    `json:"layer"`
+	ID      string `json:"id"`
+	Pack    string `json:"pack,omitempty"`
+	Subject string `json:"subject,omitempty"`
+	Status  Status `json:"status"`
+	Class   Class  `json:"class"`
+	Detail  string `json:"detail"`
+	// Next names the command to run, the doc to read, or the bd
+	// ticket that supplies a missing input. Required on every
+	// non-ok finding (enforced by the runner's invariant sweep).
+	Next string `json:"next,omitempty"`
+}
+
+// Report is a full doctor run.
+type Report struct {
+	SchemaVersion string    `json:"schema_version"`
+	GeneratedAt   string    `json:"generated_at"`
+	Findings      []Finding `json:"findings"`
+	Summary       Summary   `json:"summary"`
+}
+
+// Summary carries the per-status counts and the computed exit code.
+type Summary struct {
+	OK          int `json:"ok"`
+	Warn        int `json:"warn"`
+	Fail        int `json:"fail"`
+	Unavailable int `json:"unavailable"`
+	ExitCode    int `json:"exit_code"`
+}
+
+const reportSchemaVersion = "0.1.0"
+
+// ExitCode computes the exit policy: 0 unless a structural fail is
+// present; strict additionally promotes structural warns. Advisory
+// and unavailable findings never affect the exit code, under any
+// flag. This is the diagnostic-not-gate rule as code.
+func ExitCode(findings []Finding, strict bool) int {
+	for _, f := range findings {
+		if f.Class != Structural {
+			continue
+		}
+		if f.Status == Fail {
+			return 2
+		}
+		if strict && f.Status == Warn {
+			return 2
+		}
+	}
+	return 0
+}
+
+// summarize fills the summary block.
+func summarize(findings []Finding, strict bool) Summary {
+	var s Summary
+	for _, f := range findings {
+		switch f.Status {
+		case OK:
+			s.OK++
+		case Warn:
+			s.Warn++
+		case Fail:
+			s.Fail++
+		case Unavailable:
+			s.Unavailable++
+		}
+	}
+	s.ExitCode = ExitCode(findings, strict)
+	return s
+}
+
+// NewReport assembles the machine report.
+func NewReport(findings []Finding, strict bool, now time.Time) Report {
+	return Report{
+		SchemaVersion: reportSchemaVersion,
+		GeneratedAt:   now.UTC().Format(time.RFC3339),
+		Findings:      findings,
+		Summary:       summarize(findings, strict),
+	}
+}
+
+// WriteJSON emits the machine report.
+func (r Report) WriteJSON(w io.Writer) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(r)
+}
+
+// layerTitles names the fixed layer vocabulary (orc charter F24).
+var layerTitles = map[int]string{
+	1: "sideshow-native integrity",
+	3: "cwd discoverability (warn-only)",
+	4: "fleet drift",
+	5: "known defects",
+}
+
+// WriteText renders the human report, grouped by layer in fixed
+// order, with the layer-2 exclusion explained in place so the
+// numbering gap reads as a decision rather than a bug. Write errors
+// are discarded: the renderer targets a terminal and the exit code
+// carries the verdict.
+func (r Report) WriteText(w io.Writer, layers []int) {
+	for _, layer := range layers {
+		_, _ = fmt.Fprintf(w, "layer %d: %s\n", layer, layerTitles[layer])
+		if layer == 3 {
+			// Printed once so the exclusion is visible next to its
+			// neighbors exactly where a reader would look for layer 2.
+			_, _ = fmt.Fprintf(w, "  (layer 2, pack-declared validation, is deferred to the weave engine; aae-orc-a44c)\n")
+		}
+		any := false
+		for _, f := range r.Findings {
+			if f.Layer != layer {
+				continue
+			}
+			any = true
+			subject := f.Subject
+			if f.Pack != "" && subject != "" {
+				subject = f.Pack + " " + subject
+			} else if f.Pack != "" {
+				subject = f.Pack
+			}
+			if subject != "" {
+				_, _ = fmt.Fprintf(w, "  [%-11s] %s: %s: %s\n", f.Status, f.ID, subject, f.Detail)
+			} else {
+				_, _ = fmt.Fprintf(w, "  [%-11s] %s: %s\n", f.Status, f.ID, f.Detail)
+			}
+			if f.Next != "" && f.Status != OK {
+				_, _ = fmt.Fprintf(w, "                next: %s\n", f.Next)
+			}
+		}
+		if !any {
+			_, _ = fmt.Fprintf(w, "  (no findings)\n")
+		}
+	}
+	_, _ = fmt.Fprintf(w, "\n%d ok, %d warn, %d fail, %d unavailable\n",
+		r.Summary.OK, r.Summary.Warn, r.Summary.Fail, r.Summary.Unavailable)
+}


### PR DESCRIPTION
Consumers have no way to ask "is what sideshow recorded still true on this machine": the store can silently drift from its receipts, bindings can go stale, and the absence of a lockfile or defects feed today looks identical to a clean bill of health. This ships `sideshow doctor`, the read-only report over sideshow's own records (bd aae-orc-xteh, orc charter F24 layer vocabulary), with a spec at docs/doctor-spec.md.

Design points worth review attention:

- **Exit policy is the diagnostic-not-gate rule as code.** Findings carry a structural/advisory class; only structural failures exit 2, `--strict` promotes structural warns only, and advisory/unavailable never gate under any flag. One test row per branch of that table.
- **Absent inputs are unavailable, never clean.** No lockfile (aae-orc-333y), no defects feed (aae-orc-ztg5/10vq), no retained release manifests (aae-orc-wk92): each prints the ticket that supplies it. Zero checksummed receipts reports unavailable with both under-coverage causes named.
- **Layer 4's real signal needs no new state**: re-hash checksummed receipts against disk (the #92 observation). The #92 write-path fixes are deliberately a separate PR so this one stays read-only.
- **The d3nq.9 seam is proven by use**: plugin-class packs get a check set (ledger-row-coherence ships in it); the per-repo bind battery lands there later with no runner changes.
- Layer 3 is clamped to advisory warn-or-below by the runner, not by convention.

Verified against the live store: it found the pre-freeze beads-config install (advisory, benign causes named), a dead /tmp receipt root (skipped with reason), and one false positive during development (custom-source sync entries) which is fixed and covered by a test. 19 top-level tests; lint clean; additive only, two tiny read-only exports (bindings.LoadManifest, distribute marker accessors).