### PR TITLE
fix(bindings): classify pack content by store existence, not blind substitution

### DIFF
--- a/_kos/findings/finding-003-frozen-store-classifies-pack-content.md
+++ b/_kos/findings/finding-003-frozen-store-classifies-pack-content.md
@@ -1,0 +1,110 @@
+# finding-003: the frozen store is the read/write classifier
+
+**Probe:** aae-orc-c8v8 (P1 bug) asked for a sync-time check that no synced
+artifact resolves a write or delete argument inside pack territory, to be
+built from write-verb, flag-name, and shell-redirect signals.
+
+**Result:** the heuristic is unnecessary. Existence in the frozen store
+answers the same question exactly, with no lexical guessing.
+
+---
+
+## The defect
+
+`rewritePaths` substituted every `{project-root}/_bmad/` reference with the
+absolute user-install path. The assumption underneath is that everything
+under the shim dir is pack content. It is not. Pack content is what the
+installer put in the store; everything else under `_bmad/` is the project's
+own state, which upstream expects to create and write at runtime.
+
+Blind substitution therefore redirected project state into immutable shared
+storage, in instructions an agent then follows.
+
+## Measurement
+
+Controlled traversal of the synced surface (2,205 files, 173 skill
+directories) found **30 distinct pack references, of which 14 do not exist
+in the store**, carried by **32 files**. The ticket's write-verb audit had
+recorded 4 files.
+
+Every one of the 14 originates as `{project-root}/_bmad/...` in the pack
+source. None arrived absolute. Our rewrite created all of them.
+
+Three classes, only the first of which the ticket had named:
+
+| Class | Examples | Hits |
+|---|---|---|
+| Config write targets | `config.yaml`, `config.user.yaml`, `module-help.csv` | 22, 22, 1 |
+| Runtime state | `memory/{skillName}/` (the agent-builder sanctum, described in-file as "the place it reloads on every waking"), `planning/prd.md` | 14, 2 |
+| Customization | `custom/*.toml`, the surface `bmad-customize` exists to write | 1+ |
+
+## The rule
+
+The store is installed read-only (`pack.FreezeTree`, 0555/0444, shipped in
+`aae-orc-dihj`). A path that is not in the store can never come into being
+there: a read through it fails, a write through it fails with EACCES.
+
+So the read-versus-write distinction the ticket asked us to detect collapses
+into a question with a definite answer:
+
+> Rewrite `{project-root}/<prefix>/X` to `<store>/X` only if `<store>/X`
+> exists. Otherwise leave the token literal.
+
+Freezing turned an intent question into an existence test. The classifier
+carries no opinion about write verbs, flag names, or redirects, which is
+what makes it reliable. It separated all 30 references correctly: 16 reads
+rewritten, 14 defects left literal.
+
+Left-literal references are not orphaned. The fallback-resolution footer
+already instructs the reader to try cwd-relative first, which is the correct
+resolution for project state.
+
+## One case existence cannot decide
+
+`{project-root}/_bmad/custom/` exists in the store, so existence alone would
+rewrite it. It must not be rewritten: `pack.yaml` declares
+`custom_bridge: _bmad/custom -> _bmad-custom`, making it the repo's own
+writable territory.
+
+That case is settled by declaration, not heuristic. `custom_bridge`'s
+`upstream_path` is read at sync time and its shim-relative segment is
+preserved alongside `_bmad-custom/` and `_bmad-output/`. The two rules are
+complementary: existence covers what the store lacks, declaration covers
+what the store has but does not own.
+
+## The post-condition
+
+`packRefRules.verify` asserts, after rewrite, that no path resolving inside
+the store is absent from it. It runs independently of the rewrite rather
+than trusting it, so a reference that arrived absolute in the pack source is
+caught too. Structural, so it may gate per
+`.claude/rules/diagnostic-not-gate.md`; a violation fails the binding and
+skips stale reconcile, per the loud-failure path from sideshow#108/#113.
+
+## Verification
+
+End-to-end sync of bmad 6.10.0 into a sandboxed HOME: 119 artifacts, zero
+dangling references, down from 14 across 32 files. Legitimate reads such as
+`scripts/resolve_customization.py` still resolve to the store.
+
+## Method note, which is this finding's own lesson recurring
+
+`grep -r` under `~/.claude/skills` returns zero matches for a string present
+in 120 files, with empty stderr and an exit status indistinguishable from a
+clean run. `find -print0 | xargs -0 grep` returns the correct count. The
+first passes of the ticket's audit were run with `grep -r` and reported a
+clean bill that was false.
+
+Any scan of this surface must use controlled traversal and must assert a
+known-positive fixture, or it will pass by failing to look. The scan behind
+this finding aborts if its traversal returns zero.
+
+## Refs
+
+- bd: `aae-orc-c8v8`; `aae-orc-dihj` (freeze, shipped), `aae-orc-mkpo`
+  (custom bridge), `aae-orc-3mci` (closed premise-false, folded into c8v8)
+- Nodes: `elem-frozen-store-classifies-refs`, `elem-command-sync`,
+  `elem-custom-bridge`, `elem-runtime-links`
+- Upstream: bmad `bmb#96` covers upstream's own legacy-file deletion. The
+  write redirection is ours alone and is unfileable upstream: vanilla bmad
+  has no shared immutable store, so upstream cannot reproduce the class.

