### PR TITLE
docs(bmad): walkthrough targets the r2 re-issue; download is re-runnable

### DIFF
--- a/examples/bmad/README.md
+++ b/examples/bmad/README.md
@@ -14,24 +14,30 @@ Prerequisites: `gh`, `cosign`, and `python3` (macOS:
 `brew install gh cosign`). Every verification step below fails
 without them.
 
+The `-r2` in the tag and artifact name is a packaging revision: the
+same upstream bmad, re-issued with corrected packaging (the original
+releases predate the pack.yaml `runtime_links` emit; sideshow#109).
+Always prefer the highest revision of a version. The extracted
+directory carries no revision.
+
 ```bash
 mkdir -p /tmp/bmad-install && cd /tmp/bmad-install
-gh release download bmad-v6.10.0 -R ArcavenAE/sideshow-packs \
-  -p 'bmad-6.10.0-arcaven.tar.gz*' -p 'install.meta.json'
+gh release download bmad-v6.10.0-r2 -R ArcavenAE/sideshow-packs --clobber \
+  -p 'bmad-6.10.0-r2-arcaven.tar.gz*' -p 'install.meta.json'
 
 # Integrity: tarball sha256 must match the provenance manifest
 shasum -a 256 -c <(python3 -c \
   "import json; m=json.load(open('install.meta.json')); \
-   print(m['artifact']['tarball_sha256'], ' bmad-6.10.0-arcaven.tar.gz')")
+   print(m['artifact']['tarball_sha256'], ' bmad-6.10.0-r2-arcaven.tar.gz')")
 
 # Authenticity: cosign keyless verification against the CI identity
 cosign verify-blob \
-  --bundle bmad-6.10.0-arcaven.tar.gz.bundle \
+  --bundle bmad-6.10.0-r2-arcaven.tar.gz.bundle \
   --certificate-identity-regexp 'github.com/ArcavenAE/sideshow-packs' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  bmad-6.10.0-arcaven.tar.gz          # expect: Verified OK
+  bmad-6.10.0-r2-arcaven.tar.gz       # expect: Verified OK
 
-tar -xzf bmad-6.10.0-arcaven.tar.gz
+tar -xzf bmad-6.10.0-r2-arcaven.tar.gz
 ```
 
 ## 2. Install and activate


### PR DESCRIPTION
The walkthrough pointed at bmad releases that predate the pack.yaml runtime_links emit, so its own sections 3 and 4 fail on a clean repo (#109). The re-issued packs (bmad-v6.4.0-r2 through v6.10.0-r2, published today) fix that; this points section 1 at v6.10.0-r2, explains the -rN packaging-revision suffix, and adds --clobber so the block re-runs cleanly (the aae-orc#154 report's re-runnability nit).

Verified top to bottom against the published artifact: integrity + cosign pass, install + project init create all four runtime links, and the section-4 resolver check reports installed_agents_resolved true with 18 members on a clean repo.