### PR TITLE
feat(bindings): content-aware collision + project unregister verb

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,8 +185,15 @@ sideshow use bmad 6.10.0
 
 # Wire a repo you work in: creates the _bmad/ runtime shim (symlinks the
 # read surfaces upstream resolvers expect) + the _bmad-custom/ bridge +
-# gitignore entries. Run once per repo.
+# gitignore entries, and registers the repo as a custom-skills source.
+# Run once per repo.
 cd ~/work/myrepo && sideshow project init bmad
+
+# Stop serving a repo's custom skills (throwaway checkout, wrong-dir
+# init): removes it from the source registry; the next sync withdraws
+# its skills. Note that syncing from inside a repo that still carries
+# _bmad-custom/skills/ re-registers it.
+sideshow project unregister bmad --repo /tmp/scratch-checkout
 
 # Verify bindings are fully synced
 sideshow status

--- a/cmd/sideshow/main.go
+++ b/cmd/sideshow/main.go
@@ -41,6 +41,9 @@ Usage:
                                           and registered _<pack>-custom/skills/ sources)
   sideshow project init <pack>            Apply consumer-repo convention to cwd and
                                           register it as a custom-skills source
+  sideshow project unregister <pack> [--repo <path>]
+                                          Remove a repo from the custom-skills source
+                                          registry (next sync withdraws its skills)
   sideshow status                         Show installation status
   sideshow coexist <pack> [--repo <path>]  Read-only foreign-install census and coexistence findings
   sideshow enable <pack>[@<ver>] [--repo <path>] [--scope local|project]  Activate a pack in one repo (repo-bindings)
