### PR TITLE
fix(bindings): guard the pack-ref existence cache against concurrent use

### DIFF
--- a/internal/bindings/rewrite.go
+++ b/internal/bindings/rewrite.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/ArcavenAE/sideshow/internal/distribute"
 )
@@ -50,8 +51,13 @@ type packRefRules struct {
 	// declares as per-repo territory (e.g. "custom" from custom_bridge).
 	perRepo map[string]struct{}
 
-	// exists caches store lookups. Safe because the store is frozen for
-	// the duration of a sync and bindings sync sequentially.
+	// exists caches store lookups. The store is frozen for the duration
+	// of a sync, so a cached answer cannot go stale. The mutex is not for
+	// staleness but for callers: bindings sync sequentially today, and
+	// guarding the map means that invariant is not load-bearing. An
+	// earlier revision asserted it in a comment instead, and the race
+	// detector found the assertion through a parallel test.
+	mu     sync.Mutex
 	exists map[string]bool
 }
 
@@ -126,12 +132,19 @@ func (r *packRefRules) isPackContent(ref string) bool {
 
 // storeHas reports whether a shim-relative path exists in the store.
 func (r *packRefRules) storeHas(rel string) bool {
-	if hit, ok := r.exists[rel]; ok {
+	r.mu.Lock()
+	hit, ok := r.exists[rel]
+	r.mu.Unlock()
+	if ok {
 		return hit
 	}
+
 	_, err := os.Lstat(filepath.Join(r.packPath, filepath.FromSlash(rel)))
-	hit := err == nil
+	hit = err == nil
+
+	r.mu.Lock()
 	r.exists[rel] = hit
+	r.mu.Unlock()
 	return hit
 }
 


### PR DESCRIPTION
`main` is red and no alpha has been cut since #116, which stalls the fleet remediation waiting on a release (`aae-orc-d6gx`). This fixes it.

## What broke

#117 passed `ax quality`, passed every PR check, merged, then failed CI on `main` ([run 31233745638](https://github.com/ArcavenAE/sideshow/actions/runs/31233745638)). A parallel test shared one `packRefRules` across subtests and raced on its `exists` map.

## The fix is the type, not the test

The cache comment read *"Safe because the store is frozen for the duration of a sync and bindings sync sequentially."* Both clauses are true, and the safety claim still rested on an invariant nothing enforced. `runSync` iterates sequentially today; nothing stops a future change from parallelising it, and the corruption would be silent.

The map is now mutex-guarded, so that invariant is no longer load-bearing. The production path never raced, so the detector found the assertion rather than a bug, and the assertion was the fragile part. Guarding a map is three lines.

## Why it reached main

`ax test` ran `go test ./...`; CI runs `go test ./... -v -count=1 -race`. The pre-flight wrapper disagreed with CI on the two flags that decide this outcome. Fixed in the orchestrator alongside this, so every Go repo is pre-flighted at CI's bar.

The PR checks passing is not a defence: they run the same workflow, and the race went one way on the PR head and the other way on `main`. A flaky-presenting race green-lit the merge.

## Verification

`go test ./... -count=1 -race` clean across every package.

Refs aae-orc-c8v8, finding-119