### PR TITLE
fix(bindings): refuse cross-repo custom-skill name collisions

### DIFF
--- a/internal/bindings/bindings.go
+++ b/internal/bindings/bindings.go
@@ -140,7 +140,11 @@ func Sync() error {
 
 	custom, err := discoverCustomBindings(packs, packSkillOwners)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "warning: discover custom sources: %v\n", err)
+		// Fail closed before anything is written: a collision (or an
+		// unreadable source registry) must block the sync loudly, not
+		// downgrade to a warning while the sync serves a silently
+		// chosen winner (sideshow#110 ruling).
+		return fmt.Errorf("custom sources: %w", err)
 	}
 	all = append(all, custom...)
 
@@ -220,8 +224,14 @@ func discoverCustomBindings(packs []pack.InstalledPack, packSkillOwners map[stri
 				continue
 			}
 			if prev, ok := claimed[name]; ok {
-				fmt.Fprintf(os.Stderr, "warning: skipping custom skill %s from %s: already bound from %s\n", name, s.Project, prev)
-				continue
+				// Ruled 2026-08-01 (sideshow#110): a name collision
+				// between two registered repos refuses the sync
+				// instead of silently serving the registry-order
+				// winner. A user editing their own skill must never
+				// wonder why the edit does not take effect.
+				return nil, fmt.Errorf(
+					"custom skill %q is declared by two registered repos: %s and %s; user-scope skills are shared across all registered repos, so one of them must rename the skill (or unregister as a source) before sync can proceed",
+					name, prev, s.Project)
 			}
 			claimed[name] = s.Project
 			skills = append(skills, name)

--- a/internal/bindings/custom_skill_dir_test.go
+++ b/internal/bindings/custom_skill_dir_test.go
@@ -114,7 +114,6 @@ func TestDiscoverCustomBindings_CollisionsAndPrune(t *testing.T) {
 	projectB := t.TempDir()
 	writeFile(t, filepath.Join(projectA, "_bmad-custom", "skills", "eos-coach", "SKILL.md"), "# a\n")
 	writeFile(t, filepath.Join(projectA, "_bmad-custom", "skills", "bmad-agent-dev", "SKILL.md"), "# collides with pack\n")
-	writeFile(t, filepath.Join(projectB, "_bmad-custom", "skills", "eos-coach", "SKILL.md"), "# b duplicate\n")
 	writeFile(t, filepath.Join(projectB, "_bmad-custom", "skills", "b-only", "SKILL.md"), "# b\n")
 
 	for _, p := range []string{projectA, projectB, filepath.Join(dataDir, "gone-project")} {
@@ -148,7 +147,7 @@ func TestDiscoverCustomBindings_CollisionsAndPrune(t *testing.T) {
 		t.Errorf("project A skills = %v, want [eos-coach] (pack collision must be skipped)", a.skills)
 	}
 	if !reflect.DeepEqual(b.skills, []string{"b-only"}) {
-		t.Errorf("project B skills = %v, want [b-only] (cross-source duplicate must be skipped)", b.skills)
+		t.Errorf("project B skills = %v, want [b-only]", b.skills)
 	}
 
 	// The missing project must have been pruned from the registry.
@@ -162,6 +161,33 @@ func TestDiscoverCustomBindings_CollisionsAndPrune(t *testing.T) {
 	for _, s := range sources {
 		if strings.Contains(s.Project, "gone-project") {
 			t.Error("missing project not pruned from registry")
+		}
+	}
+}
+
+func TestDiscoverCustomBindings_CrossSourceCollisionRefuses(t *testing.T) {
+	// Ruled 2026-08-01 (sideshow#110): two registered repos declaring
+	// the same skill name is a sync error naming both repos, never a
+	// silent registry-order winner.
+	t.Setenv("SIDESHOW_HOME", t.TempDir())
+
+	projectA := t.TempDir()
+	projectB := t.TempDir()
+	writeFile(t, filepath.Join(projectA, "_bmad-custom", "skills", "shared-name", "SKILL.md"), "# a\n")
+	writeFile(t, filepath.Join(projectB, "_bmad-custom", "skills", "shared-name", "SKILL.md"), "# b\n")
+	for _, p := range []string{projectA, projectB} {
+		if _, err := RegisterCustomSource(p, "bmad"); err != nil {
+			t.Fatalf("register %s: %v", p, err)
+		}
+	}
+
+	_, err := discoverCustomBindings([]pack.InstalledPack{{Name: "bmad", Version: "6.10.0"}}, nil)
+	if err == nil {
+		t.Fatal("cross-source collision must refuse, not pick a winner")
+	}
+	for _, want := range []string{"shared-name", projectA, projectB, "rename"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error must carry %q: %v", want, err)
 		}
 	}
 }


### PR DESCRIPTION
Implements the #110 ruling: two registered repos declaring the same custom skill name refuse the sync with an error naming the skill and both repos, before anything is written. Previously the winner was registry order, silently: a user in the losing repo editing their own skill never saw the edit take effect (measured in the aae-orc#154 consumer round, where syncing from beta served alpha's content).

Scope choices: matches the repo-bindings channel's content-collision refusal; pack-owned-name shadowing keeps its existing warn-and-skip since pack content legitimately owns its names. A custom-source discovery error also now fails the sync closed instead of downgrading to a warning.

The collision refusal blocks the whole sync (including version flips) until one repo renames or unregisters; that strictness is the ruling. Tests: cross-source collision refuses naming both repos; the prior winner-picks test updated; suite and lint clean.