--- a/_kos/nodes/bedrock/elem-frozen-store-classifies-refs.yaml
+++ b/_kos/nodes/bedrock/elem-frozen-store-classifies-refs.yaml
@@ -1,0 +1,47 @@
+id: elem-frozen-store-classifies-refs
+type: element
+confidence: bedrock
+title: "the frozen store classifies a pack-content reference from project state"
+content: |
+  A `{project-root}/<prefix>/X` reference in synced content is rewritten to
+  the absolute user-install path only when `<store>/X` exists in the store.
+  Otherwise it stays literal, and the fallback-resolution footer resolves it
+  cwd-relative, which is correct for project state.
+
+  The store is installed read-only (`pack.FreezeTree`, 0555/0444), so a path
+  absent from it can never come into being there. That collapses the
+  read-versus-write question into an existence test: no write-verb, flag-name,
+  or shell-redirect heuristics, which a synced-surface audit measured as
+  unreliable in both directions.
+
+  One case existence cannot decide. A path that exists in the store but is
+  declared per-repo territory by `pack.yaml custom_bridge` (`_bmad/custom`)
+  must stay literal too. That is settled by reading the declaration, not by
+  guessing. The two rules are complementary: existence covers what the store
+  lacks, declaration covers what the store has but does not own.
+
+  The post-condition is enforced, not merely intended: after rewrite, no path
+  resolving inside the store may be absent from it. The check runs
+  independently of the rewrite, so a reference that arrived absolute in the
+  pack source is caught too. It is structural, so it gates
+  (`.claude/rules/diagnostic-not-gate.md`); a violation fails the binding and
+  skips stale reconcile.
+
+  Measured on bmad 6.10.0: 14 broken references across 32 files before, zero
+  after, with the 16 legitimate reads still resolving to the store.
+
+  Tracked work shipped: `aae-orc-c8v8`. Depends on `aae-orc-dihj` (the
+  freeze) and `aae-orc-mkpo` (the custom bridge).
+edges:
+  - target: elem-command-sync
+    type: supports
+  - target: elem-custom-bridge
+    type: derives
+  - target: elem-user-install-shape
+    type: derives
+provenance:
+  created_by: claude
+  session: session-2026-08-07
+  created_at: "2026-08-07"
+  evidence:
+    - _kos/findings/finding-003-frozen-store-classifies-pack-content.md

--- a/internal/bindings/env_shim_test.go
+++ b/internal/bindings/env_shim_test.go
@@ -199,23 +199,26 @@ func TestInlineEnvBelt_QuotesSafely(t *testing.T) {
 	}
 }
 