@@ -131,6 +134,8 @@ func main() {
 		switch os.Args[2] {
 		case "init":
 			err = runProjectInitForPack(os.Args[3:])
+		case "unregister":
+			err = runProjectUnregister(os.Args[3:])
 		default:
 			fmt.Fprintf(os.Stderr, "unknown project subcommand: %s\n", os.Args[2])
 			os.Exit(1)
@@ -640,6 +645,55 @@ func runCommandsSync() error {
 // current working directory — chiefly gitignore entries so consumer
 // repos don't commit sideshow-managed scaffolding.
 // Implements aae-orc-f6ei.
+// runProjectUnregister removes a repo + pack pair from the
+// custom-skills source registry:
+//
+//	sideshow project unregister <pack> [--repo <path>]
+//
+// The escape hatch registration never had: project init and sync
+// auto-register, and until this verb the only exits were deleting the
+// directory or hand-editing custom-sources.yaml.
+func runProjectUnregister(args []string) error {
+	if len(args) < 1 || len(args[0]) == 0 || args[0][0] == '-' {
+		return fmt.Errorf("usage: sideshow project unregister <pack> [--repo <path>]")
+	}
+	packName := args[0]
+	repoDir, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("resolve working directory: %w", err)
+	}
+	for i := 1; i < len(args); i++ {
+		switch args[i] {
+		case "--repo":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--repo requires a path")
+			}
+			i++
+			repoDir = args[i]
+		default:
+			return fmt.Errorf("unknown flag for project unregister: %s (see 'sideshow --help')", args[i])
+		}
+	}
+
+	removed, err := bindings.UnregisterCustomSource(repoDir, packName)
+	if err != nil {
+		return err
+	}
+	if !removed {
+		fmt.Printf("%s is not a registered %s custom-skills source; nothing to do\n", repoDir, packName)
+		return nil
+	}
+	fmt.Printf("Unregistered %s as a %s custom-skills source.\n", repoDir, packName)
+	fmt.Println("Run 'sideshow commands sync' to withdraw its served skills.")
+	// Sync auto-registers any cwd that carries custom skill content,
+	// so an unregister only sticks for repos you do not sync from
+	// within. Say so rather than letting the re-registration surprise.
+	if entries, dirErr := os.ReadDir(filepath.Join(repoDir, "_"+packName+"-custom", "skills")); dirErr == nil && len(entries) > 0 {
+		fmt.Printf("note: %s still contains _%s-custom/skills/; a sync run from inside it will re-register it\n", repoDir, packName)
+	}
+	return nil
+}
+
 func runProjectInitForPack(args []string) error {
 	if len(args) < 1 {
 		return fmt.Errorf("usage: sideshow project init <pack> [--dry-run]")

--- a/internal/bindings/bindings.go
+++ b/internal/bindings/bindings.go
@@ -202,7 +202,7 @@ func discoverCustomBindings(packs []pack.InstalledPack, packSkillOwners map[stri
 
 	var kept []CustomSource
 	pruned := false
-	claimed := make(map[string]string) // skill name -> claiming project
+	claimed := make(map[string]CustomSource) // skill name -> claiming source
 	var out []Binding
 
 	for _, s := range reg.Sources {
@@ -224,16 +224,30 @@ func discoverCustomBindings(packs []pack.InstalledPack, packSkillOwners map[stri
 				continue
 			}
 			if prev, ok := claimed[name]; ok {
-				// Ruled 2026-08-01 (sideshow#110): a name collision
-				// between two registered repos refuses the sync
-				// instead of silently serving the registry-order
-				// winner. A user editing their own skill must never
-				// wonder why the edit does not take effect.
+				// Ruled 2026-08-01 (sideshow#110), content-aware
+				// amendment: identical content is a benign duplicate
+				// (worktrees and second checkouts of one project are
+				// routine here) and one copy serves; differing
+				// content refuses the sync instead of silently
+				// serving the registry-order winner. A user editing
+				// their own skill must never wonder why the edit
+				// does not take effect.
+				prevDir := filepath.Join(customSkillsDir(prev.Project, prev.Pack), name)
+				curDir := filepath.Join(customSkillsDir(s.Project, s.Pack), name)
+				same, cmpErr := sameDirContent(prevDir, curDir)
+				if cmpErr != nil {
+					return nil, fmt.Errorf("compare custom skill %q between %s and %s: %w", name, prev.Project, s.Project, cmpErr)
+				}
+				if same {
+					fmt.Fprintf(os.Stderr, "note: custom skill %s in %s is byte-identical to the copy in %s; serving one copy\n", name, s.Project, prev.Project)
+					continue
+				}
 				return nil, fmt.Errorf(
-					"custom skill %q is declared by two registered repos: %s and %s; user-scope skills are shared across all registered repos, so one of them must rename the skill (or unregister as a source) before sync can proceed",
-					name, prev, s.Project)
+					"custom skill %q is declared with differing content by two registered repos: %s and %s; user-scope skills are shared across all registered repos, so rename the skill in one of them, or run 'sideshow project unregister %s' in the repo that should stop serving it, before sync can proceed",
+					name, prev.Project, s.Project, s.Pack,
+				)
 			}
-			claimed[name] = s.Project
+			claimed[name] = s
 			skills = append(skills, name)
 		}
 		if len(skills) == 0 {

--- a/internal/bindings/custom_skill_dir_test.go
+++ b/internal/bindings/custom_skill_dir_test.go
@@ -165,6 +165,44 @@ func TestDiscoverCustomBindings_CollisionsAndPrune(t *testing.T) {
 	}
 }
 
+func TestDiscoverCustomBindings_IdenticalDuplicateServesOneCopy(t *testing.T) {
+	// Content-aware amendment to the sideshow#110 ruling: a second
+	// checkout of the same project (worktree, clone) declares the
+	// same skills with byte-identical content; that is benign and one
+	// copy serves. Only differing content refuses.
+	t.Setenv("SIDESHOW_HOME", t.TempDir())
+
+	checkoutA := t.TempDir()
+	checkoutB := t.TempDir()
+	for _, c := range []string{checkoutA, checkoutB} {
+		writeFile(t, filepath.Join(c, "_bmad-custom", "skills", "twin", "SKILL.md"), "# same bytes\n")
+		writeFile(t, filepath.Join(c, "_bmad-custom", "skills", "twin", "assets", "a.txt"), "same\n")
+		if _, err := RegisterCustomSource(c, "bmad"); err != nil {
+			t.Fatalf("register %s: %v", c, err)
+		}
+	}
+
+	got, err := discoverCustomBindings([]pack.InstalledPack{{Name: "bmad", Version: "6.10.0"}}, nil)
+	if err != nil {
+		t.Fatalf("identical duplicate must not refuse: %v", err)
+	}
+	total := 0
+	for _, b := range got {
+		total += len(b.(*CustomSkillDirBinding).skills)
+	}
+	if total != 1 {
+		t.Errorf("served copies = %d, want exactly 1", total)
+	}
+
+	// Diverge one copy: the same pair now refuses.
+	writeFile(t, filepath.Join(checkoutB, "_bmad-custom", "skills", "twin", "SKILL.md"), "# edited\n")
+	if _, err := discoverCustomBindings([]pack.InstalledPack{{Name: "bmad", Version: "6.10.0"}}, nil); err == nil {
+		t.Fatal("diverged duplicate must refuse")
+	} else if !strings.Contains(err.Error(), "unregister") {
+		t.Errorf("refusal must name the unregister remedy: %v", err)
+	}
+}
+
 func TestDiscoverCustomBindings_CrossSourceCollisionRefuses(t *testing.T) {
 	// Ruled 2026-08-01 (sideshow#110): two registered repos declaring
 	// the same skill name is a sync error naming both repos, never a

--- a/internal/bindings/custom_sources.go
+++ b/internal/bindings/custom_sources.go
@@ -97,6 +97,41 @@ func RegisterCustomSource(project, packName string) (bool, error) {
 	return true, nil
 }
 
+// UnregisterCustomSource removes a consumer repo + pack pair from the
+// registry (the escape hatch registration never had: project init and
+// sync auto-register, and until this verb the only exits were deleting
+// the directory or hand-editing the registry). Returns true if the
+// pair was present and removed. The next 'commands sync' withdraws
+// the source's served skills via the ownership reconcile.
+func UnregisterCustomSource(project, packName string) (bool, error) {
+	abs, err := filepath.Abs(project)
+	if err != nil {
+		return false, fmt.Errorf("resolve project path: %w", err)
+	}
+
+	reg, err := loadCustomSources()
+	if err != nil {
+		return false, err
+	}
+
+	kept := reg.Sources[:0]
+	removed := false
+	for _, s := range reg.Sources {
+		if s.Project == abs && s.Pack == packName {
+			removed = true
+			continue
+		}
+		kept = append(kept, s)
+	}
+	if !removed {
+		return false, nil
+	}
+	if err := saveCustomSources(kept); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 // ListCustomSources returns the registered sources for status display.
 func ListCustomSources() ([]CustomSource, error) {
 	reg, err := loadCustomSources()

--- a/internal/bindings/custom_sources_test.go
+++ b/internal/bindings/custom_sources_test.go
@@ -1,0 +1,48 @@
+package bindings
+
+import "testing"
+
+func TestUnregisterCustomSource(t *testing.T) {
+	t.Setenv("SIDESHOW_HOME", t.TempDir())
+
+	project := t.TempDir()
+	other := t.TempDir()
+	for _, p := range []string{project, other} {
+		if _, err := RegisterCustomSource(p, "bmad"); err != nil {
+			t.Fatalf("register %s: %v", p, err)
+		}
+	}
+
+	removed, err := UnregisterCustomSource(project, "bmad")
+	if err != nil {
+		t.Fatalf("unregister: %v", err)
+	}
+	if !removed {
+		t.Fatal("registered pair must report removed")
+	}
+	sources, err := ListCustomSources()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sources) != 1 || sources[0].Project != other {
+		t.Errorf("sources after unregister = %+v, want only %s", sources, other)
+	}
+
+	// Second unregister of the same pair is a clean no-op.
+	removed, err = UnregisterCustomSource(project, "bmad")
+	if err != nil {
+		t.Fatalf("second unregister: %v", err)
+	}
+	if removed {
+		t.Error("already-absent pair must report not removed")
+	}
+
+	// Pack mismatch does not remove.
+	removed, err = UnregisterCustomSource(other, "spectacle")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if removed {
+		t.Error("pack-mismatched pair must not remove")
+	}
+}

--- a/internal/bindings/dir_compare.go
+++ b/internal/bindings/dir_compare.go
@@ -1,0 +1,78 @@
+package bindings
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// sameDirContent reports whether two directories carry the same file
+// set with byte-identical content (relative paths compared; modes and
+// times ignored; symlinks compared by target). Used to distinguish a
+// benign duplicate custom skill (a second checkout of the same
+// project) from a genuine content collision.
+func sameDirContent(a, b string) (bool, error) {
+	am, err := dirDigest(a)
+	if err != nil {
+		return false, err
+	}
+	bm, err := dirDigest(b)
+	if err != nil {
+		return false, err
+	}
+	if len(am) != len(bm) {
+		return false, nil
+	}
+	for rel, sum := range am {
+		if !bytes.Equal(bm[rel], sum) {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// dirDigest maps each relative path under root to a content digest.
+func dirDigest(root string) (map[string][]byte, error) {
+	out := map[string][]byte{}
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return relErr
+		}
+		if d.Type()&fs.ModeSymlink != 0 {
+			target, linkErr := os.Readlink(path)
+			if linkErr != nil {
+				return linkErr
+			}
+			sum := sha256.Sum256([]byte("symlink\x00" + target))
+			out[rel] = sum[:]
+			return nil
+		}
+		f, openErr := os.Open(path)
+		if openErr != nil {
+			return openErr
+		}
+		h := sha256.New()
+		_, copyErr := io.Copy(h, f)
+		_ = f.Close()
+		if copyErr != nil {
+			return copyErr
+		}
+		out[rel] = h.Sum(nil)
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("digest %s: %w", root, err)
+	}
+	return out, nil
+}


### PR DESCRIPTION
The #110 refusal as shipped breaks a routine pattern: worktrees and second checkouts of one project auto-register on sync, declare identical skills, and the name-only check refuses even though nothing is ambiguous (verified: today's scratch repos sat permanently in custom-sources.yaml with no removal verb). Two amendments, both ruled:

- **Content-aware collision:** byte-identical duplicates serve one copy with a note; differing content refuses naming both repos and the remedy. A duplicate that diverges mid-edit flips to refusal exactly when the ambiguity becomes real.
- **`sideshow project unregister <pack> [--repo]`:** the escape hatch registration never had (the aae-orc#154 report called out the gap). Next sync withdraws the source's skills via the existing ownership reconcile; output warns that syncing from inside a repo that still carries custom skills re-registers it.

Tests: identical-duplicate serves exactly one copy then refuses after divergence; refusal names the unregister remedy; unregister round trip with no-op repeat and pack-mismatch cases. Verified live by unregistering today's scratch-repo pollution.