-// Regression coverage for the rewritePaths parameterization: the bmad
-// default is unchanged and a second prefix routes correctly.
-func TestRewritePathsForPrefix(t *testing.T) {
+// Regression coverage for the shim-prefix parameterization: a non-bmad
+// prefix routes correctly, and the sibling per-repo dirs stay literal.
+func TestRewriteForPrefix(t *testing.T) {
 	t.Parallel()
+
+	store := newFixtureStore(t, "", "templates/a.md")
+	rules := newPackRefRules(store, "_vsdd")
+
 	in := "read {project-root}/_vsdd/templates/a.md, write {project-root}/_vsdd-custom/x " +
 		"and {project-root}/_vsdd-output/y, leave {project-root}/README.md"
-	got := rewritePathsForPrefix(in, "/store/vsdd/1.0.0", "_vsdd")
-	want := "read /store/vsdd/1.0.0/templates/a.md, write {project-root}/_vsdd-custom/x " +
+	want := "read " + store + "/templates/a.md, write {project-root}/_vsdd-custom/x " +
 		"and {project-root}/_vsdd-output/y, leave {project-root}/README.md"
-	if got != want {
-		t.Errorf("rewritePathsForPrefix:\n got %q\nwant %q", got, want)
+
+	if got := rules.rewrite(in); got != want {
+		t.Errorf("rewrite:\n got %q\nwant %q", got, want)
 	}
 
-	// The bmad wrapper still behaves exactly as before.
-	bmadIn := "{project-root}/_bmad/core/a.md {project-root}/_bmad-custom/b"
-	bmadWant := "/packs/bmad/6.3.0/core/a.md {project-root}/_bmad-custom/b"
-	if got := rewritePaths(bmadIn, "/packs/bmad/6.3.0"); got != bmadWant {
-		t.Errorf("rewritePaths (bmad default):\n got %q\nwant %q", got, bmadWant)
+	// A _bmad reference is not this pack's prefix and stays untouched.
+	other := "{project-root}/_bmad/core/a.md"
+	if got := rules.rewrite(other); got != other {
+		t.Errorf("rewrite touched another pack's prefix:\n got %q\nwant %q", got, other)
 	}
 }

--- a/internal/bindings/markdown_command.go
+++ b/internal/bindings/markdown_command.go
@@ -17,6 +17,7 @@ type MarkdownCommandBinding struct {
 	name     string
 	version  string
 	packPath string
+	rules    *packRefRules
 }
 
 // NewMarkdownCommandBinding constructs a binding for a pack that ships
@@ -26,6 +27,7 @@ func NewMarkdownCommandBinding(name, version, packPath string) *MarkdownCommandB
 		name:     name,
 		version:  version,
 		packPath: packPath,
+		rules:    newPackRefRules(packPath, defaultShimPrefix),
 	}
 }
 
@@ -64,9 +66,11 @@ func (b *MarkdownCommandBinding) Sync() (int, error) {
 				return fmt.Errorf("read command %s: %w", path, err)
 			}
 
-			content := string(data)
-			content = rewritePaths(content, b.packPath)
+			content := b.rules.rewrite(string(data))
 			content = appendFallbackFooter(content, b.packPath)
+			if err := b.rules.verify(content); err != nil {
+				return fmt.Errorf("%s: %w", path, err)
+			}
 
 			destPath := filepath.Join(claudeDir, filepath.Base(path))
 			if err := writeWithSourceMode(destPath, []byte(content), path); err != nil {
@@ -103,9 +107,14 @@ func (b *MarkdownCommandBinding) Sync() (int, error) {
 			return nil // skip on read error
 		}
 
-		content := string(data)
-		content = rewritePaths(content, b.packPath)
+		content := b.rules.rewrite(string(data))
 		content = appendFallbackFooter(content, b.packPath)
+		// Unlike the read/write faults below, a dangling store reference
+		// is a defect in what we would publish, not a transient local
+		// fault — it fails the sync rather than being skipped.
+		if err := b.rules.verify(content); err != nil {
+			return fmt.Errorf("%s: %w", path, err)
+		}
 
 		destPath := filepath.Join(claudeDir, name)
 		if err := writeWithSourceMode(destPath, []byte(content), path); err != nil {

--- a/internal/bindings/markdown_command_test.go
+++ b/internal/bindings/markdown_command_test.go
@@ -19,6 +19,11 @@ func TestMarkdownCommandBinding_Sync_RewritesAndFooter(t *testing.T) {
 	destRoot := t.TempDir()
 	t.Setenv("HOME", destRoot)
 
+	// Pack content the references below resolve to — a reference is
+	// rewritten only when it exists in the store.
+	writeFile(t, filepath.Join(packPath, "core", "workflow.md"), "workflow\n")
+	writeFile(t, filepath.Join(packPath, "help", "index.md"), "index\n")
+
 	// commands/ subdir layout.
 	writeFile(t, filepath.Join(packPath, "commands", "bmad-party-mode.md"),
 		"LOAD {project-root}/_bmad/core/workflow.md\n")

--- a/internal/bindings/rewrite.go
+++ b/internal/bindings/rewrite.go
@@ -1,51 +1,225 @@
 package bindings
 
 import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
 	"strings"
+
+	"github.com/ArcavenAE/sideshow/internal/distribute"
 )
 
-// rewritePaths replaces pack content references with the absolute pack
-// installation path while preserving per-repo paths that must stay
-// relative to the invoking project.
+// ErrDanglingPackRefs reports that synced content carries a path inside the
+// frozen pack store that does not exist there. The store is installed
+// read-only (pack.FreezeTree), so such a path can never come into being:
+// a read through it fails, a write through it fails with EACCES.
+var ErrDanglingPackRefs = errors.New("dangling pack references")
+
+// defaultShimPrefix is the project-root shim dir assumed for packs that
+// do not declare another. Packs with a different prefix (e.g. "_vsdd")
+// construct their rules with it explicitly.
+const defaultShimPrefix = "_bmad"
+
+// packRefRules classifies {project-root}/<prefix>/ references for one
+// installed pack: which name pack content (rewritable to the absolute
+// store path) and which name project state (left literal).
 //
-// Rewrites (pack content — read-only, user-install):
+// The classifier is the frozen store itself. Pack content is exactly what
+// exists under packPath; everything else under the shim dir is the
+// project's own state, whether the reference reads it or writes it. That
+// collapses the read-vs-write question into an existence test with no
+// lexical guessing about write verbs, flag names, or shell redirects —
+// the heuristics a synced-surface audit measured as unreliable
+// (aae-orc-c8v8).
 //
-//	{project-root}/_<pack>/module/path → /absolute/packs/<pack>/<v>/module/path
+// Two reference classes are therefore left literal, for the reading LLM
+// to resolve cwd-relative via the fallback footer:
 //
-// Preserves (per-repo — stays relative to cwd):
-//
-//	{project-root}/_<pack>-custom/ → unchanged (per-repo customization)
-//	{project-root}/_<pack>-output/ → unchanged (per-repo output)
-//	{project-root}/              → unchanged (any other project-relative path)
-//
-// The implementation uses nul-byte sentinels to protect the per-repo
-// prefixes from being caught by the pack-content rewrite.
-//
-// rewritePaths keeps the historical bmad default; every binding that
-// syncs a differently prefixed pack calls rewritePathsForPrefix with
-// that pack's prefix (aae-orc-d3nq.50).
-func rewritePaths(content, packPath string) string {
-	return rewritePathsForPrefix(content, packPath, "_bmad")
+//   - a path absent from the store (project state: config.yaml,
+//     planning/prd.md, the agent-builder's memory/ sanctum)
+//   - a path under a declared per-repo surface, even though it exists in
+//     the store (pack.yaml custom_bridge — _bmad/custom is symlinked to
+//     the checked-in _bmad-custom, so it must stay project-relative)
+type packRefRules struct {
+	packPath string
+	prefix   string
+
+	// perRepo holds first path segments under the shim dir that the pack
+	// declares as per-repo territory (e.g. "custom" from custom_bridge).
+	perRepo map[string]struct{}
+
+	// exists caches store lookups. Safe because the store is frozen for
+	// the duration of a sync and bindings sync sequentially.
+	exists map[string]bool
 }
 
-// rewritePathsForPrefix is rewritePaths parameterized on the pack's
-// project-root prefix (e.g. "_bmad", "_gds"): {project-root}/<prefix>/
-// references become absolute store paths while the sibling per-repo
-// dirs (<prefix>-custom/, <prefix>-output/) stay project-relative.
-func rewritePathsForPrefix(content, packPath, prefix string) string {
-	const customSentinel = "\x00PACK_CUSTOM\x00"
-	const outputSentinel = "\x00PACK_OUTPUT\x00"
+// newPackRefRules builds the classifier for a pack rooted at packPath
+// whose project-root shim dir is prefix (e.g. "_bmad").
+func newPackRefRules(packPath, prefix string) *packRefRules {
+	return &packRefRules{
+		packPath: packPath,
+		prefix:   prefix,
+		perRepo:  declaredPerRepoDirs(packPath, prefix),
+		exists:   make(map[string]bool),
+	}
+}
 
-	root := "{project-root}/" + prefix
-	content = strings.ReplaceAll(content, root+"-custom/", customSentinel)
-	content = strings.ReplaceAll(content, root+"-output/", outputSentinel)
+// declaredPerRepoDirs reads the pack's custom_bridge declaration and
+// returns the shim-relative directories it makes per-repo territory. A
+// pack with no pack.yaml, or none declaring a bridge, yields an empty
+// set — no reference is preserved on this ground.
+func declaredPerRepoDirs(packPath, prefix string) map[string]struct{} {
+	out := make(map[string]struct{})
 
-	content = strings.ReplaceAll(content, root+"/", packPath+"/")
+	p, err := distribute.LoadPackYAML(packPath)
+	if err != nil || p == nil || p.Distribute.CustomBridge == nil {
+		return out
+	}
 
-	content = strings.ReplaceAll(content, customSentinel, root+"-custom/")
-	content = strings.ReplaceAll(content, outputSentinel, root+"-output/")
+	// upstream_path is repo-relative and starts with the shim dir
+	// (e.g. _bmad/custom). The segment after it is what a
+	// {project-root}/<prefix>/ reference would name.
+	rel := filepath.ToSlash(filepath.Clean(p.Distribute.CustomBridge.UpstreamPath))
+	rel = strings.TrimPrefix(rel, prefix+"/")
+	if seg := firstSegment(rel); seg != "" {
+		out[seg] = struct{}{}
+	}
+	return out
+}
 
-	return content
+// rewrite replaces pack-content references with the absolute store path
+// while leaving project-state references literal.
+func (r *packRefRules) rewrite(content string) string {
+	token := "{project-root}/" + r.prefix + "/"
+
+	var b strings.Builder
+	rest := content
+	for {
+		i := strings.Index(rest, token)
+		if i < 0 {
+			b.WriteString(rest)
+			return b.String()
+		}
+
+		b.WriteString(rest[:i])
+		tail := rest[i+len(token):]
+
+		if r.isPackContent(refCandidate(tail)) {
+			b.WriteString(r.packPath + "/")
+		} else {
+			b.WriteString(token)
+		}
+		rest = tail
+	}
+}
+
+// isPackContent reports whether a shim-relative reference names content
+// that lives in the frozen store and is not declared per-repo territory.
+func (r *packRefRules) isPackContent(ref string) bool {
+	if _, ok := r.perRepo[firstSegment(ref)]; ok {
+		return false
+	}
+	return r.storeHas(literalPrefix(ref))
+}
+
+// storeHas reports whether a shim-relative path exists in the store.
+func (r *packRefRules) storeHas(rel string) bool {
+	if hit, ok := r.exists[rel]; ok {
+		return hit
+	}
+	_, err := os.Lstat(filepath.Join(r.packPath, filepath.FromSlash(rel)))
+	hit := err == nil
+	r.exists[rel] = hit
+	return hit
+}
+
+// verify is the sync-time post-condition: no path resolving inside the
+// frozen store may be absent from it. Structural — an existence test over
+// declared content, not a health metric — so it may gate
+// (.claude/rules/diagnostic-not-gate.md).
+//
+// It runs independently of rewrite rather than trusting it, so a
+// reference that arrived absolute in the pack source is caught too.
+func (r *packRefRules) verify(content string) error {
+	token := r.packPath + "/"
+	dangling := make(map[string]struct{})
+
+	rest := content
+	for {
+		i := strings.Index(rest, token)
+		if i < 0 {
+			break
+		}
+		rest = rest[i+len(token):]
+
+		rel := literalPrefix(refCandidate(rest))
+		if rel != "" && !r.storeHas(rel) {
+			dangling[rel] = struct{}{}
+		}
+	}
+
+	if len(dangling) == 0 {
+		return nil
+	}
+
+	refs := make([]string, 0, len(dangling))
+	for rel := range dangling {
+		refs = append(refs, rel)
+	}
+	sort.Strings(refs)
+
+	return fmt.Errorf("%w: %s resolves %s inside the read-only pack store, which does not exist there",
+		ErrDanglingPackRefs, r.packPath, strings.Join(refs, ", "))
+}
+
+// refCandidate extracts the path that follows a reference token, ending
+// at the first character that cannot continue a path in prose, code
+// fences, or shell arguments. Placeholder braces are kept — literalPrefix
+// trims them.
+func refCandidate(s string) string {
+	end := strings.IndexFunc(s, func(rn rune) bool {
+		switch rn {
+		case ' ', '\t', '\n', '\r', '`', '"', '\'', ')', ']', '>', '<', '|', ',', ';', ':', '=':
+			return true
+		}
+		return false
+	})
+	if end >= 0 {
+		s = s[:end]
+	}
+	return strings.TrimRight(s, ".")
+}
+
+// literalPrefix reduces a reference to the longest leading portion that
+// contains no template placeholder, backing up to the last path
+// separator so a partially-templated segment is not tested as a literal.
+//
+//	bmm/agents/pm.md      → bmm/agents/pm.md
+//	memory/{skillName}/   → memory/
+//	bmm/agent-{code}.md   → bmm/
+//	{skill-name}.toml     → ""   (checks the pack root)
+func literalPrefix(ref string) string {
+	i := strings.IndexByte(ref, '{')
+	if i < 0 {
+		return ref
+	}
+	ref = ref[:i]
+	j := strings.LastIndexByte(ref, '/')
+	if j < 0 {
+		return ""
+	}
+	return ref[:j+1]
+}
+
+// firstSegment returns the first path segment of a relative reference.
+func firstSegment(ref string) string {
+	ref = strings.TrimPrefix(ref, "/")
+	if i := strings.IndexByte(ref, '/'); i >= 0 {
+		return ref[:i]
+	}
+	return ref
 }
 
 // appendFallbackFooter adds LLM-executable guidance so that pack-internal
@@ -54,12 +228,14 @@ func rewritePathsForPrefix(content, packPath, prefix string) string {
 // directory.
 //
 // The top-level entry file (slash command or skill SKILL.md) gets its
-// {project-root}/_bmad/ references rewritten by rewritePaths. Files the
+// pack-content references rewritten by packRefRules.rewrite. Files the
 // entry file loads are not rewritten — they live inside the installed
-// pack and stay literal. The footer tells the reading LLM to resolve
-// such references via a two-step fallback chain:
+// pack and stay literal. So do project-state references anywhere, which
+// the classifier deliberately leaves alone. The footer tells the reading
+// LLM to resolve such references via a two-step fallback chain:
 //
-//  1. Try cwd-relative first (works for per-project installs).
+//  1. Try cwd-relative first (works for per-project installs, and is the
+//     correct resolution for project state).
 //  2. Substitute with the pack user-install path (works at orc roots).
 //
 // Wrapped in sentinel markers for idempotency — re-syncing doesn't

--- a/internal/bindings/rewrite_test.go
+++ b/internal/bindings/rewrite_test.go
@@ -1,62 +1,290 @@
 package bindings
 
 import (
+	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
 
-func TestRewritePaths_PackContent(t *testing.T) {
-	input := "Load from {project-root}/_bmad/bmm/agents/pm.md"
-	want := "Load from /global/packs/bmad/6.2.2/bmm/agents/pm.md"
+// newFixtureStore builds a frozen-store stand-in containing exactly the
+// relative paths given (a trailing slash makes a directory), plus an
+// optional pack.yaml body. It returns the store root.
+func newFixtureStore(t *testing.T, packYAML string, entries ...string) string {
+	t.Helper()
 
-	got := rewritePaths(input, "/global/packs/bmad/6.2.2")
-	if got != want {
-		t.Errorf("rewritePaths() =\n  %q\nwant\n  %q", got, want)
+	root := t.TempDir()
+	for _, e := range entries {
+		full := filepath.Join(root, filepath.FromSlash(e))
+		if strings.HasSuffix(e, "/") {
+			if err := os.MkdirAll(full, 0o755); err != nil {
+				t.Fatalf("mkdir %s: %v", e, err)
+			}
+			continue
+		}
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatalf("mkdir parent of %s: %v", e, err)
+		}
+		if err := os.WriteFile(full, []byte("fixture\n"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", e, err)
+		}
+	}
+	if packYAML != "" {
+		if err := os.WriteFile(filepath.Join(root, "pack.yaml"), []byte(packYAML), 0o644); err != nil {
+			t.Fatalf("write pack.yaml: %v", err)
+		}
+	}
+	return root
+}
+
+const bridgePackYAML = `name: bmad
+version: 6.10.0
+distribute:
+  custom_bridge:
+    upstream_path: _bmad/custom
+    per_repo_dir: _bmad-custom
+`
+
+func TestRewrite_Classification(t *testing.T) {
+	t.Parallel()
+
+	// The store carries pack content only. config.yaml, module-help.csv
+	// and memory/ are absent because they are project state — exactly the
+	// shape of a real user-install (aae-orc-c8v8).
+	store := newFixtureStore(t, bridgePackYAML,
+		"bmm/agents/pm.md",
+		"scripts/merge-config.py",
+		"core/workflows/party-mode/",
+		"custom/config.toml",
+	)
+	rules := newPackRefRules(store, "_bmad")
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "pack content rewrites",
+			in:   "Load from {project-root}/_bmad/bmm/agents/pm.md",
+			want: "Load from " + store + "/bmm/agents/pm.md",
+		},
+		{
+			name: "project state stays literal",
+			in:   "write {project-root}/_bmad/config.yaml",
+			want: "write {project-root}/_bmad/config.yaml",
+		},
+		{
+			name: "declared per-repo surface stays literal even though it exists",
+			in:   "Create {project-root}/_bmad/custom/ if needed.",
+			want: "Create {project-root}/_bmad/custom/ if needed.",
+		},
+		{
+			name: "per-repo surface stays literal for a concrete file",
+			in:   "read {project-root}/_bmad/custom/config.toml",
+			want: "read {project-root}/_bmad/custom/config.toml",
+		},
+		{
+			name: "placeholder tail resolves against its literal prefix",
+			in:   "see {project-root}/_bmad/core/workflows/{name}/workflow.md",
+			want: "see " + store + "/core/workflows/{name}/workflow.md",
+		},
+		{
+			name: "absent directory under a placeholder stays literal",
+			in:   "sanctum at {project-root}/_bmad/memory/{skillName}/",
+			want: "sanctum at {project-root}/_bmad/memory/{skillName}/",
+		},
+		{
+			name: "sibling per-repo dirs still preserved",
+			in:   "{project-root}/_bmad-custom/x {project-root}/_bmad-output/y",
+			want: "{project-root}/_bmad-custom/x {project-root}/_bmad-output/y",
+		},
+		{
+			name: "unrelated project paths untouched",
+			in:   "Read {project-root}/docs/readme.md",
+			want: "Read {project-root}/docs/readme.md",
+		},
+		{
+			name: "mixed content classifies per reference",
+			in: "Load {project-root}/_bmad/scripts/merge-config.py " +
+				"then write {project-root}/_bmad/module-help.csv",
+			want: "Load " + store + "/scripts/merge-config.py " +
+				"then write {project-root}/_bmad/module-help.csv",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := rules.rewrite(tt.in); got != tt.want {
+				t.Errorf("rewrite:\n got  %q\n want %q", got, tt.want)
+			}
+		})
 	}
 }
 
-func TestRewritePaths_PreservesCustom(t *testing.T) {
-	input := "Read {project-root}/_bmad-custom/overrides.yaml"
-	got := rewritePaths(input, "/global/packs/bmad/6.2.2")
-	if got != input {
-		t.Errorf("rewritePaths() modified _bmad-custom path:\n  got:  %q\n  want: %q", got, input)
+// The fixture the ticket names: bmad-bmb-setup SKILL.md line 48, where
+// three write targets were redirected into the frozen store.
+func TestRewrite_BmbSetupLine48(t *testing.T) {
+	t.Parallel()
+
+	store := newFixtureStore(t, bridgePackYAML, "scripts/merge-config.py")
+	rules := newPackRefRules(store, "_bmad")
+
+	in := `python3 ./scripts/merge-config.py --config-path "{project-root}/_bmad/config.yaml" ` +
+		`--user-config-path "{project-root}/_bmad/config.user.yaml" ` +
+		`--answers {temp-file} --legacy-dir "{project-root}/_bmad"`
+
+	got := rules.rewrite(in)
+	if got != in {
+		t.Errorf("write targets were redirected into the pack store:\n got  %q\n want %q", got, in)
+	}
+	if strings.Contains(got, store) {
+		t.Errorf("rewrite leaked the store path into a write argument: %q", got)
+	}
+	if err := rules.verify(got); err != nil {
+		t.Errorf("verify rejected correctly-classified content: %v", err)
 	}
 }
 
-func TestRewritePaths_PreservesOutput(t *testing.T) {
-	input := "Write to {project-root}/_bmad-output/results.md"
-	got := rewritePaths(input, "/global/packs/bmad/6.2.2")
-	if got != input {
-		t.Errorf("rewritePaths() modified _bmad-output path:\n  got:  %q\n  want: %q", got, input)
+func TestVerify(t *testing.T) {
+	t.Parallel()
+
+	store := newFixtureStore(t, "", "bmm/agents/pm.md", "custom/")
+	rules := newPackRefRules(store, "_bmad")
+
+	tests := []struct {
+		name    string
+		in      string
+		wantErr bool
+		wantRef string
+	}{
+		{
+			name: "references that exist pass",
+			in:   "load " + store + "/bmm/agents/pm.md and " + store + "/custom/",
+		},
+		{
+			name: "bare store root passes",
+			in:   "the pack lives at " + store + "/",
+		},
+		{
+			name:    "absent path is caught",
+			in:      "write " + store + "/config.yaml",
+			wantErr: true,
+			wantRef: "config.yaml",
+		},
+		{
+			name:    "absent path under a placeholder is caught",
+			in:      "sanctum at " + store + "/memory/{skillName}/",
+			wantErr: true,
+			wantRef: "memory/",
+		},
+		{
+			name: "paths outside this store are not our business",
+			in:   "see /some/other/pack/config.yaml",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := rules.verify(tt.in)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("verify accepted a dangling reference: %q", tt.in)
+				}
+				if !errors.Is(err, ErrDanglingPackRefs) {
+					t.Errorf("verify error is not ErrDanglingPackRefs: %v", err)
+				}
+				if !strings.Contains(err.Error(), tt.wantRef) {
+					t.Errorf("verify error does not name %q: %v", tt.wantRef, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("verify rejected valid content %q: %v", tt.in, err)
+			}
+		})
 	}
 }
 
-func TestRewritePaths_PreservesProjectRoot(t *testing.T) {
-	input := "Read {project-root}/docs/readme.md"
-	got := rewritePaths(input, "/global/packs/bmad/6.2.2")
-	if got != input {
-		t.Errorf("rewritePaths() modified project-root path:\n  got:  %q\n  want: %q", got, input)
+// verify runs independently of rewrite, so a reference that arrived
+// absolute in the pack source is caught rather than trusted.
+func TestVerify_CatchesPreRewrittenAbsoluteRef(t *testing.T) {
+	t.Parallel()
+
+	store := newFixtureStore(t, "", "bmm/agents/pm.md")
+	rules := newPackRefRules(store, "_bmad")
+
+	content := "--target " + store + "/module-help.csv"
+	if rules.rewrite(content) != content {
+		t.Fatal("precondition: rewrite should not touch an already-absolute reference")
+	}
+	if err := rules.verify(content); err == nil {
+		t.Error("verify accepted an absolute dangling reference the rewrite never produced")
 	}
 }
 
-func TestRewritePaths_MixedContent(t *testing.T) {
-	input := `Load {project-root}/_bmad/core/workflow.md
-Read {project-root}/_bmad-custom/config.yaml
-Write {project-root}/_bmad-output/report.md
-Check {project-root}/docs/spec.md`
+func TestDeclaredPerRepoDirs(t *testing.T) {
+	t.Parallel()
 
-	want := `Load /g/core/workflow.md
-Read {project-root}/_bmad-custom/config.yaml
-Write {project-root}/_bmad-output/report.md
-Check {project-root}/docs/spec.md`
+	t.Run("bridge declared", func(t *testing.T) {
+		t.Parallel()
+		store := newFixtureStore(t, bridgePackYAML)
+		got := declaredPerRepoDirs(store, "_bmad")
+		if _, ok := got["custom"]; !ok || len(got) != 1 {
+			t.Errorf("declaredPerRepoDirs = %v, want {custom}", got)
+		}
+	})
 
-	got := rewritePaths(input, "/g")
-	if got != want {
-		t.Errorf("rewritePaths() =\n  %q\nwant\n  %q", got, want)
+	t.Run("no pack.yaml yields no preserved dirs", func(t *testing.T) {
+		t.Parallel()
+		store := newFixtureStore(t, "")
+		if got := declaredPerRepoDirs(store, "_bmad"); len(got) != 0 {
+			t.Errorf("declaredPerRepoDirs = %v, want empty", got)
+		}
+	})
+}
+
+func TestLiteralPrefix(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct{ in, want string }{
+		{"bmm/agents/pm.md", "bmm/agents/pm.md"},
+		{"memory/{skillName}/", "memory/"},
+		{"bmm/agent-{code}.md", "bmm/"},
+		{"{skill-name}.toml", ""},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		if got := literalPrefix(tt.in); got != tt.want {
+			t.Errorf("literalPrefix(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestRefCandidate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct{ in, want string }{
+		{"bmm/pm.md and more", "bmm/pm.md"},
+		{"bmm/pm.md`", "bmm/pm.md"},
+		{`config.yaml" --next`, "config.yaml"},
+		{"custom/ if needed.", "custom/"},
+		{"planning/prd.md.", "planning/prd.md"},
+		{"scripts/x.py)", "scripts/x.py"},
+	}
+	for _, tt := range tests {
+		if got := refCandidate(tt.in); got != tt.want {
+			t.Errorf("refCandidate(%q) = %q, want %q", tt.in, got, tt.want)
+		}
 	}
 }
 
 func TestAppendFallbackFooter_AddsFooter(t *testing.T) {
+	t.Parallel()
+
 	input := "Some command content.\n"
 	got := appendFallbackFooter(input, "/global/packs/bmad/6.2.2")
 
@@ -75,6 +303,8 @@ func TestAppendFallbackFooter_AddsFooter(t *testing.T) {
 }
 
 func TestAppendFallbackFooter_Idempotent(t *testing.T) {
+	t.Parallel()
+
 	input := "Some command content.\n"
 	once := appendFallbackFooter(input, "/global/packs/bmad/6.2.2")
 	twice := appendFallbackFooter(once, "/global/packs/bmad/6.2.2")

--- a/internal/bindings/skill_dir.go
+++ b/internal/bindings/skill_dir.go
@@ -20,6 +20,7 @@ type SkillDirBinding struct {
 	name     string
 	version  string
 	packPath string
+	rules    *packRefRules
 }
 
 // NewSkillDirBinding constructs a binding for a pack that ships per-skill
@@ -29,6 +30,7 @@ func NewSkillDirBinding(name, version, packPath string) *SkillDirBinding {
 		name:     name,
 		version:  version,
 		packPath: packPath,
+		rules:    newPackRefRules(packPath, defaultShimPrefix),
 	}
 }
 
@@ -43,9 +45,10 @@ func (b *SkillDirBinding) PackVersion() string { return b.version }
 
 // Sync materializes skill directories into ~/.claude/skills/<name>/.
 // Each skill directory under the pack's .claude/skills/ is copied intact.
-// Text files (.md, .yaml, .yml, .csv) are passed through rewritePaths.
-// SKILL.md receives the fallback-resolution footer (it is the LLM entry
-// point). Returns the number of skills synced.
+// Text files (.md, .yaml, .yml, .csv) have their pack-content references
+// rewritten to the absolute store path; project-state references are left
+// literal. SKILL.md receives the fallback-resolution footer (it is the LLM
+// entry point). Returns the number of skills synced.
 func (b *SkillDirBinding) Sync() (int, error) {
 	skillsSrc := filepath.Join(b.packPath, ".claude", "skills")
 	skillsDst := claudeSkillsDir()
@@ -105,10 +108,12 @@ func (b *SkillDirBinding) syncSkillTree(src, dst string) error {
 		}
 
 		if shouldRewrite(path) {
-			content := string(data)
-			content = rewritePaths(content, b.packPath)
+			content := b.rules.rewrite(string(data))
 			if filepath.Base(path) == "SKILL.md" {
 				content = appendFallbackFooter(content, b.packPath)
+			}
+			if err := b.rules.verify(content); err != nil {
+				return fmt.Errorf("%s: %w", path, err)
 			}
 			data = []byte(content)
 		}
@@ -120,8 +125,8 @@ func (b *SkillDirBinding) syncSkillTree(src, dst string) error {
 	})
 }
 
-// shouldRewrite reports whether a file's content should pass through
-// rewritePaths before being written to the target. Binary-like files are
+// shouldRewrite reports whether a file's content should pass through path
+// classification before being written to the target. Binary-like files are
 // passed through unchanged; text formats get the rewrite.
 func shouldRewrite(path string) bool {
 	switch filepath.Ext(path) {

--- a/internal/bindings/skill_dir_test.go
+++ b/internal/bindings/skill_dir_test.go
@@ -33,10 +33,17 @@ func TestSkillDirBinding_Sync_CopiesTreeAndRewrites(t *testing.T) {
 	// Force HOME so claudeSkillsDir() lands under destRoot.
 	t.Setenv("HOME", destRoot)
 
+	// Pack content the references below resolve to. Existence in the
+	// store is what makes a reference pack content rather than project
+	// state, so a fixture without these would (correctly) not rewrite.
+	writeFile(t, filepath.Join(packPath, "core", "workflow.md"), "workflow\n")
+	writeFile(t, filepath.Join(packPath, "helpers", "util.md"), "util\n")
+
 	// Build a fake pack with a skill dir containing a SKILL.md + a manifest + a nested file.
 	skillBase := filepath.Join(packPath, ".claude", "skills", "bmad-agent-test")
 	writeFile(t, filepath.Join(skillBase, "SKILL.md"),
-		"# Test skill\nLoad {project-root}/_bmad/config.yaml\n")
+		"# Test skill\nLoad {project-root}/_bmad/core/workflow.md\n"+
+			"Write {project-root}/_bmad/config.yaml\n")
 	writeFile(t, filepath.Join(skillBase, "bmad-skill-manifest.yaml"),
 		"schema_version: 1.0\nagent: test\n")
 	writeFile(t, filepath.Join(skillBase, "nested", "helper.md"),
@@ -59,8 +66,13 @@ func TestSkillDirBinding_Sync_CopiesTreeAndRewrites(t *testing.T) {
 		t.Fatalf("read synced SKILL.md: %v", err)
 	}
 	skillStr := string(skillMD)
-	if !strings.Contains(skillStr, packPath+"/config.yaml") {
+	if !strings.Contains(skillStr, packPath+"/core/workflow.md") {
 		t.Errorf("SKILL.md rewrite did not substitute pack path:\n%s", skillStr)
+	}
+	// Project state is absent from the store and must stay literal, so
+	// the instruction keeps pointing at the invoking project.
+	if !strings.Contains(skillStr, "{project-root}/_bmad/config.yaml") {
+		t.Errorf("SKILL.md redirected project state into the pack store:\n%s", skillStr)
 	}
 	if !strings.Contains(skillStr, "<!-- sideshow:fallback-resolution:begin -->") {
 		t.Errorf("SKILL.md missing fallback footer:\n%s", skillStr)


### PR DESCRIPTION
Sideshow was shipping instructions that tell an agent to write into the frozen pack store. The path rewrite substituted every `{project-root}/_bmad/` reference with the absolute user-install path, on the assumption that everything under the shim dir is pack content. It is not: pack content is what the installer put in the store, and everything else under `_bmad/` is project state that upstream creates and writes at runtime.

## What is actually broken

Controlled traversal of the synced surface (2,205 files, 173 skill directories) finds **30 distinct pack references, 14 of them absent from the store, carried by 32 files**. Every one of the 14 originates as `{project-root}/_bmad/...` in the pack source, so the rewrite created all of them.

Two classes were not previously recorded:

- **Runtime state**: `memory/{skillName}/`, the agent-builder sanctum, described in-file as "the place it reloads on every waking" (14 hits). Also `planning/prd.md`.
- **Customization**: `custom/*.toml`, the exact surface `bmad-customize` exists to write.

The store is frozen 0555/0444, so these fail loudly rather than corrupting anything. The artifact is still wrong, and an agent following it gets an EACCES traceback instead of a diagnostic.

## The fix

Freezing the store (`aae-orc-dihj`) makes a path absent from it unreachable by construction: a read fails, a write fails with EACCES. That collapses the read-versus-write question into an existence test.

> Rewrite `{project-root}/<prefix>/X` only if `<store>/X` exists. Otherwise leave the token literal.

No write-verb, flag-name, or shell-redirect heuristics, which is what makes it reliable; the audit behind the ticket measured those as wrong in both directions. Left-literal references are not orphaned, since the fallback footer already resolves cwd-relative, which is the correct resolution for project state.

Existence cannot decide one case. `{project-root}/_bmad/custom/` exists in the store but `pack.yaml custom_bridge` declares it repo-writable territory. That is settled by reading the declaration, so the bridge path is preserved alongside `_bmad-custom/` and `_bmad-output/`. The two rules are complementary: existence covers what the store lacks, declaration covers what the store has but does not own.

`verify()` is the post-condition, run independently of the rewrite so a reference that arrived absolute in the pack source is caught too. It is structural rather than a health metric, so it gates per `.claude/rules/diagnostic-not-gate.md`: a violation fails the binding and skips stale reconcile, per the loud-failure path from #108/#113.

## Verification

End-to-end sync of bmad 6.10.0 into a sandboxed HOME: 119 artifacts, **zero dangling references, down from 14 across 32 files**, with the 16 legitimate reads such as `scripts/resolve_customization.py` still resolving to the store.

Unit coverage includes the fixture the ticket names (`bmad-bmb-setup` line 48), the `bmad-customize` bare-`custom/` case, placeholder tails, and a reference that arrived absolute.

## Cost of merge

Behavior changes for 14 references across 32 synced files; each stops being rewritten and reverts to vanilla bmad semantics. Existing binding tests needed realistic fixtures, since existence is now the classifier.

Two follow-ups worth noting and not in scope here: the user's live `~/.claude/skills` still carries the old output until the next sync, and sideshow doctor has no layer that scans the synced surface for this class.

Closes aae-orc-c8v8
Refs aae-orc-dihj, aae-orc-mkpo, aae-orc-3mci